### PR TITLE
Restore OpenSSL support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,7 @@ jobs:
         under the MPL version 2.0.
         
         For more information and updates, see: https://curl.se/docs/caextract.html
-        "
+        "@
         
         New-Item ca_certs.readme
         Set-Content ca_certs.readme $readme

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,7 +165,7 @@ jobs:
         wget https://curl.se/ca/cacert.pem -outfile ca_certs.pem
         wget https://www.mozilla.org/media/MPL/2.0/index.815ca599c9df.txt -outfile ca_certs.license
         
-        @readme = @"
+        $readme = @"
         ca_certs.pem was exported from the Mozilla CA Certificate Store and is licensed
         under the MPL version 2.0.
         
@@ -173,7 +173,7 @@ jobs:
         "
         
         New-Item ca_certs.readme
-        Set-Content ca_certs.readme @readme
+        Set-Content ca_certs.readme $readme
       shell: powershell
       working-directory: ${{ github.workspace }}\kermit\k95\dist
     - name: Prepare Artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,6 +148,7 @@ jobs:
       run: |
         call ..\..\setenv.bat
         call mk.bat
+        call mkdist.bat
       shell: cmd
       working-directory: ${{ github.workspace }}\kermit\k95
       env:
@@ -156,10 +157,6 @@ jobs:
         # build. Undefined or CKF_NO_CRYPTO=no leaves crypto features enabled
         # where the required dependencies exist.
         CKF_NO_CRYPTO: ${{ matrix.no_crypto }}
-    - name: Make Distribution
-      run: mkdist.bat
-      shell: cmd
-      working-directory: ${{ github.workspace }}\kermit\k95
     - name: Fetch CA Certs bundle
       run: |
         wget https://curl.se/ca/cacert.pem -outfile ca_certs.pem

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,7 +165,8 @@ jobs:
         wget https://curl.se/ca/cacert.pem -outfile ca_certs.pem
         wget https://www.mozilla.org/media/MPL/2.0/index.815ca599c9df.txt -outfile ca_certs.license
         
-        @readme = @"ca_certs.pem was exported from the Mozilla CA Certificate Store and is licensed
+        @readme = @"
+        ca_certs.pem was exported from the Mozilla CA Certificate Store and is licensed
         under the MPL version 2.0.
         
         For more information and updates, see: https://curl.se/docs/caextract.html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,6 @@ jobs:
       run: |
         call ..\..\setenv.bat
         call mk.bat
-        call mkdist.bat
       shell: cmd
       working-directory: ${{ github.workspace }}\kermit\k95
       env:
@@ -161,6 +160,21 @@ jobs:
       run: mkdist.bat
       shell: cmd
       working-directory: ${{ github.workspace }}\kermit\k95
+    - name: Fetch CA Certs bundle
+      run: |
+        wget https://curl.se/ca/cacert.pem -outfile ca_certs.pem
+        wget https://www.mozilla.org/media/MPL/2.0/index.815ca599c9df.txt -outfile ca_certs.license
+        
+        @readme = @"ca_certs.pem was exported from the Mozilla CA Certificate Store and is licensed
+        under the MPL version 2.0.
+        
+        For more information and updates, see: https://curl.se/docs/caextract.html
+        "
+        
+        New-Item ca_certs.readme
+        Set-Content ca_certs.readme @readme
+      shell: powershell
+      working-directory: ${{ github.workspace }}\kermit\k95\dist
     - name: Prepare Artifact
       shell: cmd
       working-directory: ${{ github.workspace }}\kermit\k95

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
           ${{github.workspace}}\openssl 
           ${{github.workspace}}\libssh 
           ${{github.workspace}}\tools
-        key: msvc-${{ matrix.toolset }}-${{ matrix.arch }}+zlib-${{env.ZLIB_VERSION}}+openssl-${{env.OPENSSL_VERSION}}+libssh-${{env.LIBSSH_VERSION}}rel+nasm
+        key: msvc-${{ matrix.toolset }}-${{ matrix.arch }}+zlib-${{env.ZLIB_VERSION}}+openssl-${{env.OPENSSL_VERSION}}+libssh-${{env.LIBSSH_VERSION}}rel+nasm+xp
 
     - name: Get dependencies
       if: steps.cache-optional-dependencies.outputs.cache-hit != 'true'
