### PR TITLE
Restore SRP support

### DIFF
--- a/kermit/k95/ckoker.mak
+++ b/kermit/k95/ckoker.mak
@@ -685,44 +685,77 @@ COMMODE_OBJ = commode.obj
 
 !ifdef PLATFORM
 !if "$(PLATFORM)" == "OS2"
-LIBS = os2386.lib rexx.lib \
-!if "$(CMP)" != "OWCL"
-       bigmath.lib
-!endif
+LIBS = os2386.lib rexx.lib
+
 # OpenWatcom doesn't have bigmath.lib
-# SRP support: libsrp.lib
+!if "$(CMP)" != "OWCL"
+LIBS = $(LIBS) bigmath.lib
+!endif
+
+!if "$(CKF_SRP") == "yes"
+LIBS = $(LIBS) libsrp.lib
+!endif
+
 !else if "$(PLATFORM)" == "NT"
 !if "$(K95BUILD)" == "UIUC"
 LIBS = kernel32.lib user32.lib gdi32.lib wsock32.lib \
-       winmm.lib mpr.lib advapi32.lib winspool.lib 
-       # Kerberos: wshload.lib
+       winmm.lib mpr.lib advapi32.lib winspool.lib
+
+!if "$(CKF_K4W)" == "yes"
+LIBS = $(LIBS) wshload.lib
+!endif
+
 !else
 KUILIBS = kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib \
         advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib \
         rpcrt4.lib rpcns4.lib wsock32.lib \
-        winmm.lib vdmdbg.lib comctl32.lib mpr.lib $(COMMODE_OBJ) \
+        winmm.lib vdmdbg.lib comctl32.lib mpr.lib $(COMMODE_OBJ)
+
 !if "$(CKF_SSH)" == "yes"
-       ssh.lib ws2_32.lib \
+KUILIBS = $(KUILIBS) ssh.lib ws2_32.lib
 !endif
+
 !if "$(CKF_SSL)" == "yes"
-       $(SSL_LIBS) \
+KUILIBS = $(KUILIBS) $(SSL_LIBS)
 !endif
-        #msvcrt.lib
-        #Kerberos: wshload.lib
-		# SRP support: srpstatic.lib
-        #libsrp.lib bigmath.lib
+
+!if "$(CKF_SRP)" == "yes"
+# K95 2.1.3 was built with srpstatic.lib
+#KUILIBS = $(KUILIBS) srpstatic.lib
+KUILIBS = $(KUILIBS) srp.lib
+!endif
+
+# MIT Kerberos for Windows
+!if "$(CKF_K4W)" == "yes"
+KUILIBS = $(KUILIBS) wshload.lib
+!endif
+
+# Commented out KUILIBS in K95 2.1.3: msvcrt.lib libsrp.lib bigmath.lib
+
 LIBS = kernel32.lib user32.lib gdi32.lib wsock32.lib shell32.lib\
-       winmm.lib mpr.lib advapi32.lib winspool.lib $(COMMODE_OBJ) \
+       winmm.lib mpr.lib advapi32.lib winspool.lib $(COMMODE_OBJ)
+
 !if "$(CKF_SSH)" == "yes"
-       ssh.lib ws2_32.lib \
+LIBS = $(LIBS) ssh.lib ws2_32.lib
 !endif
+
 !if "$(CKF_SSL)" == "yes"
-       $(SSL_LIBS) \
+LIBS = $(LIBS) $(SSL_LIBS)
 !endif
-       #msvcrt.lib  
-       # Kerberos: wshload.lib
-	   # SRP support: srpstatic.lib
-       # libsrp.lib bigmath.lib
+
+!if "$(CKF_SRP)" == "yes"
+# K95 2.1.3 was built with srpstatic.lib
+#LIBS = $(LIBS) srpstatic.lib
+LIBS = $(LIBS) srp.lib
+!endif
+
+# MIT Kerberos for Windows
+!if "$(CKF_K4W)" == "yes"
+LIBS = $(LIBS) wshload.lib
+!endif
+
+# Commented out LIBS in K95 2.1.3: msvcrt.lib libsrp.lib bigmath.lib
+
 !endif
 !endif /* PLATFORM */
 !endif
