### PR TITLE
Fix broken GHA build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,6 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1.12.0
         with:
           arch: x86
-          toolset: 14.3
       - name: Build ckwart
         run: |
           call ..\..\setenv.bat

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,7 +166,7 @@ jobs:
         toolset:
           - 14.0
           - 14.2
-          - 14.3
+          - 14.4
         exclude:
           # No point building ARM or ARM64 targets with anything less than the latest as the latest
           # still supports the first ARM Windows.


### PR DESCRIPTION
The Github runner images only contain the latest toolset now which is breaking things.