@@ -130,7 +130,7 @@ jobs:
         cd openssl\${{env.OPENSSL_VERSION}}
         $env:Path += ";${{github.workspace}}\tools\nasm"
         $env:Path
-        perl Configure VC-WIN32 zlib-dynamic --with-zlib-include=${{github.workspace}}\zlib\${{env.ZLIB_VERSION}}     
+        perl Configure VC-WIN32 -D"_WIN32_WINNT=0x502" zlib-dynamic --with-zlib-include=${{github.workspace}}\zlib\${{env.ZLIB_VERSION}}     
         nmake
 
     - name: Build libssh

--- a/doc/optional-dependencies.md
+++ b/doc/optional-dependencies.md
@@ -92,6 +92,9 @@ nmake
 cd ..\..\
 ```
 
+If you want OpenSSL to work on versions of windows older than Vista, add the
+`-D"_WIN32_WINNT=0x502"` parameter to the Configure step.
+
 ### 3. Building libssh
 
 For libssh you need to the following specifying the correct OPENSSL_ROOT_DIR and ZLIB_ROOT:

--- a/doc/optional-dependencies.md
+++ b/doc/optional-dependencies.md
@@ -5,17 +5,15 @@ these but if you don't have them some features (like built-in SSH) will be
 unavailable. These are:
 
 * [zlib](https://zlib.net/)
-* [OpenSSL](https://www.openssl.org/) 0.9.8 - 1.1.1
+* [OpenSSL](https://www.openssl.org/) 0.9.8 - 3.0.x
 * [libssh](https://www.libssh.org/) 0.9.x, 0.10.x
 
-For SSH support all three are required and the openssl version should be 1.1.1 
-(though apparently 1.0.2 and 1.1.0 also work). 
-
-OpenSSL 3.0.x is not currently supported.
+For SSH support all three are required and the openssl version should be >=1.1.1 
+(though apparently 1.0.2 and 1.1.0 also work but have known security issues). 
 
 You may also want a CA certificates bundle. A convenient source is here:
-https://curl.se/docs/caextract.html. Save the file as `ca_certs.pem` in the CKW directory and it should be picked up
-automatically.
+https://curl.se/docs/caextract.html. Save the file as `ca_certs.pem` in the CKW 
+directory and it should be picked up automatically.
 
 ## Building with SSH Support
 

--- a/doc/optional-dependencies.md
+++ b/doc/optional-dependencies.md
@@ -4,9 +4,20 @@ C-Kermit for Windows has the following optional dependencies. You don't *need*
 these but if you don't have them some features (like built-in SSH) will be 
 unavailable. These are:
 
-* [zlib](https://zlib.net/) - required for compression, ssl (https) and ssh
-* [OpenSSL](https://www.openssl.org/) - required for ssl and ssh
-* [libssh](https://www.libssh.org/) - required for ssh
+* [zlib](https://zlib.net/)
+* [OpenSSL](https://www.openssl.org/) 0.9.8 - 1.1.1
+* [libssh](https://www.libssh.org/) 0.9.x, 0.10.x
+
+For SSH support all three are required and the openssl version should be 1.1.1 
+(though apparently 1.0.2 and 1.1.0 also work). 
+
+OpenSSL 3.0.x is not currently supported.
+
+You may also want a CA certificates bundle. A convenient source is here:
+https://curl.se/docs/caextract.html. Save the file as `ca_certs.pem` in the CKW directory and it should be picked up
+automatically.
+
+## Building with SSH Support
 
 This doesn't necessarily document the *best* way to build these dependencies.
 Ideally you should read the readme file and other documentation for each of 
@@ -55,7 +66,7 @@ Once you've built the dependencies you want you can uncomment the associated
 lines in setenv.bat which will result in any features requiring the dependencies
 you've built to be automatically enabled.
 
-## 1. Building zlib
+### 1. Building zlib
 
 zlib is easy. Download zlib-1.1.12.tar.gz and extract it as `zlib\1.1.12`. Then:
 ```
@@ -65,7 +76,11 @@ nmake -f win32\Makefile.msc
 cd ..\..\
 ```
 
-## 2. Building OpenSSL
+If using an older compiler like Visual C++ 6 and don't have cmake handy you can
+just skip that step. Running `nmake -f win32\Makefile.msc` seems to work fine
+without it.
+
+### 2. Building OpenSSL
 
 Before building OpenSSL for the first time you need to install `Text::Template`
 from CPAN with: `cpan -i Text::Template`
@@ -79,7 +94,7 @@ nmake
 cd ..\..\
 ```
 
