### PR TITLE
Build for Itanium with the Windows 7 Platform SDK version 7.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -366,6 +366,10 @@ jobs:
           SET PlatformToolset=100
           call vc10.cmd /release /xp /${{matrix.arch}}
           
+          echo PATH: %PATH%
+          echo LIB: %LIB%
+          echo INCLUDE: %INCLUDE%
+          
           echo Run Build...
           call setenv.bat
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -370,8 +370,20 @@ jobs:
           echo LIB: %LIB%
           echo INCLUDE: %INCLUDE%
           
-          echo CL:
-          "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\VC\Bin\x86_IA64"\cl.exe /version
+          echo IA64 CL:
+          "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\VC\Bin\x86_IA64"\cl.exe
+          echo Error level: %errorlevel%
+          
+          echo x86 CL:
+          "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\VC\Bin"\cl.exe
+          echo Error level: %errorlevel%
+          
+          echo Dir:
+          dir /w "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\VC\Bin\"
+          copy "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\Common7\IDE"\*.dll "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\VC\Bin\"
+          
+          echo x86 CL after copy:
+          "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\VC\Bin"\cl.exe
           echo Error level: %errorlevel%
           
           echo Run Build...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -354,6 +354,11 @@ jobs:
           wget https://ftp.zx.net.nz/pub/dev/WinSDK/win7-7.1-dn4/win7-7.1-sdk-vc.7z -outfile win7-7.1-sdk-vc.7z
           7z x win7-7.1-sdk-vc.7z
           
+          wget https://ftp.zx.net.nz/pub/dev/WinSDK/win7-7.1-dn4/win7-7.1-sdk-psdk.7z -outfile win7-7.1-sdk-psdk.7z
+          7z x win7-7.1-sdk-vc.7z
+          
+          del *.7z
+          
           wget http://download.microsoft.com/download/5/B/C/5BC5DBB3-652D-4DCE-B14A-475AB85EEF6E/vcredist_x86.exe -outfile vcredist_x86.exe
         shell: powershell
 
@@ -381,22 +386,6 @@ jobs:
           echo x86 CL:
           "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\VC\Bin"\cl.exe
           echo Error level: %errorlevel%
-          
-          echo Dir:
-          dir /w "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\VC\Bin\"
-          copy "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\Common7\IDE"\*.dll "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\VC\Bin\"
-          
-          echo x86 CL after copy:
-          "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\VC\Bin"\cl.exe
-          echo Error level: %errorlevel%
-          
-          echo Try again
-          cd "Microsoft Visual Studio 10.0\VC\Bin\"
-          REM copy ..\..\..\vcredist\*.dll
-          dir /w
-          cl
-          echo Error level: %errorlevel%
-          cd ..\..\..
           
           echo Configure build environment...
           call setenv.bat

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -331,8 +331,8 @@ jobs:
       matrix:
         arch:
           - ia64
-          #- x86
-          #- x64
+          - x86
+          - x64
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -433,7 +433,7 @@ jobs:
           call vc10.cmd /release /xp /${{matrix.arch}}
           
           cd openssl\${{env.OPENSSL_VERSION}}
-          perl Configure VC-WIN32I
+          perl Configure VC-WIN64I
           
           REM The perl configure script doesn't work quite right for cross-compiling to IA64
           REM it leaves the /machine flag off the link flags, so we'll just add it on ourselves.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,13 +33,13 @@ jobs:
       matrix:
         arch:
           - x86
-          - x64
-          - x64_arm
-          - x64_arm64
+          #- x64
+          #- x64_arm
+          #- x64_arm64
         toolset:
           - 14.0
-          - 14.2
-          - 14.3
+          #- 14.2
+          #- 14.3
         exclude:
           # No point building ARM or ARM64 targets with anything less than the latest as the latest
           # still supports the first ARM Windows.
@@ -369,6 +369,9 @@ jobs:
           echo PATH: %PATH%
           echo LIB: %LIB%
           echo INCLUDE: %INCLUDE%
+          
+          echo CL:
+          "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\VC\Bin\x86_IA64"\cl.exe /version
           
           echo Run Build...
           call setenv.bat

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -369,13 +369,122 @@ jobs:
         working-directory: ${{ github.workspace }}
 
         ##########################################################################