@@ -809,10 +842,16 @@ $(PDLLDIR)\pdll_z_global.obj \
 
 os232: ckoker32.exe tcp32 otelnet.exe ckoclip.exe orlogin.exe osetup.exe otextps.exe \
 !if "$(CMP)" != "OWCL386"
-       cko32rtl.dll     # IBM compiler only.
+       cko32rtl.dll \    # IBM compiler only.
 !endif
-# SRP support: srp-tconf.exe srp-passwd.exe
-# Crypto stuff: k2crypt.dll 
+!if "$(CKF_SRP)" == "yes"
+#!if "$(CKF_SSL)" == "yes"
+       srp-tconf.exe srp-passwd.exe \
+#!endif
+!endif
+!if "$(CKF_CRYPTDLL)" == "yes"
+# TODO: Figure out how to build this for OS/2 with Watcom: k2crypt.dll
+!endif
 
 # docs pcfonts.dll cksnval.dll 
 
@@ -821,9 +860,15 @@ os232: ckoker32.exe tcp32 otelnet.exe ckoclip.exe orlogin.exe osetup.exe otextps
 win32: cknker.exe wtelnet wrlogin k95d textps ctl3dins.exe iksdsvc.exe iksd.exe \
     se.exe \
 !if "$(CKF_CRYPTDLL)" == "yes"
-    k95crypt.dll
+    k95crypt.dll \
 !endif
-# SRP support: srp-tconf.exe srp-passwd.exe
+# These likely require an old version of SRP (perhaps pre-1.7?) to build. They
+# appear to just be versions of utilities that come with SRP likely modified to
+# load the SSL DLL dynamically like K95 did - not really something we care much
+# about now.
+#!if "$(CKF_SRP)" == "yes"
+#       srp-passwd.exe srp-tconf.exe
+#!endif
 
 win32md: mdnker.exe
 
@@ -1042,21 +1087,23 @@ ckoclip.exe: ckoclip.obj ckoker.mak ckoclip.res
 !endif
 
 # SRP support
-#srp-tconf.exe: srp-tconf.obj getopt.obj ssh\ckosslc.obj ckoker.mak
-#!if "$(PLATFORM)" == "OS2"
-#        $(CC) $(CC2) $(DEBUG) srp-tconf.obj getopt.obj ssh\ckosslc.obj ckotel.def $(OUT) $@ $(LIBS)
-#        dllrname $@ CPPRMI36=CKO32RTL       
-#!else if "$(PLATFORM)" == "NT"
-#	link /debug /out:$@ srp-tconf.obj getopt.obj ssh\ckosslc.obj $(LIBS)
-#!endif
-#        
-#srp-passwd.exe: srp-passwd.obj getopt.obj ssh\ckosslc.obj ckoker.mak
-#!if "$(PLATFORM)" == "OS2"
-#        $(CC) $(CC2) $(DEBUG) srp-passwd.obj getopt.obj ssh\ckosslc.obj ckotel.def $(OUT) $@ $(LIBS)
-#        dllrname $@ CPPRMI36=CKO32RTL       
-#!else if "$(PLATFORM)" == "NT"
-#	link /debug /out:$@ srp-passwd.obj getopt.obj ssh\ckosslc.obj $(LIBS)
-#!endif
+!if "$(CKF_SRP)" == "yes"
+srp-tconf.exe: srp-tconf.obj getopt.obj ckosslc.obj ckoker.mak
+!if "$(PLATFORM)" == "OS2"
+        $(CC) $(CC2) $(DEBUG) srp-tconf.obj getopt.obj ckosslc.obj ckotel.def $(OUT) $@ $(LIBS)
+        dllrname $@ CPPRMI36=CKO32RTL
+!else if "$(PLATFORM)" == "NT"
+	link /debug /out:$@ srp-tconf.obj getopt.obj ckosslc.obj $(LIBS)
+!endif
+
+srp-passwd.exe: srp-passwd.obj getopt.obj ckosslc.obj ckoker.mak
+!if "$(PLATFORM)" == "OS2"
+        $(CC) $(CC2) $(DEBUG) srp-passwd.obj getopt.obj ckosslc.obj ckotel.def $(OUT) $@ $(LIBS)
+        dllrname $@ CPPRMI36=CKO32RTL
+!else if "$(PLATFORM)" == "NT"
+	link /debug /out:$@ srp-passwd.obj getopt.obj ckosslc.obj $(LIBS)
+!endif
+!endif
         
 iksdsvc.exe: iksdsvc.obj ckoker.mak
 !if "$(PLATFORM)" == "OS2"