-## 3. Building libssh
+### 3. Building libssh
 
 For libssh you need to the following specifying the correct OPENSSL_ROOT_DIR and ZLIB_ROOT:
 ```
@@ -92,3 +107,105 @@ cd ..\..\..\
 ```
 
 Note that this does not build libssh with GSSAPI support.
+
+## Building with Older OpenSSL Versions
+If you want to build with older **_INSECURE_** versions of OpenSSL for some
+reason, C-Kermit for Windows still supports the following:
+
+* 0.9.8zf of 2016-01-29 (**_INSECURE_**)
+* 1.0.0s of 2016-01-29 (**_INSECURE_**)
+* 1.0.1u of 2016-09-22 (**_INSECURE_**)
+* 1.0.2u of 2019-12-20 (**_INSECURE_** unless you pay for premium OpenSSL support)
+* 1.1.0l of 2019-09-10 (**_INSECURE_**)
+
+This is of course not recommended. But perhaps bad encryption is better than
+none at all in some situations. Or maybe you're not doing anything where
+security matters all that much.
+
+Firstly, build zlib as described above. You'll also want NASM on your PATH. For 
+OpenSSL 0.9.8, NASM 0.98 should work. For newer versions, NASM 2.15.05 seems to 
+work fine.
+
+### OpenSSL 0.9.8zf
+Extract to `\openssl\0.9.8`, update `openssl_root` in your `setenv.bat`, then
+do the following:
+
+```
+cd openssl\0.9.8
+perl configure VC-WIN32
+ms\do_ms
+nmake -f ms\ntdll.mak
+```
+
+To build an optimised version, use `ms\do_nasm` instead of `ms\do_ms`.
+
+### OpenSSL 1.0.0s
+Extract to `\openssl\1.0.0`, update `openssl_root` in your `setenv.bat`, then
+do the following
+
+```
+cd openssl\1.0.0
+perl configure VC-WIN32 enable-static-engine -DOPENSSL_USE_IPV6=0
+ms\do_nasm
+nmake -f ms\ntdll.mak
+```
+
+For some older versions of Visual C++, including Visual C++ 6, the additional
+`-DOPENSSL_USE_IPV6=0` parameter is required as IPv6 isn't supported properly.
+For newer compilers you should omit it.
+
+### OpenSSL 1.0.1u
+Extract to `\openssl\1.0.1`, update `openssl_root` in your `setenv.bat`, then
+do the following
+
+```
+cd openssl\1.0.1
+perl configure VC-WIN32 enable-static-engine zlib-dynamic --with-zlib-include=C:\path\to\ckwin\zlib\1.2.12 -DOPENSSL_USE_IPV6=0
+ms\do_ms
+nmake -f ms\ntdll.mak
+```
+
+For some older versions of Visual C++, including Visual C++ 6, the additional
+`-DOPENSSL_USE_IPV6=0` parameter is required as IPv6 isn't supported properly.
+For newer compilers you should omit it.
+
+### OpenSSL 1.0.2u
+
+If you're paying for OpenSSL Premium Support (US$50k/year), you should have
+access to newer versions of OpenSSL 1.0.2 aren't full of known security
+vulnerabilities. C-Kermit for windows hasn't been tested against anything newer
+than the final public release (1.0.2u) but it should work with later patch
+levels.
+
+Extract to `\openssl\1.0.2`, update `openssl_root` in your `setenv.bat`, then
+do the following
+
+```
+cd openssl\1.0.2
+perl configure VC-WIN32 enable-static-engine zlib-dynamic --with-zlib-include=C:\path\to\ckwin\zlib\1.2.12 -DOPENSSL_USE_IPV6=0
+ms\do_ms
+nmake -f ms\ntdll.mak
+```
+
+For some older versions of Visual C++, including Visual C++ 6, the additional
+`-DOPENSSL_USE_IPV6=0` parameter is required as IPv6 isn't supported properly.
+For newer compilers you should omit it.
+
+To build with Visual C++ 6, you may have to edit `Configure` and remove `-WX`
+from line 596:
+```
+"VC-WIN32","cl:-W3 -WX -Gs0 -GF -Gy -nologo -DOPENSSL_SYSNAME_WIN32 -DWIN32_LEAN_AND_MEAN -DL_ENDIAN -D_CRT_SECURE_NO_DEPRECATE -D_WINSOCK_DEPRECATED_NO_WARNINGS:::WIN32::BN_LLONG RC4_INDEX EXPORT_VAR_AS_FN ${x86_gcc_opts}:${x86_asm}:win32n:win32",
+```
+
+### OpenSSL 1.1.0l
+Extract to `\openssl\1.1.0`, update `openssl_root` in your `setenv.bat`, then
+do the following
+
+```
+cd openssl\1.1.0
+perl Configure VC-WIN32 zlib-dynamic --with-zlib-include=C:\path\to\ckwin\zlib\1.2.12
+nmake
+cd ..\..\
+```
+
+This version does not build with Visual C++ 6.

