### PR TITLE
Fix Windows XP compatibility issue with libssh

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -376,6 +376,17 @@ jobs:
         cd libssh\${{env.LIBSSH_VERSION}}\build
         cmake .. -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DOPENSSL_ROOT_DIR=${{github.workspace}}\openssl\${{env.OPENSSL_VERSION}}\ -DZLIB_ROOT:PATH=${{github.workspace}}\zlib\${{env.ZLIB_VERSION}}\ -DWITH_DSA=ON
         nmake
+        
+        if "${{env.LIBSSH_VERSION}} NEQ "0.10.6" goto :end 
+        REM Build a patched version thats compatible with Windows XP
+        mv src\ssh.dll src\ssh-standard.dll
+        cd ..
+        patch -p1 < ..\xp-fix.patch
+        cd build
+        nmake
+        mv src\ssh.dll src\ssh-xp.dll
+        mv src\ssh-standard.dll src\ssh.dll
+        :end        
 
     - name: Build GSSAPI-enabled libssh (x86/x86-64)
       if: steps.cache-optional-dependencies.outputs.cache-hit != 'true' && (matrix.arch == 'x86' || matrix.arch == 'x64')
@@ -386,6 +397,18 @@ jobs:
         cd build
         cmake .. -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DOPENSSL_ROOT_DIR=${{github.workspace}}\openssl\${{env.OPENSSL_VERSION}}\ -DZLIB_ROOT:PATH=${{github.workspace}}\zlib\${{env.ZLIB_VERSION}}\ -DWITH_DSA=ON -DGSSAPI_ROOT_DIR="${{github.workspace}}\kerberos\kfw\Kerberos"
         nmake
+        
+        if "${{env.LIBSSH_VERSION}} NEQ "0.10.6" goto :end 
+        REM Build a patched version thats compatible with Windows XP
+        mv src\ssh.dll src\ssh-standard.dll
+        cd ..
+        patch -p1 < ..\xp-fix.patch
+        cd build
+        nmake
+        mv src\ssh.dll src\ssh-xp.dll
+        mv src\ssh-standard.dll src\ssh.dll
+        :end
+
 
       # 32bit ARM doesn't get libssh as version 0.10.3 gets link errors there:
       #   misc.c.obj : error LNK2019: unresolved external symbol __imp_GetUserNameA referenced in function ssh_get_local_username
@@ -468,6 +491,14 @@ jobs:
       working-directory: ${{ github.workspace }}\kermit\k95\dist
       run: |
         copy ${{ github.workspace }}\libssh\${{env.LIBSSH_VERSION}}-gssapi\build\src\ssh.dll ssh-gssapi.dll
+
+    - name: Dist XP-patched libssh (x86/x86-64)
+      if: (matrix.arch == 'x86' || matrix.arch == 'x64') && (env.LIBSSH_VERSION == '0.10.6')
+      shell: cmd
+      working-directory: ${{ github.workspace }}\kermit\k95\dist
+      run: |
+        copy ${{ github.workspace }}\libssh\${{env.LIBSSH_VERSION}}-gssapi\build\src\ssh-xp.dll ssh-gssapi-xp.dll
+        copy ${{ github.workspace }}\libssh\${{env.LIBSSH_VERSION}}\build\src\ssh-xp.dll ssh-xp.dll
 
     - name: Fetch CA Certs bundle
       uses: actions/download-artifact@v3

--- a/libssh/build.bat
+++ b/libssh/build.bat
@@ -6,11 +6,12 @@ set CKB_LIBSSH=%1
 set CKB_OPENSSL=%2
 set CKB_ZLIB=%3
 
-set CKB_LIBSSH_ZLIB_ROOT=%root%\zlib\%CKB_ZLIB%
-if not exist %CKB_LIBSSH_ZLIB_ROOT%\zlib.h set CKB_LIBSSH_ZLIB_ROOT=%ZLIB_ROOT%
 