@@ -1274,9 +1321,11 @@ ckoclip$(O):     ckoclip.c
 k95d$(O):  k95d.c
 
 # SRP support
-#getopt$(O):     getopt.c getopt.h
-#srp-tconf$(O):  srp-tconf.c getopt.h 
-#srp-passwd$(O): srp-passwd.c getopt.h
+!if "$(CKF_SRP)" == "yes"
+getopt$(O):     getopt.c getopt.h
+srp-tconf$(O):  srp-tconf.c getopt.h
+srp-passwd$(O): srp-passwd.c getopt.h
+!endif
 
 iksdsvc$(O):    iksdsvc.c 
 

--- a/kermit/k95/feature_flags.mak
+++ b/kermit/k95/feature_flags.mak
@@ -48,11 +48,11 @@
 
 # Network Connections are always supported. We only put it here because
 # the Watcom nmake clone can't handle empty macros so we need *something* here.
-ENABLED_FEATURES = Network-Connections
-ENABLED_FEATURE_DEFS = -DNETCONN
+#ENABLED_FEATURES = Network-Connections
+#ENABLED_FEATURE_DEFS = -DNETCONN
 
-DISABLED_FEATURES = Kerberos SRP
-DISABLED_FEATURE_DEFS = -DNO_KERBEROS -DNO_SRP
+#DISABLED_FEATURES =
+#DISABLED_FEATURE_DEFS =
 
 # type /interpret doesn't work on windows currently.
 DISABLED_FEATURE_DEFS = $(DISABLED_FEATURE_DEFS) -DNOTYPEINTERPRET
@@ -139,6 +139,10 @@ CKF_NETBIOS=no
 !message Turning X/Y/Z MODEM support off - build errors with OpenWatcom need fixing
 CKF_XYZ=no
 
+!message Turning SRP off - no Watcom support for it yet.
+CKF_SRP=no
+# TODO: Figure out SRP support on OS/2 with OpenWatcom
+
 !endif
 
 !if "$(CKF_SSH)" == "yes"
@@ -155,18 +159,7 @@ CKF_SSH=no
 # SFTP:
 #   Turn on with -DSFTP_BUILTIN
 #   Requires: reimplementing with libssl (existing implementation relies on the
-#             missing OpenSSL bits)
-# Kerberos:
-#   Turn off with: -DNO_KERBEROS
-#   Requires: An antique version of MIT Kerberos for Windows.
-#      OR: Rework this to use Heimdal Kerberos
-# SRP:
-#   Turn off with: -DNO_SRP
-#   Optionally: -DPRE_SRP_1_7_3
-#   Requires: Some version of Stanford SRP (ancient)
-#      OR: Reimplementing using SRP support in OpenSSL
-#          (libssh has no SRP support and the SRP patches for OpenSSH are a
-#           decade or two out of date making this not very useful)
+#             missing OpenSSH bits)
 
 !if "$(CKF_NO_CRYPTO)" == "yes"
 # A No-crypto build has been requested regardless of what libraries may have