+        # Build optional dependencies (openssl, libdes)                          #
+        ##########################################################################
+      - name: Cache Optional Dependencies
+        uses: actions/cache@v3.0.11
+        id: cache-optional-dependencies
+        with:
+          path: |
+            ${{github.workspace}}\zlib 
+            ${{github.workspace}}\openssl 
+            ${{github.workspace}}\libssh
+            ${{github.workspace}}\libdes\des
+            ${{github.workspace}}\libdes\Release
+            ${{github.workspace}}\libdes\Debug
+            ${{github.workspace}}\tools
+          key: platform-sdk-71-optdepts-${{ matrix.arch }}+nasm+openssl-${{env.OPENSSL_VERSION}}+libdes
+
+      - name: Get dependencies
+        if: steps.cache-optional-dependencies.outputs.cache-hit != 'true'
+        run: |         
+          # Get and unpack openssl
+          mkdir openssl
+          cd openssl
+          wget https://www.openssl.org/source/openssl-${{env.OPENSSL_VERSION}}.tar.gz -outfile openssl-${{env.OPENSSL_VERSION}}.tar.gz
+          7z x openssl-${{env.OPENSSL_VERSION}}.tar.gz
+          7z x openssl-${{env.OPENSSL_VERSION}}.tar
+          ren openssl-${{env.OPENSSL_VERSION}} ${{env.OPENSSL_VERSION}}
+          del *.tar 
+          del *.gz
+          cd ..
+          
+          # Get and unpack libdes
+          cd libdes
+          wget ${{env.LIBDES}} -outfile libdes.tar.gz
+          7z x libdes.tar.gz
+          7z x libdes.tar
+          del *.tar
+          del *.gz
+          cd ..
+          
+          # Get and unpack nasm
+          mkdir tools
+          cd tools
+          wget https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/win32/nasm-2.15.05-win32.zip -outfile nasm-2.15.05-win32.zip
+          7z x nasm-2.15.05-win32.zip
+          ren nasm-2.15.05 nasm
+          del *.zip
+          dir
+          cd nasm
+          dir
+          cd ..
+          cd ..          
+          
+          # Install perl modules required by OpenSSL build
+          cpan -i Text::Template
+        shell: powershell
+
+      - name: Build openssl (ia64)
+        if: steps.cache-optional-dependencies.outputs.cache-hit != 'true' && matrix.arch == 'ia64'
+        shell: cmd
+        run: |
+          SET PlatformToolset=100
+          call vc10.cmd /release /xp /${{matrix.arch}}
+          
+          cd openssl\${{env.OPENSSL_VERSION}}
+          perl Configure VC-WIN32I
+          
+          REM The perl configure script doesn't work quite right for cross-compiling to IA64
+          REM it leaves the /machine flag off the link flags, so we'll just add it on ourselves.
+          sed -i "s/^LDFLAGS=\/nologo.*/& \/machine:ia64/g" makefile
+          
+          nmake
+
+      - name: Build openssl (x86-64)
+        if: steps.cache-optional-dependencies.outputs.cache-hit != 'true' && matrix.arch == 'x64'
+        shell: cmd
+        run: |
+          SET PlatformToolset=100
+          call vc10.cmd /release /xp /${{matrix.arch}}
+          
+          cd openssl\${{env.OPENSSL_VERSION}}
+          set PATH=%PATH%;${{github.workspace}}\tools\nasm
+          
+          perl Configure VC-WIN64A -D"_WIN32_WINNT=0x502"     
+          nmake       
+
+      - name: Build openssl (x86)
+        if: steps.cache-optional-dependencies.outputs.cache-hit != 'true' && matrix.arch == 'x64_arm'
+        shell: powershell
+        run: |
+          SET PlatformToolset=100
+          call vc10.cmd /release /xp /${{matrix.arch}}
+          
+          cd openssl\${{env.OPENSSL_VERSION}}
+          
+          set PATH=%PATH%;${{github.workspace}}\tools\nasm
+          
+          perl Configure VC-WIN32 -D"_WIN32_WINNT=0x502" 
+          nmake     
+
+      - name: Build libdes
+        if: steps.cache-optional-dependencies.outputs.cache-hit != 'true'
+        shell: cmd
+        run: |
+          SET PlatformToolset=100
+          call vc10.cmd /release /xp /${{matrix.arch}}
+          
+          cd libdes
+          call mknt.bat
+
+        ##########################################################################
         # Build K95, K95G and other bits for redistribution                      #
         ##########################################################################
       - name: Full Build
         run: |         
           echo Configure Platform SDK Build Environment...
           SET PlatformToolset=100
