### PR TITLE
Upgrade to OpenSSL 3.0.12 and libssh 0.10.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,10 @@ env:
   # So we're now fetching zlib from ftp.zx.net.nz instead.
   ZLIB_VERSION: 1.2.13
   # Expected filename: https://www.openssl.org/source/openssl-${{env.OPENSSL_VERSION}}.tar.gz
-  OPENSSL_VERSION: 3.0.11
+  OPENSSL_VERSION: 3.0.12
   # Exoected filename: ${{env.LIBSSH_SOURCE}}libssh-${{env.LIBSSH_VERSION}}.tar.xz
   LIBSSH_SOURCE: https://www.libssh.org/files/0.10/
-  LIBSSH_VERSION: 0.10.5
+  LIBSSH_VERSION: 0.10.6
   # OpenZinc is available from http://openzinc.com/Downloads/OZ1.zip
   # But we don't want to waste the resources of the generous OpenZinc developer,
   # so we grab it from a mirror


### PR DESCRIPTION
Upgrade to the latest versions of OpenSSL 3.0 and libssh 0.10