@@ -174,11 +167,38 @@ CKF_SSH=no
 CKF_SSH=no
 CKF_SSL=no
 CKF_TELNET_ENCRYPTION=no
+CKF_SRP=no
+CKF_K4W=no
 !endif
 
-# Force SSL off - it doesn't build currently (the OS/2 and NT bits need
-# upgrading to at least OpenSSL 1.1.1 if not 3.0)
-#CKF_SSL=no
+# MIT Kerberos for Windows:
+#   On by default
+#   Turn off with: -DNO_KERBEROS
+#   Requires: An antique version of MIT Kerberos for Windows.
+#      OR: Rework this to use Heimdal Kerberos
+!if "$(CKF_K4W)" == "yes"
+# Nothing required - its on by default.
+ENABLED_FEATURES = $(ENABLED_FEATURES) Kerberos
+!else
+DISABLED_FEATURES = $(DISABLED_FEATURES) Kerberos
+DISABLED_FEATURE_DEFS = $(DISABLED_FEATURE_DEFS) -DNO_KERBEROS
+!endif
+
+# Stanford SRP:
+#   On by default
+#   Turn off with: -DNO_SRP
+!if "$(CKF_SRP)" == "yes"
+# Requires Stanford SRP. Tested work version 2.1.2 but older versions may be
+# supported with -DPRE_SRP_1_7_3
+#
+# Ideally SRP functionality would be (optionally) reimplemented using OpenSSL
+# which likely has a more up-to-date and secure SRP implementation.
+ENABLED_FEATURES = $(ENABLED_FEATURES) SRP
+
+!else
+DISABLED_FEATURES = $(DISABLED_FEATURES) SRP
+DISABLED_FEATURE_DEFS = $(DISABLED_FEATURE_DEFS) -DNO_SRP
+!endif
 
 # ZLIB:
 #   Turn on with: -DZLIB