-set CKB_LIBSSH_OPENSSL_ROOT=%root%\openssl\%CKB_OPENSSL%
-if not exist %CKB_LIBSSH_OPENSSL_ROOT%\NUL set CKB_LIBSSH_OPENSSL_ROOT=%openssl_root%
+if "%CKB_ZLIB%" NEQ "" set CKB_LIBSSH_ZLIB_ROOT=%root%\zlib\%CKB_ZLIB%
+if "%CKB_ZLIB%" == "" set CKB_LIBSSH_ZLIB_ROOT=%ZLIB_ROOT%
+
+if "%CKB_OPENSSL%" NEQ "" set CKB_LIBSSH_OPENSSL_ROOT=%root%\openssl\%CKB_OPENSSL%
+if "%CKB_OPENSSL%" == "" set CKB_LIBSSH_OPENSSL_ROOT=%openssl_root%\
 
 if exist %CKB_OPENSSL_ZLIB_ROOT%\zlib.h set CKB_LIBSSH_ZLIB_OPT=-DZLIB_ROOT:PATH=%CKB_LIBSSH_ZLIB_ROOT%
 
@@ -18,16 +19,15 @@ echo.
 echo LibSSH Build Configuration
 echo ---------------------------
 echo LibSSH: %CKB_LIBSSH%
-echo OpenSSH: %CKB_LIBSSH_OPENSSL_ROOT%
+echo OpenSSL: %CKB_LIBSSH_OPENSSL_ROOT%
 echo zlib: %CKB_LIBSSH_ZLIB_ROOT%
 echo.
-
 pushd %root%\libssh\%CKB_LIBSSH%
 
 REM run the build!
 mkdir build
 cd build
-cmake .. -G "NMake Makefiles" -DOPENSSL_ROOT_DIR=%CKB_LIBSSH_OPENSSL_ROOT% %CKB_LIBSSH_ZLIB_OPT%
+cmake .. -G "NMake Makefiles" -DOPENSSL_ROOT_DIR=%CKB_LIBSSH_OPENSSL_ROOT% %CKB_LIBSSH_ZLIB_OPT% -DWITH_DSA=ON
 nmake
 cd ..
 
@@ -41,7 +41,7 @@ if exist %CKB_OPENSSL_ZLIB_ROOT%\zlib.h echo   set zlib_root_override=%CKB_OPENS
 echo   set openssl_root_override=%CKB_OPENSSL_ROOT_DIR%
 echo   set libssh_root_override=%%root%%\libssh\%CKB_LIBSSH%
 echo   set libssh_build_override=%%root%%\libssh\%CKB_LIBSSH%\build
-echo   cd %root%
+echo   cd %%root%%
 echo   setenv.bat
 echo alternatively, update setenv.bat and update the various root paths
 echo.

--- a/libssh/xp-fix.patch
+++ b/libssh/xp-fix.patch
@@ -1,0 +1,29 @@
+diff --git a/src/misc.c.old b/src/misc.c
+index 7081f12..cd0e225 100644
+--- a/src/misc.c.old
++++ b/src/misc.c
+@@ -221,6 +221,8 @@ int ssh_is_ipaddr_v4(const char *str)
+     return 0;
+ }
+ 
++typedef NET_IFINDEX (NETIOAPI_API_ *if_nametoindex_t)(PCSTR);
++
+ int ssh_is_ipaddr(const char *str)
+ {
+     int rc = SOCKET_ERROR;
+@@ -233,10 +235,13 @@ int ssh_is_ipaddr(const char *str)
+         struct sockaddr_storage ss;
+         int sslen = sizeof(ss);
+         char *network_interface = strchr(s, '%');
++		HINSTANCE hIPHLPAPI = LoadLibrary("IPHLPAPI"); 
++		if_nametoindex_t h_if_nametoindex = (if_nametoindex_t)GetProcAddress(hIPHLPAPI, "if_nametoindex");
++
+ 
+         /* link-local (IP:v6:addr%ifname). */
+-        if (network_interface != NULL) {
+-            rc = if_nametoindex(network_interface + 1);
++        if (network_interface != NULL && h_if_nametoindex != NULL) {
++            rc = h_if_nametoindex(network_interface + 1);
+             if (rc == 0) {
+                 free(s);
+                 return 0;


### PR DESCRIPTION
This may just be a temporary thing - I don't like patching 3rd party libraries like this.