--- a/kermit/k95/ck_ssl.c
+++ b/kermit/k95/ck_ssl.c
@@ -1157,6 +1157,10 @@ int keylength;
 static void
 ssl_display_comp(SSL * ssl)
 {
+    #ifndef OPENSSL_NO_COMP
+    const COMP_METHOD *method;
+    #endif
+
     if ( quiet )			/* fdc - Mon Nov 28 11:44:15 2005 */
         return;
 
@@ -1167,7 +1171,7 @@ ssl_display_comp(SSL * ssl)
         return;
 
 #ifndef OPENSSL_NO_COMP                  /* ifdefs Bernard Spil 12/2015 */
-    const COMP_METHOD *method = SSL_get_current_compression(ssl);
+    method = SSL_get_current_compression(ssl);
     if (method == NULL)
 #endif /* OPENSSL_NO_COMP */
         printf("Compression: None\r\n");

--- a/kermit/k95/ck_ssl.c
+++ b/kermit/k95/ck_ssl.c
@@ -2941,7 +2941,15 @@ ssl_verify_crl(int ok, X509_STORE_CTX *ctx)
 char *
 tls_userid_from_client_cert(ssl) SSL * ssl;
 {
-#ifndef OS2		/* [jt] 2013/11/21 - K-95 doesn't have X509_to_user */
+    /* DavidG 2022-09-05: On Windows and OS/2, X509_to_user is expected to be
+     * provided by a user-supplied DLL as described here:
+     *   http://www.columbia.edu/kermit/security70.html#x3.1.4
+     * This DLL would normally be loaded in ckossl.c (search for X5092UID) but
+     * at the moment that only happens when CKW is built with SSLDLL. SSLDLL is
+     * only compatible with OpenSSL 0.9.x so in practice X509_to_user is never
+     * available. It wouldn't be hard to make it work without SSLDLL if needed.
+     */
+#ifndef HAVE_X509_TO_USER /* [jt] 2013/11/21 - K-95 doesn't have X509_to_user */
     static char cn[256];
     static char *r = cn;
     int err;

--- a/kermit/k95/ck_ssl.c
+++ b/kermit/k95/ck_ssl.c
@@ -2841,7 +2841,11 @@ ssl_verify_crl(int ok, X509_STORE_CTX *ctx)
         /*
          * Check date of CRL to make sure it's not expired
          */
+#if OPENSSL_VERSION_NUMBER >= 0x10100005L
         i = X509_cmp_current_time(X509_CRL_get0_nextUpdate(crl));
+#else
+        i = X509_cmp_current_time(X509_CRL_get_nextUpdate(crl));
+#endif
         if (i == 0) {
             fprintf(stderr, "Found CRL has invalid nextUpdate field.\n");
             X509_STORE_CTX_set_error(ctx,

--- a/kermit/k95/ck_ssl.c
+++ b/kermit/k95/ck_ssl.c
@@ -2949,7 +2949,7 @@ tls_userid_from_client_cert(ssl) SSL * ssl;
      * only compatible with OpenSSL 0.9.x so in practice X509_to_user is never
      * available. It wouldn't be hard to make it work without SSLDLL if needed.
      */
-#ifndef HAVE_X509_TO_USER /* [jt] 2013/11/21 - K-95 doesn't have X509_to_user */
+#ifndef OS2 /* [jt] 2013/11/21 - K-95 doesn't have X509_to_user */
     static char cn[256];
     static char *r = cn;
     int err;

--- a/kermit/k95/ck_ssl.h
+++ b/kermit/k95/ck_ssl.h
@@ -32,7 +32,9 @@
 #endif /* OS2 */
 
 #ifdef ZLIB
+#ifndef OPENSSL_NO_COMP
 #include <openssl/comp.h>
+#endif
 #endif /* ZLIB */
 /* We place the following to avoid loading openssl/mdc2.h since it 
  * relies on the OpenSSL des.h.  Since we do not need the MDC2 

--- a/kermit/k95/ckcdeb.h
+++ b/kermit/k95/ckcdeb.h
@@ -2912,7 +2912,7 @@ extern long ztmsec, ztusec;		/* Fraction of sec of current time */
 #else /* _M_PPC */
 #ifndef NO_SSL
 #define CK_SSL
-#define SSLDLL  /* OpenSSL included at link time now - [jt] 2013/11/21 */
+/*#define SSLDLL*/  /* OpenSSL included at link time now - [jt] 2013/11/21 */
 #endif /* NO_SSL */
 #endif /* _M_PPC */
 #ifndef NO_KERBEROS

--- a/kermit/k95/ckcdeb.h
+++ b/kermit/k95/ckcdeb.h
@@ -2912,7 +2912,7 @@ extern long ztmsec, ztusec;		/* Fraction of sec of current time */
 #else /* _M_PPC */
 #ifndef NO_SSL
 #define CK_SSL
-/* #define SSLDLL */ /* OpenSSL included at link time now - [jt] 2013/11/21 */
+#define SSLDLL  /* OpenSSL included at link time now - [jt] 2013/11/21 */
 #endif /* NO_SSL */
 #endif /* _M_PPC */
 #ifndef NO_KERBEROS

--- a/kermit/k95/ckoath.c
+++ b/kermit/k95/ckoath.c
@@ -9547,8 +9547,10 @@ ck_security_loaddll( void )
 #endif /* CK_KERBEROS */
 
 #ifdef CK_SSL
+#ifdef SSLDLL
     ck_crypto_loaddll();
     ck_ssl_loaddll();
+#endif
 #endif /* CK_SSL */
 
 #ifdef ZLIB
@@ -9572,8 +9574,10 @@ ck_security_unloaddll( void )
     ck_krb5_loaddll_eh();
 
 #ifdef CK_SSL
+#ifdef SSLDLL
     ck_ssl_unloaddll();
     ck_crypto_unloaddll();
+#endif
 #endif /* CK_SSL */
 
 #ifdef ZLIB

--- a/kermit/k95/ckoker.mak
+++ b/kermit/k95/ckoker.mak
@@ -706,7 +706,7 @@ KUILIBS = kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib \
        ssh.lib ws2_32.lib \
 !endif
 !if "$(CKF_SSL)" == "yes"
-       libssl.lib libcrypto.lib \
+       $(SSL_LIBS) \
 !endif
         #msvcrt.lib
         #Kerberos: wshload.lib
@@ -718,7 +718,7 @@ LIBS = kernel32.lib user32.lib gdi32.lib wsock32.lib shell32.lib\
        ssh.lib ws2_32.lib \
 !endif
 !if "$(CKF_SSL)" == "yes"
-       libssl.lib libcrypto.lib \
+       $(SSL_LIBS) \
 !endif
        #msvcrt.lib  
        # Kerberos: wshload.lib

--- a/kermit/k95/ckossl.c
+++ b/kermit/k95/ckossl.c
@@ -52,6 +52,8 @@ static int deblog = 0;
 #endif
 static int ssl_finished_messages = 0;
 static unsigned long startflags = 0;
+#else
+extern int ssl_finished_messages;
 #endif /* NOT_KERMIT */
 
 int     (*p_SSL_get_error)(SSL *ssl,int num)=NULL;

--- a/kermit/k95/feature_flags.mak
+++ b/kermit/k95/feature_flags.mak
@@ -192,6 +192,17 @@ DISABLED_FEATURES = $(DISABLED_FEATURES) ZLIB
 #   Requires: OpenSSL
 #             And also some stuff fixed
 !if "$(CKF_SSL)" == "yes"
+
+#ENABLED_FEATURE_DEFS = $(ENABLED_FEATURE_DEFS) -DOPENSSL_097
+
+# No ZLIB? No OpenSSL Compression.
+!if "$(CKF_ZLIB)" != "yes"
+DISABLED_FEATURE_DEFS = $(DISABLED_FEATURE_DEFS) -DOPENSSL_NO_COMP
+!endif
+
+#SSL_LIBS=libssl.lib libcrypto.lib
+SSL_LIBS=ssleay32.lib libeay32.lib
+
 !else
 DISABLED_FEATURES = $(DISABLED_FEATURES) SSL
 DISABLED_FEATURE_DEFS = $(DISABLED_FEATURE_DEFS) -DNO_SSL

--- a/kermit/k95/feature_flags.mak
+++ b/kermit/k95/feature_flags.mak
@@ -203,6 +203,7 @@ ENABLED_FEATURES = $(ENABLED_FEATURES) SSL
 
 # No ZLIB? No OpenSSL Compression.
 !if "$(CKF_ZLIB)" != "yes"
+!message Building without SSL Compression
 DISABLED_FEATURE_DEFS = $(DISABLED_FEATURE_DEFS) -DOPENSSL_NO_COMP
 !endif
 

--- a/kermit/k95/feature_flags.mak
+++ b/kermit/k95/feature_flags.mak
@@ -173,7 +173,7 @@ CKF_SSL=no
 
 # Force SSL off - it doesn't build currently (the OS/2 and NT bits need
 # upgrading to at least OpenSSL 1.1.1 if not 3.0)
-CKF_SSL=no
+#CKF_SSL=no
 
 # ZLIB:
 #   Turn on with: -DZLIB
@@ -193,15 +193,18 @@ DISABLED_FEATURES = $(DISABLED_FEATURES) ZLIB
 #             And also some stuff fixed
 !if "$(CKF_SSL)" == "yes"
 
-#ENABLED_FEATURE_DEFS = $(ENABLED_FEATURE_DEFS) -DOPENSSL_097
+# You can optionally do this to have SSL support loaded at runtime when
+# SSLEAY32.DLL can be found. This is not compatible with OpenSSL 1.0.0 or newer
+# at this time however - STACK is not defined causing the build to fail in
+# ckosslc.c, line 173: void (*p_sk_free)(STACK *)=NULL;
+#ENABLED_FEATURE_DEFS = $(ENABLED_FEATURE_DEFS) -DSSLDLL
 
 # No ZLIB? No OpenSSL Compression.
 !if "$(CKF_ZLIB)" != "yes"
 DISABLED_FEATURE_DEFS = $(DISABLED_FEATURE_DEFS) -DOPENSSL_NO_COMP
 !endif
 
-#SSL_LIBS=libssl.lib libcrypto.lib
-SSL_LIBS=ssleay32.lib libeay32.lib
+SSL_LIBS=$(CKF_SSL_LIBS)
 
 !else
 DISABLED_FEATURES = $(DISABLED_FEATURES) SSL

--- a/kermit/k95/feature_flags.mak
+++ b/kermit/k95/feature_flags.mak
@@ -193,6 +193,8 @@ DISABLED_FEATURES = $(DISABLED_FEATURES) ZLIB
 #             And also some stuff fixed
 !if "$(CKF_SSL)" == "yes"
 
+ENABLED_FEATURES = $(ENABLED_FEATURES) SSL
+
 # You can optionally do this to have SSL support loaded at runtime when
 # SSLEAY32.DLL can be found. This is not compatible with OpenSSL 1.0.0 or newer
 # at this time however - STACK is not defined causing the build to fail in
@@ -203,6 +205,8 @@ DISABLED_FEATURES = $(DISABLED_FEATURES) ZLIB
 !if "$(CKF_ZLIB)" != "yes"
 DISABLED_FEATURE_DEFS = $(DISABLED_FEATURE_DEFS) -DOPENSSL_NO_COMP
 !endif
+
+#ENABLED_FEATURE_DEFS = $(ENABLED_FEATURE_DEFS) -DOPENSSL_100
 
 SSL_LIBS=$(CKF_SSL_LIBS)
 

--- a/kermit/k95/mkdist.bat
+++ b/kermit/k95/mkdist.bat
@@ -31,3 +31,12 @@ if defined WATCOM copy %WATCOM%\binnt\plbr*.dll dist
 
 @echo Copy enabled optional dependencies
 for %%I in (%CK_DIST_DLLS%) do copy %%I dist\
+
+@echo Copy licenses
+copy ..\..\COPYING dist
+if exist dist\ssh.dll copy %libssh_root%\COPYING dist\COPYING.libssh
+if not exist dist\openssl.exe goto :nossl
+REM OpenSSL License was renamed in 3.0.0 to LICENSE.txt
+if exist %openssl_root%\LICENSE.txt copy %openssl_root%\LICENSE.txt dist\COPYING.openssl
+if exist %openssl_root%\LICENSE copy %openssl_root%\LICENSE dist\COPYING.openssl
+:nossl

--- a/setenv.bat
+++ b/setenv.bat
@@ -86,8 +86,7 @@ REM zlib:
 if exist %zlib_root%\zlib.h set include=%include%;%zlib_root%
 if exist %zlib_root%\zlib.lib set lib=%lib%;%zlib_root%
 if exist %zlib_root%\zlib.lib set CKF_ZLIB=yes
-REM Not currently required -
-REM     if exist %zlib_root%\zlib1.dll set CK_DIST_DLLS=%CK_DIST_DLLS% %zlib_root%\zlib1.dll
+if exist %zlib_root%\zlib1.dll set CK_DIST_DLLS=%CK_DIST_DLLS% %zlib_root%\zlib1.dll
 
 REM OpenSSL
 REM OpenSSL 0.9.8, 1.0.0, 1.1.0, 1.1.1 and 3.0.x use this:
@@ -99,6 +98,7 @@ REM OpenSSL 1.1.x, 3.0.x
 if exist %openssl_root%\libssl.lib set lib=%lib%;%openssl_root%
 if exist %openssl_root%\libssl.lib set CKF_SSL=yes
 if exist %openssl_root%\libssl.lib set CKF_SSL_LIBS=libssl.lib libcrypto.lib
+if exist %openssl_root%\apps\openssl.exe set CK_DIST_DLLS=%CK_DIST_DLLS% %openssl_root%\apps\openssl.exe
 
 REM OpenSSL 3.0.x
 if exist %openssl_root%\libcrypto-3.dll set CK_DIST_DLLS=%CK_DIST_DLLS% %openssl_root%\libcrypto-3.dll %openssl_root%\libssl-3.dll
@@ -111,6 +111,7 @@ if exist %openssl_root%\out32dll\ssleay32.lib set lib=%lib%;%openssl_root%\out32
 if exist %openssl_root%\out32dll\ssleay32.lib set CKF_SSL=yes
 if exist %openssl_root%\out32dll\ssleay32.lib set CKF_SSL_LIBS=ssleay32.lib libeay32.lib
 if exist %openssl_root%\out32dll\ssleay32.dll set CK_DIST_DLLS=%CK_DIST_DLLS% %openssl_root%\out32dll\ssleay32.dll %openssl_root%\out32dll\libeay32.dll
+if exist %openssl_root%\out32dll\openssl.exe set CK_DIST_DLLS=%CK_DIST_DLLS% %openssl_root%\out32dll\openssl.exe
 
 REM libssh:
 if exist %libssh_root%\include\NUL set include=%include%;%libssh_root%\include;%libssh_build%\include

--- a/setenv.bat
+++ b/setenv.bat
@@ -125,6 +125,9 @@ echo.
 echo Library path set to:
 echo    %lib%
 echo.
+echo Dist files set to:
+echo    %CK_DIST_DLLS%
+echo.
 echo Optional Dependencies Found:
 echo    zlib: %CKF_ZLIB%
 echo OpenSSL: %CKF_SSL%

--- a/setenv.bat
+++ b/setenv.bat
@@ -89,12 +89,21 @@ if exist %zlib_root%\zlib.lib set CKF_ZLIB=yes
 REM Not currently required -
 REM     if exist %zlib_root%\zlib1.dll set CK_DIST_DLLS=%CK_DIST_DLLS% %zlib_root%\zlib1.dll
 
-REM OpenSSL:
+REM OpenSSL
 if exist %openssl_root%\include\NUL set include=%include%;%openssl_root%\include
+
+REM OpenSSL 1.1.1:
 if exist %openssl_root%\libssl.lib set lib=%lib%;%openssl_root%
 if exist %openssl_root%\libssl.lib set CKF_SSL=yes
+if exist %openssl_root%\libssl.lib set CKF_SSL_LIBS=libssl.lib libcrypto.lib
 if exist %openssl_root%\libcrypto-1_1.dll set CK_DIST_DLLS=%CK_DIST_DLLS% %openssl_root%\libcrypto-1_1.dll
 REM libcrypto is only needed for libssh
+
+REM OpenSSL 0.9.8, 1.0.0:
+if exist %openssl_root%\out32dll\ssleay32.lib set lib=%lib%;%openssl_root%\out32dll
+if exist %openssl_root%\out32dll\ssleay32.lib set CKF_SSL=yes
+if exist %openssl_root%\out32dll\ssleay32.lib set CKF_SSL_LIBS=ssleay32.lib libeay32.lib
+if exist %openssl_root%\out32dll\ssleay32.dll set CK_DIST_DLLS=%CK_DIST_DLLS% %openssl_root%\out32dll\ssleay32.dll %openssl_root%\out32dll\libeay32.dll
 
 REM libssh:
 if exist %libssh_root%\include\NUL set include=%include%;%libssh_root%\include;%libssh_build%\include

--- a/setenv.bat
+++ b/setenv.bat
@@ -90,16 +90,23 @@ REM Not currently required -
 REM     if exist %zlib_root%\zlib1.dll set CK_DIST_DLLS=%CK_DIST_DLLS% %zlib_root%\zlib1.dll
 
 REM OpenSSL
-if exist %openssl_root%\include\NUL set include=%include%;%openssl_root%\include
+REM OpenSSL 0.9.8, 1.0.0, 1.1.0, 1.1.1 and 3.0.x use this:
+if exist %openssl_root%\include\openssl\NUL set include=%include%;%openssl_root%\include
+REM OpenSSL 1.0.1 and 1.0.2 uses this:
+if exist %openssl_root%\inc32\openssl\NUL set include=%include%;%openssl_root%\inc32
 
-REM OpenSSL 1.1.1:
+REM OpenSSL 1.1.x, 3.0.x
 if exist %openssl_root%\libssl.lib set lib=%lib%;%openssl_root%
 if exist %openssl_root%\libssl.lib set CKF_SSL=yes
 if exist %openssl_root%\libssl.lib set CKF_SSL_LIBS=libssl.lib libcrypto.lib
-if exist %openssl_root%\libcrypto-1_1.dll set CK_DIST_DLLS=%CK_DIST_DLLS% %openssl_root%\libcrypto-1_1.dll
-REM libcrypto is only needed for libssh
 
-REM OpenSSL 0.9.8, 1.0.0:
+REM OpenSSL 3.0.x
+if exist %openssl_root%\libcrypto-3.dll set CK_DIST_DLLS=%CK_DIST_DLLS% %openssl_root%\libcrypto-3.dll %openssl_root%\libssl-3.dll
+
+REM OpenSSL 1.1.x
+if exist %openssl_root%\libcrypto-1_1.dll set CK_DIST_DLLS=%CK_DIST_DLLS% %openssl_root%\libcrypto-1_1.dll %openssl_root%\libssl-1_1.dll
+
+REM OpenSSL 0.9.8, 1.0.x:
 if exist %openssl_root%\out32dll\ssleay32.lib set lib=%lib%;%openssl_root%\out32dll
 if exist %openssl_root%\out32dll\ssleay32.lib set CKF_SSL=yes
 if exist %openssl_root%\out32dll\ssleay32.lib set CKF_SSL_LIBS=ssleay32.lib libeay32.lib


### PR DESCRIPTION
Now builds and appears to work with OpenSSL 0.9.8zf, 1.0.0s, 1.0.1u, 1.1.0l and 1.1.1q. Builds with OpenSSL 3.0.4 too though HTTPS connections don't work for some reason

- [x] Build instructions
- [x] Investigate why compression isn't working. Does the zlib DLL need to be included and if so under what filename?
- [x] Include a CA Certs bundle in the distribution - probably from here: https://curl.se/docs/caextract.html - should be named ca_certs.pem in either the bin dir, or appdata, or programdata
- [x] Investigate why tls_userid_from_client_cert is commented out now specifically for K95/CKW - it wasn't commented out in Kermit 95 2.2. What changed? Why is X509_to_user missing? Was it in some part of the codebase that wasn't released?
- [x] Have another go at building 1.1.1q without a bcrypt dependency so that it works on XP
- [x] Investigate why OpenSSL 3.0.4 isn't working properly and fix it if its not too much work.
- [x] Review all changes for impacts beyond NT/OS2