--- a/kermit/k95/getopt.c
+++ b/kermit/k95/getopt.c
@@ -1,0 +1,250 @@
+/*****************************************************************************
+* getopt.c - competent and free getopt library.
+* $Header: /cvsroot/freegetopt/freegetopt/getopt.c,v 1.2 2003/10/26 03:10:20 vindaci Exp $
+*
+* Copyright (c)2002-2003 Mark K. Kim
+* All rights reserved.
+* 
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*
+*   * Redistributions in binary form must reproduce the above copyright
+*     notice, this list of conditions and the following disclaimer in
+*     the documentation and/or other materials provided with the
+*     distribution.
+*
+*   * Neither the original author of this software nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+* THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+* DAMAGE.
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "getopt.h"
+
+
+static const char* ID = "$Id: getopt.c,v 1.2 2003/10/26 03:10:20 vindaci Exp $";
+
+
+char* optarg = NULL;
+int optind = 0;
+int opterr = 1;
+int optopt = '?';
+
+
+static char** prev_argv = NULL;        /* Keep a copy of argv and argc to */
+static int prev_argc = 0;              /*    tell if getopt params change */
+static int argv_index = 0;             /* Option we're checking */
+static int argv_index2 = 0;            /* Option argument we're checking */
+static int opt_offset = 0;             /* Index into compounded "-option" */
+static int dashdash = 0;               /* True if "--" option reached */
+static int nonopt = 0;                 /* How many nonopts we've found */
+
+static void increment_index()
+{
+	/* Move onto the next option */
+	if(argv_index < argv_index2)
+	{
+		while(prev_argv[++argv_index] && prev_argv[argv_index][0] != '-'
+				&& argv_index < argv_index2+1);
+	}
+	else argv_index++;
+	opt_offset = 1;
+}
+
+
+/*
+* Permutes argv[] so that the argument currently being processed is moved
+* to the end.
+*/
+static int permute_argv_once()
+{
+	/* Movability check */
+	if(argv_index + nonopt >= prev_argc) return 1;
+	/* Move the current option to the end, bring the others to front */
+	else
+	{
+		char* tmp = prev_argv[argv_index];
+
+		/* Move the data */
+		memmove(&prev_argv[argv_index], &prev_argv[argv_index+1],
+				sizeof(char**) * (prev_argc - argv_index - 1));
+		prev_argv[prev_argc - 1] = tmp;
+
+		nonopt++;
+		return 0;
+	}
+}
+
+
+int getopt(int argc, char** argv, char* optstr)
+{
+	int c = 0;
+
+	/* If we have new argv, reinitialize */
+	if(prev_argv != argv || prev_argc != argc)
+	{
+		/* Initialize variables */
+		prev_argv = argv;
+		prev_argc = argc;
+		argv_index = 1;
+		argv_index2 = 1;
+		opt_offset = 1;
+		dashdash = 0;
+		nonopt = 0;
+	}
+
+	/* Jump point in case we want to ignore the current argv_index */
+	getopt_top:
+
+	/* Misc. initializations */
+	optarg = NULL;
+
+	/* Dash-dash check */
+	if(argv[argv_index] && !strcmp(argv[argv_index], "--"))
+	{
+		dashdash = 1;
+		increment_index();
+	}
+
+	/* If we're at the end of argv, that's it. */
+	if(argv[argv_index] == NULL)
+	{
+		c = -1;
+	}
+	/* Are we looking at a string? Single dash is also a string */
+	else if(dashdash || argv[argv_index][0] != '-' || !strcmp(argv[argv_index], "-"))
+	{
+		/* If we want a string... */
+		if(optstr[0] == '-')
+		{
+			c = 1;
+			optarg = argv[argv_index];
+			increment_index();
+		}
+		/* If we really don't want it (we're in POSIX mode), we're done */
+		else if(optstr[0] == '+' || getenv("POSIXLY_CORRECT"))
+		{
+			c = -1;
+
+			/* Everything else is a non-opt argument */
+			nonopt = argc - argv_index;
+		}
+		/* If we mildly don't want it, then move it back */
+		else
+		{
+			if(!permute_argv_once()) goto getopt_top;
+			else c = -1;
+		}
+	}
+	/* Otherwise we're looking at an option */
+	else
+	{
+		char* opt_ptr = NULL;
+
+		/* Grab the option */
+		c = argv[argv_index][opt_offset++];
+
+		/* Is the option in the optstr? */
+		if(optstr[0] == '-') opt_ptr = strchr(optstr+1, c);
+		else opt_ptr = strchr(optstr, c);
+		/* Invalid argument */
+		if(!opt_ptr)
+		{
+			if(opterr)
+			{
+				fprintf(stderr, "%s: invalid option -- %c\n", argv[0], c);
+			}
+
+			optopt = c;
+			c = '?';
+
+			/* Move onto the next option */
+			increment_index();
+		}
+		/* Option takes argument */
+		else if(opt_ptr[1] == ':')
+		{
+			/* ie, -oARGUMENT, -xxxoARGUMENT, etc. */
+			if(argv[argv_index][opt_offset] != '\0')
+			{
+				optarg = &argv[argv_index][opt_offset];
+				increment_index();
+			}
+			/* ie, -o ARGUMENT (only if it's a required argument) */
+			else if(opt_ptr[2] != ':')
+			{
+				/* One of those "you're not expected to understand this" moment */
+				if(argv_index2 < argv_index) argv_index2 = argv_index;
+				while(argv[++argv_index2] && argv[argv_index2][0] == '-');
+				optarg = argv[argv_index2];
+
+				/* Don't cross into the non-option argument list */
+				if(argv_index2 + nonopt >= prev_argc) optarg = NULL;
+
+				/* Move onto the next option */
+				increment_index();
+			}
+			else
+			{
+				/* Move onto the next option */
+				increment_index();
+			}
+
+			/* In case we got no argument for an option with required argument */
+			if(optarg == NULL && opt_ptr[2] != ':')
+			{
+				optopt = c;
+				c = '?';
+
+				if(opterr)
+				{
+					fprintf(stderr,"%s: option requires an argument -- %c\n",
+							argv[0], optopt);
+				}
+			}
+		}
+		/* Option does not take argument */
+		else
+		{
+			/* Next argv_index */
+			if(argv[argv_index][opt_offset] == '\0')
+			{
+				increment_index();
+			}
+		}
+	}
+
+	/* Calculate optind */
+	if(c == -1)
+	{
+		optind = argc - nonopt;
+	}
+	else
+	{
+		optind = argv_index;
+	}
+
+	return c;
+}
+
+
+/* vim:ts=3
+*/