-          REM set PATH=%PATH%;${{ github.workspace }}\vcredist
           call vc10.cmd /release /xp /${{matrix.arch}}
           
           echo Configure build environment...
@@ -390,8 +499,8 @@ jobs:
           
           echo Check outputs...
           set MISSING_BUILD_RESULTS=
-          REM ctl3dins.exe k95crypt.dll
-          for %%y in (k95.exe iksd.exe iksdsvc.exe k95d.exe rlogin.exe telnet.exe textps.exe k95g.exe  p95.dll) do (
+          REM ctl3dins.exe
+          for %%y in (k95.exe iksd.exe iksdsvc.exe k95d.exe rlogin.exe telnet.exe textps.exe k95g.exe k95crypt.dll p95.dll) do (
             if not exist dist\%%y echo Build result not found: %%y
             if not exist dist\%%y set MISSING_BUILD_RESULTS=%MISSING_BUILD_RESULTS% %%y
             if not exist dist\%%y set FAILED=yes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -372,6 +372,7 @@ jobs:
           
           echo CL:
           "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\VC\Bin\x86_IA64"\cl.exe /version
+          echo Error level: %errorlevel%
           
           echo Run Build...
           call setenv.bat

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -451,7 +451,12 @@ jobs:
           cd openssl\${{env.OPENSSL_VERSION}}
           set PATH=%PATH%;${{github.workspace}}\tools\nasm
           
-          perl Configure VC-WIN64A -D"_WIN32_WINNT=0x502"     
+          perl Configure VC-WIN64A -D"_WIN32_WINNT=0x502"
+          
+          REM The perl configure script doesn't work quite right for cross-compiling to x64
+          REM it leaves the /machine flag off the link flags, so we'll just add it on ourselves.
+          sed -i "s/^LDFLAGS=\/nologo.*/& \/machine:x64/g" makefile
+          
           nmake
 
       - name: Build openssl (x86)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -352,6 +352,12 @@ jobs:
         run: |
           wget https://ftp.zx.net.nz/pub/dev/WinSDK/win7-7.1-dn4/win7-7.1-sdk-vc.7z -outfile win7-7.1-sdk-vc.7z
           7z x win7-7.1-sdk-vc.7z
+          
+          mkdir vcredist
+          cd vcredist
+          wget https://ftp.zx.net.nz/public/tmp/vc_red.7z -outfile vc_red.7z
+          7z x vc_red.7z
+          cd ..
         shell: powershell
 
         ##########################################################################
@@ -364,6 +370,7 @@ jobs:
           
           echo Configure Platform SDK Build Environment...
           SET PlatformToolset=100
+          set PATH=%PATH%;${{ github.workspace }}\vcredist
           call vc10.cmd /release /xp /${{matrix.arch}}
           
           echo PATH: %PATH%

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -359,9 +359,8 @@ jobs:
         ##########################################################################
       - name: Full Build
         run: |
+          SET PlatformToolset=100
           call vc10.cmd /release /xp /${{matrix.arch}}
-          
-          cl.exe
           
           call setenv.bat
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -346,8 +346,9 @@ jobs:
           path: |
             ${{github.workspace}}\Microsoft SDKs 
             ${{github.workspace}}\Microsoft Visual Studio 10.0
+            ${{github.workspace}}\vc10.cmd
             ${{github.workspace}}\vcredist_x86.exe
-          key: platform-sdk-71-compiler
+          key: platform-sdk-71-compiler+sdk+redist
       - name: Get Windows 7 Platform SDK v7.1
         if: steps.cache-compiler.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -461,7 +461,7 @@ jobs:
 
       - name: Build openssl (x86)
         if: steps.cache-optional-dependencies.outputs.cache-hit != 'true' && matrix.arch == 'x86'
-        shell: powershell
+        shell: cmd
         run: |
           SET PlatformToolset=100
           call vc10.cmd /release /xp /${{matrix.arch}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -357,14 +357,14 @@ jobs:
           wget http://download.microsoft.com/download/5/B/C/5BC5DBB3-652D-4DCE-B14A-475AB85EEF6E/vcredist_x86.exe -outfile vcredist_x86.exe
         shell: powershell
 
-      - name: Install Visual C++ 2010 Redist
-        run: ${{github.workspace}}\vcredist_x86.exe /q /norestart
-
         ##########################################################################
         # Build K95, K95G and other bits for redistribution                      #
         ##########################################################################
       - name: Full Build
-        run: |         
+        run: |
+          REM install the VC Redist
+          vcredist_x86.exe /q /norestart
+          
           echo Configure Platform SDK Build Environment...
           SET PlatformToolset=100
           REM set PATH=%PATH%;${{ github.workspace }}\vcredist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -364,6 +364,7 @@ jobs:
 
       - name: Install the Visual C++ 2010 Runtime
         run: vcredist_x86.exe /q /norestart
+        shell: cmd
         working-directory: ${{ github.workspace }}
 
         ##########################################################################

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -452,10 +452,10 @@ jobs:
           set PATH=%PATH%;${{github.workspace}}\tools\nasm
           
           perl Configure VC-WIN64A -D"_WIN32_WINNT=0x502"     
-          nmake       
+          nmake
 
       - name: Build openssl (x86)
-        if: steps.cache-optional-dependencies.outputs.cache-hit != 'true' && matrix.arch == 'x64_arm'
+        if: steps.cache-optional-dependencies.outputs.cache-hit != 'true' && matrix.arch == 'x86'
         shell: powershell
         run: |
           SET PlatformToolset=100
@@ -466,7 +466,7 @@ jobs:
           set PATH=%PATH%;${{github.workspace}}\tools\nasm
           
           perl Configure VC-WIN32 -D"_WIN32_WINNT=0x502" 
-          nmake     
+          nmake
 
       - name: Build libdes
         if: steps.cache-optional-dependencies.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -386,6 +386,13 @@ jobs:
           "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\VC\Bin"\cl.exe
           echo Error level: %errorlevel%
           
+          echo Try again
+          cd "Microsoft Visual Studio 10.0\VC\Bin\"
+          dir /w
+          cl
+          echo Error level: %errorlevel%
+          cd ..\..\..
+          
           echo Run Build...
           call setenv.bat
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -346,6 +346,7 @@ jobs:
           path: |
             ${{github.workspace}}\Microsoft SDKs 
             ${{github.workspace}}\Microsoft Visual Studio 10.0
+            ${{github.workspace}}\vcredist_x86.exe
           key: platform-sdk-71-compiler
       - name: Get Windows 7 Platform SDK v7.1
         if: steps.cache-compiler.outputs.cache-hit != 'true'
@@ -353,27 +354,17 @@ jobs:
           wget https://ftp.zx.net.nz/pub/dev/WinSDK/win7-7.1-dn4/win7-7.1-sdk-vc.7z -outfile win7-7.1-sdk-vc.7z
           7z x win7-7.1-sdk-vc.7z
           
-          mkdir vcredist
-          cd vcredist
-          wget https://ftp.zx.net.nz/public/tmp/vc_red.7z -outfile vc_red.7z
-          7z x vc_red.7z
-          cd ..
-          
           wget http://download.microsoft.com/download/5/B/C/5BC5DBB3-652D-4DCE-B14A-475AB85EEF6E/vcredist_x86.exe -outfile vcredist_x86.exe
         shell: powershell
+
+      - name: Install Visual C++ 2010 Redist
+        run: ${{github.workspace}}\vcredist_x86.exe /q /norestart
 
         ##########################################################################
         # Build K95, K95G and other bits for redistribution                      #
         ##########################################################################
       - name: Full Build
-        run: |
-          echo Install redist:
-          vcredist_x86.exe /q /norestart
-          echo Error level: %errorlevel%
-          
-          echo Current working directory:
-          dir /w 
-          
+        run: |         
           echo Configure Platform SDK Build Environment...
           SET PlatformToolset=100
           REM set PATH=%PATH%;${{ github.workspace }}\vcredist
@@ -383,33 +374,10 @@ jobs:
           echo LIB: %LIB%
           echo INCLUDE: %INCLUDE%
           
-          echo IA64 CL:
-          "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\VC\Bin\x86_IA64"\cl.exe
-          echo Error level: %errorlevel%
-          
-          echo x86 CL:
-          "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\VC\Bin"\cl.exe
-          echo Error level: %errorlevel%
-          
-          echo Dir:
-          dir /w "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\VC\Bin\"
-          copy "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\Common7\IDE"\*.dll "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\VC\Bin\"
-          
-          echo x86 CL after copy:
-          "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\VC\Bin"\cl.exe
-          echo Error level: %errorlevel%
-          
-          echo Try again
-          cd "Microsoft Visual Studio 10.0\VC\Bin\"
-          REM copy ..\..\..\vcredist\*.dll
-          dir /w
-          cl
-          echo Error level: %errorlevel%
-          cd ..\..\..
-          
-          echo Run Build...
+          echo Configure build environment...
           call setenv.bat
           
+          echo Run build...
           cd kermit\p95
           call mknt.bat
           cd ..\k95

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -355,7 +355,7 @@ jobs:
           7z x win7-7.1-sdk-vc.7z
           
           wget https://ftp.zx.net.nz/pub/dev/WinSDK/win7-7.1-dn4/win7-7.1-sdk-psdk.7z -outfile win7-7.1-sdk-psdk.7z
-          7z x win7-7.1-sdk-vc.7z
+          7z x win7-7.1-sdk-psdk.7z
           
           del *.7z
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -312,6 +312,129 @@ jobs:
         if-no-files-found: error
         retention-days: 7
 
+  ##############################################################################
+  # Build with Windows 7 Platform SDK version 7.1 (Visual C++ 2010)            #
+  ##############################################################################
+  # This is the last compiler that can target Itanium. Due to its lack of C99
+  # support, builds with Visual C++ 2010 and older don't include SSH support.
+  # OpenSSL 1.1.1s is supported however.
+  Build-PSDK71:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        arch:
+          - ia64
+          #- x86
+          #- x64
+
+    steps:
+      - uses: actions/checkout@v3
+        ##########################################################################
+        # Fetch the compiler                                                     #
+        ##########################################################################
+      - name: Cache Compiler
+        uses: actions/cache@v3.0.11
+        id: cache-compiler
+        with:
+          path: |
+            ${{github.workspace}}\Microsoft SDKs 
+            ${{github.workspace}}\Microsoft Visual Studio 10.0
+          key: platform-sdk-71-compiler
+      - name: Get Windows 7 Platform SDK v7.1
+        if: steps.cache-compiler.outputs.cache-hit != 'true'
+        run: |
+          wget https://ftp.zx.net.nz/pub/dev/WinSDK/win7-7.1-dn4/win7-7.1-sdk-vc.7z -outfile win7-7.1-sdk-vc.7z
+          7z x win7-7.1-sdk-vc.7z
+        shell: powershell
+
+        ##########################################################################
+        # Build K95, K95G and other bits for redistribution                      #
+        ##########################################################################
+      - name: Full Build
+        run: |
+          call vc10.cmd /release /xp /${{matrix.arch}}
+          
+          call setenv.bat
+          
+          cd kermit\p95
+          call mknt.bat
+          cd ..\k95
+          call mk.bat
+          call mkdist.bat
+          
+          REM Check outputs
+          set MISSING_BUILD_RESULTS=
+          REM ctl3dins.exe
+          for %%y in (k95.exe iksd.exe iksdsvc.exe k95d.exe rlogin.exe telnet.exe textps.exe k95g.exe k95crypt.dll p95.dll) do (
+            if not exist dist\%%y echo Build result not found: %%y
+            if not exist dist\%%y set MISSING_BUILD_RESULTS=%MISSING_BUILD_RESULTS% %%y
+            if not exist dist\%%y set FAILED=yes
+          )
+          
+          if "%MISSING_BUILD_RESULTS%" NEQ "" echo Missing build outputs: %MISSING_BUILD_RESULTS%
+          if "%MISSING_BUILD_RESULTS%" NEQ "" echo One or more expected outputs are missing - failing build
+          if "%MISSING_BUILD_RESULTS%" NEQ "" exit /b 1
+
+        shell: cmd
+        working-directory: ${{ github.workspace }}
+        env:
+          ROOT: ${{ github.workspace }}
+      - name: Fetch CA Certs bundle
+        run: |
+          wget https://curl.se/ca/cacert.pem -outfile ca_certs.pem
+          wget https://www.mozilla.org/media/MPL/2.0/index.815ca599c9df.txt -outfile ca_certs.license
+          
+          $readme = @"
+          ca_certs.pem was exported from the Mozilla CA Certificate Store and is licensed
+          under the MPL version 2.0.
+          
+          For more information and updates, see: https://curl.se/docs/caextract.html
+          "@
+          
+          New-Item ca_certs.readme
+          Set-Content ca_certs.readme $readme
+        shell: powershell
+        working-directory: ${{ github.workspace }}\kermit\k95\dist
+
+      - name: HTMLise Markdown Docs
+        run: |
+          pip3 install markdown
+          (
+          echo ^<html^>
+          echo ^<head^>^<title^>C-Kermit for Windows SSH Readme^</title^>^</head^>
+          echo ^<body^>
+          ) > ssh-readme.html
+          (
+          echo ^<html^>
+          echo ^<head^>^<title^>C-Kermit for Windows Change-Log^</title^>^</head^>
+          echo ^<body^>
+          ) > change-log.html
+          python -m markdown -x markdown.extensions.fenced_code ${{ github.workspace }}\doc\ssh-readme.md >> ssh-readme.html
+          python -m markdown -x markdown.extensions.fenced_code ${{ github.workspace }}\doc\changes.md >> change-log.html
+          (
+          echo ^</body^>
+          echo ^</html^>
+          ) >> change-log.html
+          (
+          echo ^</body^>
+          echo ^</html^>
+          ) >> ssh-readme.html
+        shell: cmd
+        working-directory: ${{ github.workspace }}\kermit\k95\dist
+
+      - name: Prepare Artifact
+        shell: cmd
+        working-directory: ${{ github.workspace }}\kermit\k95
+        run: |
+          move dist ${{ github.workspace }}\ckwin
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3.1.1
+        with:
+          name: ckwin-vc10-${{ matrix.arch }}
+          path: ${{ github.workspace }}\ckwin
+          if-no-files-found: error
+          retention-days: 7
+
 
   ##############################################################################
   # Build with OpenWatcom 1.9 which allows targeting older versions of Windows #

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -395,6 +395,7 @@ jobs:
           
           echo Try again
           cd "Microsoft Visual Studio 10.0\VC\Bin\"
+          copy ..\..\..\vcredist\*.dll
           dir /w
           cl
           echo Error level: %errorlevel%

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -399,8 +399,8 @@ jobs:
           
           REM Check outputs
           set MISSING_BUILD_RESULTS=
-          REM ctl3dins.exe
-          for %%y in (k95.exe iksd.exe iksdsvc.exe k95d.exe rlogin.exe telnet.exe textps.exe k95g.exe k95crypt.dll p95.dll) do (
+          REM ctl3dins.exe k95crypt.dll
+          for %%y in (k95.exe iksd.exe iksdsvc.exe k95d.exe rlogin.exe telnet.exe textps.exe k95g.exe  p95.dll) do (
             if not exist dist\%%y echo Build result not found: %%y
             if not exist dist\%%y set MISSING_BUILD_RESULTS=%MISSING_BUILD_RESULTS% %%y
             if not exist dist\%%y set FAILED=yes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -362,13 +362,17 @@ jobs:
           wget http://download.microsoft.com/download/5/B/C/5BC5DBB3-652D-4DCE-B14A-475AB85EEF6E/vcredist_x86.exe -outfile vcredist_x86.exe
         shell: powershell
 
+      - name: Install the Visual C++ 2010 Runtime
+        run: vcredist_x86.exe /q /norestart
+        working-directory: ${{ github.workspace }}
+
         ##########################################################################
         # Build K95, K95G and other bits for redistribution                      #
         ##########################################################################
       - name: Full Build
         run: |
           REM install the VC Redist
-          vcredist_x86.exe /q /norestart
+          REM vcredist_x86.exe /q /norestart
           
           echo Configure Platform SDK Build Environment...
           SET PlatformToolset=100

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -372,26 +372,11 @@ jobs:
         # Build K95, K95G and other bits for redistribution                      #
         ##########################################################################
       - name: Full Build
-        run: |
-          REM install the VC Redist
-          REM vcredist_x86.exe /q /norestart
-          
+        run: |         
           echo Configure Platform SDK Build Environment...
           SET PlatformToolset=100
           REM set PATH=%PATH%;${{ github.workspace }}\vcredist
           call vc10.cmd /release /xp /${{matrix.arch}}
-          
-          echo PATH: %PATH%
-          echo LIB: %LIB%
-          echo INCLUDE: %INCLUDE%
-          
-          echo IA64 CL:
-          "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\VC\Bin\x86_IA64"\cl.exe
-          echo Error level: %errorlevel%
-          
-          echo x86 CL:
-          "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\VC\Bin"\cl.exe
-          echo Error level: %errorlevel%
           
           echo Configure build environment...
           call setenv.bat
@@ -403,7 +388,7 @@ jobs:
           call mk.bat
           call mkdist.bat
           
-          REM Check outputs
+          echo Check outputs...
           set MISSING_BUILD_RESULTS=
           REM ctl3dins.exe k95crypt.dll
           for %%y in (k95.exe iksd.exe iksdsvc.exe k95d.exe rlogin.exe telnet.exe textps.exe k95g.exe  p95.dll) do (

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -358,6 +358,8 @@ jobs:
           wget https://ftp.zx.net.nz/public/tmp/vc_red.7z -outfile vc_red.7z
           7z x vc_red.7z
           cd ..
+          
+          wget http://download.microsoft.com/download/5/B/C/5BC5DBB3-652D-4DCE-B14A-475AB85EEF6E/vcredist_x86.exe -outfile vcredist_x86.exe
         shell: powershell
 
         ##########################################################################
@@ -365,12 +367,16 @@ jobs:
         ##########################################################################
       - name: Full Build
         run: |
+          echo Install redist:
+          vcredist_x86.exe /q /norestart
+          echo Error level: %errorlevel%
+          
           echo Current working directory:
           dir /w 
           
           echo Configure Platform SDK Build Environment...
           SET PlatformToolset=100
-          set PATH=%PATH%;${{ github.workspace }}\vcredist
+          REM set PATH=%PATH%;${{ github.workspace }}\vcredist
           call vc10.cmd /release /xp /${{matrix.arch}}
           
           echo PATH: %PATH%
@@ -395,7 +401,7 @@ jobs:
           
           echo Try again
           cd "Microsoft Visual Studio 10.0\VC\Bin\"
-          copy ..\..\..\vcredist\*.dll
+          REM copy ..\..\..\vcredist\*.dll
           dir /w
           cl
           echo Error level: %errorlevel%

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -359,9 +359,14 @@ jobs:
         ##########################################################################
       - name: Full Build
         run: |
+          echo Current working directory:
+          dir /w 
+          
+          echo Configure Platform SDK Build Environment...
           SET PlatformToolset=100
           call vc10.cmd /release /xp /${{matrix.arch}}
           
+          echo Run Build...
           call setenv.bat
           
           cd kermit\p95

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -361,6 +361,8 @@ jobs:
         run: |
           call vc10.cmd /release /xp /${{matrix.arch}}
           
+          cl.exe
+          
           call setenv.bat
           
           cd kermit\p95

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,13 +33,13 @@ jobs:
       matrix:
         arch:
           - x86
-          #- x64
-          #- x64_arm
-          #- x64_arm64
+          - x64
+          - x64_arm
+          - x64_arm64
         toolset:
           - 14.0
-          #- 14.2
-          #- 14.3
+          - 14.2
+          - 14.3
         exclude:
           # No point building ARM or ARM64 targets with anything less than the latest as the latest
           # still supports the first ARM Windows.
@@ -331,8 +331,8 @@ jobs:
       matrix:
         arch:
           - ia64
-          - x86
-          - x64
+          #- x86
+          #- x64
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -374,10 +374,34 @@ jobs:
           echo LIB: %LIB%
           echo INCLUDE: %INCLUDE%
           
+          echo IA64 CL:
+          "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\VC\Bin\x86_IA64"\cl.exe
+          echo Error level: %errorlevel%
+          
+          echo x86 CL:
+          "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\VC\Bin"\cl.exe
+          echo Error level: %errorlevel%
+          
+          echo Dir:
+          dir /w "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\VC\Bin\"
+          copy "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\Common7\IDE"\*.dll "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\VC\Bin\"
+          
+          echo x86 CL after copy:
+          "D:\a\ckwin\ckwin\Microsoft Visual Studio 10.0\VC\Bin"\cl.exe
+          echo Error level: %errorlevel%
+          
+          echo Try again
+          cd "Microsoft Visual Studio 10.0\VC\Bin\"
+          REM copy ..\..\..\vcredist\*.dll
+          dir /w
+          cl
+          echo Error level: %errorlevel%
+          cd ..\..\..
+          
           echo Configure build environment...
           call setenv.bat
           
-          echo Run build...
+          echo Run Build...
           cd kermit\p95
           call mknt.bat
           cd ..\k95


### PR DESCRIPTION
This includes the Visual C++ 2010 compiler which is the last that can target Itanium and is new enough to still be supported by OpenSSL 1.1.1 (though its not new enough to be supported by libssh)