### PR TITLE
Increase max terminal dimensions

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -3,6 +3,7 @@ This document covers what has changed in each release of C-Kermit for Windows
 (formerly known as Kermit 95). For a more in-depth look at what has changed, 
 check the git commit log.
 
+
 ## C-Kermit for Windows 10.0b10 beta 6 - coming soon
 
 This is a minor release focused on upgrading from OpenSSL 1.1.1 (which is
@@ -20,7 +21,6 @@ Windows XP. See the included SSH Readme for a workaround if SSH support on
 Windows XP.
 
 ### Fixed Bugs
-
 * Fixed directory listings not reporting a size or modified time for files
   requiring more than 32 bits to store the file size on Windows NT 3.51 and
   newer. This issue will remain on NT 3.1/3.50.
@@ -44,6 +44,11 @@ Windows XP.
   in builds that *do* have SSH support
 * Fixed `show network` command showing "SSH V1 and V2 protocols" when SSH V1 is
   no longer supported in C-Kermit for Windows.
+* Fixed not being able to resize the terminal area to greater than the primary
+  display in K95G. For example, if the window was moved on to a display that
+  was taller than the primary display and maximised the bottom of the terminal
+  screen would not be correctly rendered. This fix only applies to modern
+  versions of Windows.
 
 ### Minor Enhancements and other changes
 
@@ -63,6 +68,11 @@ Windows XP.
 * Upgraded to C-Kermit 10.0 Pre-Beta.11
 * About window (Help -> About) now includes the beta number
 * Added help text for `set terminal autopage` and `set terminal autoscroll`
+* Increased the maximum number of terminal columns from 256 to 512 in K95G.
+  This should be enough to fill a 4K display at with a 10pt font or larger.
+  As this change increases memory requirements by around 1MB whether the extra
+  columns are used or not, it has only been increased in builds targeting
+  modern PCs. Vintage PCs will still be limited to 256 columns.
 
 ### New features
 

--- a/kermit/k95/ckocon.h
+++ b/kermit/k95/ckocon.h
@@ -87,7 +87,11 @@
 #endif /* min */
 
 #ifdef NT
+#ifdef KUI
+#define MAXSCRNCOL  512            /* Maximum screen columns */
+#else /* KUI */
 #define MAXSCRNCOL  256            /* Maximum screen columns */
+#endif /* KUI */
 #define MAXSCRNROW  128            /* Maximum screen rows    */
 #define MAXTERMSIZE (MAXSCRNCOL*MAXSCRNROW)
 #else /* NT */

--- a/kermit/k95/ckocon.h
+++ b/kermit/k95/ckocon.h
@@ -88,7 +88,20 @@
 
 #ifdef NT
 #ifdef KUI
+
+#if (defined(_MSC_VER) && _MSC_VER > 1400) || defined(__GNUC__)
+/*
+ * Don't increase max columns on compilers capable of targeting older versions
+ * of windows (VC++ 2005 is the last one capable of building for 9x and NT)
+ * as they could potentially be running on more resource constrained machines.
+ *
+ * This is a bit arbitrary and a bit of a hack - someday we'll allow this
+ * maximum to be changed at runtime solving this problem properly.
+ */
 #define MAXSCRNCOL  512            /* Maximum screen columns */
+#else
+#define MAXSCRNCOL  256            /* Maximum screen columns */
+#endif
 #else /* KUI */
 #define MAXSCRNCOL  256            /* Maximum screen columns */
 #endif /* KUI */

--- a/kermit/k95/kui/kclient.hxx
+++ b/kermit/k95/kui/kclient.hxx
@@ -17,7 +17,7 @@
 #include "kwin.hxx"
 #include "kscroll.hxx"
 
-const int MAXNUMCOL = 256;
+const int MAXNUMCOL = 512;
 struct _K_CLIENT_PAINT;
 struct _K_WORK_STORE;
 

--- a/kermit/k95/kui/kclient.hxx
+++ b/kermit/k95/kui/kclient.hxx
@@ -17,7 +17,12 @@
 #include "kwin.hxx"
 #include "kscroll.hxx"
 
+/* MAXNUMCOL is also defined in ckocon.h */
+#if (defined(_MSC_VER) && _MSC_VER > 1400) || defined(__GNUC__)
 const int MAXNUMCOL = 512;
+#else
+const int MAXNUMCOL = 256;
+#endif
 struct _K_CLIENT_PAINT;
 struct _K_WORK_STORE;
 

--- a/kermit/k95/kui/ksysmets.cxx
+++ b/kermit/k95/kui/ksysmets.cxx
@@ -17,8 +17,24 @@ KSysMetrics::~KSysMetrics()
 ------------------------------------------------------------------------*/
 void KSysMetrics::reset()
 {
+    /* SM_CXVIRTUALSCREEN only exists in Visual C++ 6.0 and newer */
+#ifndef SM_CXVIRTUALSCREEN
     _screenWidth = GetSystemMetrics( SM_CXSCREEN );
     _screenHeight = GetSystemMetrics( SM_CYSCREEN );
+#else
+    _screenWidth = GetSystemMetrics( SM_CXVIRTUALSCREEN );
+    _screenHeight = GetSystemMetrics( SM_CYVIRTUALSCREEN );
+    
+    /* SM_CXVIRTUALSCREEN and SM_CYVIRTUALSCREEN are new to Windows 98.
+     * So check for a sensible value and if we don't get one, fall back
+     * to using the dimensions of the primary display */
+    if (_screenWidth < 1) {
+        _screenWidth = GetSystemMetrics( SM_CXSCREEN );
+    }
+    if (_screenHeight < 1) {
+        _screenHeight = GetSystemMetrics( SM_CYSCREEN );
+    }
+#endif
 
     _vscrollWidth = GetSystemMetrics( SM_CXVSCROLL );
     _hscrollHeight = GetSystemMetrics( SM_CYHSCROLL );

--- a/kermit/k95/kui/ksysmets.cxx
+++ b/kermit/k95/kui/ksysmets.cxx
@@ -24,7 +24,7 @@ void KSysMetrics::reset()
 #else
     _screenWidth = GetSystemMetrics( SM_CXVIRTUALSCREEN );
     _screenHeight = GetSystemMetrics( SM_CYVIRTUALSCREEN );
-    
+
     /* SM_CXVIRTUALSCREEN and SM_CYVIRTUALSCREEN are new to Windows 98.
      * So check for a sensible value and if we don't get one, fall back
      * to using the dimensions of the primary display */


### PR DESCRIPTION
In K95G only, doubles max width to 512 columns and increases the max window size to be that of the virtual screen rather than the primary screen on windows versions that support this.