--- a/kermit/k95/getopt.h
+++ b/kermit/k95/getopt.h
@@ -1,0 +1,63 @@
+/*****************************************************************************
+* getopt.h - competent and free getopt library.
+* $Header: /cvsroot/freegetopt/freegetopt/getopt.h,v 1.2 2003/10/26 03:10:20 vindaci Exp $
+*
+* Copyright (c)2002-2003 Mark K. Kim
+* All rights reserved.
+* 
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*
+*   * Redistributions in binary form must reproduce the above copyright
+*     notice, this list of conditions and the following disclaimer in
+*     the documentation and/or other materials provided with the
+*     distribution.
+*
+*   * Neither the original author of this software nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+* THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+* DAMAGE.
+*/
+#ifndef GETOPT_H_
+#define GETOPT_H_
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+extern char* optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+
+int getopt(int argc, char** argv, char* optstr);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* GETOPT_H_ */
+
+
+/* vim:ts=3
+*/

--- a/setenv.bat
+++ b/setenv.bat
@@ -49,9 +49,18 @@ REM libdes - required for building k95crypt.dll and enabling a few features that
 REm rely on obsolete and easily broken encryption
 set libdes_root=%root%\libdes
 
+REM Stanford SRP - Optional SRP Authentication for Telnet and FTP connections
+REM Extract srp-2.1.2.tar.gz to the following location:
+set srp_root=%root%\srp
+
+REM Kerberos for Windows, support for which probably hasn't been built since 2002
+set k4w_root=%root%\kerberos\kfw-2.2-beta-2
+
 REM ============================================================================
 REM ================== No changes required beyond this point ===================
 REM ============================================================================
+
+echo Searching for Optional Dependencies...
 
 REM base include path - this is required for both Windows and OS/2
 set ckinclude=%root%\kermit\k95
@@ -119,15 +128,18 @@ REM ------------------------------------------------------------
 REM zlib:
 if "%CKF_ZLIB%" == "no" echo Skipping check for ZLIB
 if "%CKF_ZLIB%" == "no" goto :nozlib
+set CKF_ZLIB=no
 if exist %zlib_root%\zlib.h set include=%include%;%zlib_root%
 if exist %zlib_root%\zlib.lib set lib=%lib%;%zlib_root%
 if exist %zlib_root%\zlib.lib set CKF_ZLIB=yes
+if exist %zlib_root%\zlib.lib echo Found zlib
 if exist %zlib_root%\zlib1.dll set CK_ZLIB_DIST_DLLS=%zlib_root%\zlib1.dll
 :nozlib
 
 REM OpenSSL
 if "%CKF_SSL%" == "no" echo Skipping check for OpenSSL
 if "%CKF_SSL%" == "no" goto :nossl
+set CKF_SSL=no
 REM OpenSSL 0.9.8, 1.0.0, 1.1.0, 1.1.1 and 3.0.x use this:
 if exist %openssl_root%\include\openssl\NUL set include=%include%;%openssl_root%\include
 REM OpenSSL 1.0.1 and 1.0.2 uses this:
@@ -136,6 +148,7 @@ if exist %openssl_root%\inc32\openssl\NUL set include=%include%;%openssl_root%\i
 REM OpenSSL 1.1.x, 3.0.x
 if exist %openssl_root%\libssl.lib set lib=%lib%;%openssl_root%
 if exist %openssl_root%\libssl.lib set CKF_SSL=yes
+if exist %openssl_root%\libssl.lib echo Found OpenSSL 1.1.x or 3.0.x
 if exist %openssl_root%\libssl.lib set CKF_SSL_LIBS=libssl.lib libcrypto.lib
 if exist %openssl_root%\apps\openssl.exe set CK_SSL_DIST_DLLS=%CK_SSL_DIST_DLLS% %openssl_root%\apps\openssl.exe
 
@@ -148,6 +161,7 @@ if exist %openssl_root%\libcrypto-1_1.dll set CK_SSL_DIST_DLLS=%CK_SSL_DIST_DLLS
 REM OpenSSL 0.9.8, 1.0.x:
 if exist %openssl_root%\out32dll\ssleay32.lib set lib=%lib%;%openssl_root%\out32dll
 if exist %openssl_root%\out32dll\ssleay32.lib set CKF_SSL=yes
+if exist %openssl_root%\out32dll\ssleay32.lib echo Found OpenSSL 0.9.8 or 1.0.x
 if exist %openssl_root%\out32dll\ssleay32.lib set CKF_SSL_LIBS=ssleay32.lib libeay32.lib
 if exist %openssl_root%\out32dll\ssleay32.dll set CK_SSL_DIST_DLLS=%CK_SSL_DIST_DLLS% %openssl_root%\out32dll\ssleay32.dll %openssl_root%\out32dll\libeay32.dll
 if exist %openssl_root%\out32dll\openssl.exe set CK_SSL_DIST_DLLS=%CK_SSL_DIST_DLLS% %openssl_root%\out32dll\openssl.exe
@@ -156,31 +170,61 @@ if exist %openssl_root%\out32dll\openssl.exe set CK_SSL_DIST_DLLS=%CK_SSL_DIST_D
 REM libssh:
 if "%CKF_SSH%" == "no" echo Skipping check for libssh
 if "%CKF_SSH%" == "no" goto :nossh
+set CKF_SSH=no
 if exist %libssh_root%\include\NUL set include=%include%;%libssh_root%\include;%libssh_build%\include
 if exist %libssh_build%\src\ssh.lib set lib=%lib%;%libssh_build%\src
 if exist %libssh_build%\src\ssh.lib set CKF_SSH=yes
+if exist %libssh_build%\src\ssh.lib echo Found libssh
 if exist %libssh_build%\src\ssh.dll set CK_SSH_DIST_DLLS=%libssh_build%\src\ssh.dll
 :nossh
 
 REM libdes:
 if "%CKF_LIBDES%" == "no" echo Skipping check for libdes
 if "%CKF_LIBDES%" == "no" goto :nolibdes
-if exist %libdes_root%\des\des.h set CKF_LIBDES=yes
-if exist %libdes_root%\des\des.h set CKF_CRYPTDLL=yes
-if exist %libdes_root%\des\des.h set INCLUDE=%include%;%libdes_root%
+set CKF_LIBDES=no
+if not exist %libdes_root%\des\des.h goto :nolibdes
+echo Found libdes
+set CKF_LIBDES=yes
+set CKF_CRYPTDLL=yes
+set INCLUDE=%include%;%libdes_root%
 if exist %libdes_root%\Release\libdes.lib set lib=%lib%;%libdes_root%\Release\
 if exist %libdes_root%\Debug\libdes.lib set lib=%lib%;%libdes_root%\Debug\
 :nolibdes
 
-if not defined CKF_ZLIB set CKF_ZLIB=no
-if not defined CKF_SSL set CKF_SSL=no
-if not defined CKF_SSH set CKF_SSH=no
-if not defined CKF_LIBDES set CKF_LIBDES=no
+REM Stanford SRP
+if "%CKF_LIBDES%" == "no" echo Skipping check for SRP (libdes is required but not available)
+if "%CKF_LIBDES%" == "no" goto :nosrp
+if "%CKF_SRP%" == "no" echo Skipping check for SRP
+if "%CKF_SRP%" == "no" goto :nosrp
+set CKF_SRP=no
+if not exist %srp_root%\win32\libsrp_openssl\Release\srp.lib echo Stanford SRP not found.
+if not exist %srp_root%\win32\libsrp_openssl\Release\srp.lib goto :nosrp
+echo Found Stanford SRP
+set CKF_SRP=yes
+set INCLUDE=%INCLUDE%;%srp_root%\include
+set LIB=%LIB%;%srp_root%\win32\libsrp_openssl\Release\
+set CK_SRP_DIST_DLLS=%srp_root%\win32\libsrp_openssl\Release\srp.dll %srp_root%\win32\libsrp_openssl\Release\tconf.exe
+:nosrp
+
+REM Kerberos for Windows
+if "%CKF_K4W%" == "no" echo Skipping check for K4W
+if "%CKF_K4W%" == "no" goto :nok4w
+set CKF_K4W=no
+if not exist %k4w_root%\target\lib\i386\rel\wshload.lib echo Kerberos for Windows (K4W) not found.
+if not exist %k4w_root%\target\lib\i386\rel\wshload.lib goto :nok4w
+echo Found Kerberos for Windows (K4W)
+set CKF_K4W=yes
+set INCLUDE=$INCLUDE%;%k4w_root%\athena\wshelper\include
+set INCLUDE=$INCLUDE%;%k4w_root%\athena\auth\krb5\src\include
+set lib=%lib%;%k4w_root%\target\lib\i386\rel
+:nok4w
 
 
 REM --------------------------------------------------------------
 REM Detect compiler so the OpenZinc build environment can be setup 
 REM --------------------------------------------------------------
+
+echo Attempting to identify compiler (this may take a moment)...
 
 REM Now figure out what compiler we're using - we need to find this out so we'll
 REM know where to look for OpenZinc and if we're able to build it if it can't be
@@ -399,7 +443,7 @@ if "%CK_K95CINIT%" == "yes" goto :build_k95cinit
 REM TODO - if we're using an old compiler, force things like SSH off
 REM        and remove their dist files.
 
-set CK_DIST_DLLS=%CK_ZLIB_DIST_DLLS% %CK_SSL_DIST_DLLS% %CK_SSH_DIST_DLLS%
+set CK_DIST_DLLS=%CK_ZLIB_DIST_DLLS% %CK_SSL_DIST_DLLS% %CK_SSH_DIST_DLLS% %CK_SRP_DIST_DLLS%
 
 echo -----------------------------
 echo.
@@ -421,6 +465,8 @@ echo   libssh: %CKF_SSH%
 echo     zinc: %CKF_ZINC%
 echo   libdes: %CKF_LIBDES%
 echo SuperLAT: %CKF_SUPERLAT%
+echo      SRP: %CKF_SRP%
+echo      K4W: %CKF_K4W%
 echo.
 if "%BUILD_ZINC%" == "yes" echo OpenZinc is required for building the dialer. You can build it by extracting
 if "%BUILD_ZINC%" == "yes" echo the OpenZinc distribution to %root%\zinc and running


### PR DESCRIPTION
There is a pile of SRP code present. It ought to at least be buildable.

At some point all the SRP code really needs to be shifted to a newer implementation (perhaps the one that comes with OpenSSL) as the original Stanford SRP distribution is no longer maintained and likely has security issues. This is going to be easier for someone to do if the SRP code in CKW can be built and seen working.

Until that happens, SRP support needs the latest version of the Stanford SRP distribution.