### PR TITLE
Exclude Console API code from K95G

### DIFF
--- a/kermit/k95/ckctel.c
+++ b/kermit/k95/ckctel.c
@@ -3529,7 +3529,15 @@ tn_debug(s) char *s;
     if (!scrninitialized[VTERM]) {
         USHORT x,y;
         checkscreenmode();
+#ifndef ONETERMUPD
         GetCurPos(&y, &x);
+#else
+        {
+            position * ppos = VscrnGetCurPos(VCMD);
+            x = ppos->x;
+            y = ppos->y;
+        };
+#endif
         SaveCmdMode(x+1,y+1);
         scrninit();
         RestoreCmdMode();

--- a/kermit/k95/ckoco2.c
+++ b/kermit/k95/ckoco2.c
@@ -3813,11 +3813,13 @@ IsCellPartOfURL( BYTE mode, USHORT row, USHORT col )
     return(retval);
 }
 
+#ifndef KUI
 /*---------------------------------------------------------------------------*/
 /* TermScrnUpd                                                               */
 /*---------------------------------------------------------------------------*/
 #define URLMINCNT 4096
 #define NEW_EXCLUSIVE 1
+
 void
 TermScrnUpd( void * threadinfo)
 {
@@ -4547,6 +4549,7 @@ TermScrnUpd( void * threadinfo)
     ckThreadEnd(threadinfo) ;
 #endif /* ONETERMUPD */
 }
+#endif /* ! KUI */
 
 #ifdef PCFONTS
 APIRET

--- a/kermit/k95/ckoco2.c
+++ b/kermit/k95/ckoco2.c
@@ -97,6 +97,7 @@ extern vtattrib attrib, cmdattrib;
 extern bool cursoron[], cursorena[],scrollflag[], scrollstatus[], flipscrnflag[] ;
 extern TID tidTermScrnUpd ;
 
+#ifndef KUI
 extern
 #ifdef NT
 HANDLE
@@ -104,6 +105,7 @@ HANDLE
 HVIO
 #endif
 VioHandle;
+#endif /* ! KUI */
 
 #ifdef OS2MOUSE
 extern int tt_mouse ;
@@ -136,6 +138,7 @@ int pwidth, pheight;            /* Physical screen width, height */
 int ttgcwsz();                  /* ckocon.c */
 int os2settitle(char *, int);   /* ckotio.c */
 
+#ifndef KUI
 /*---------------------------------------------------------------------------*/
 /* ReadCellStr                                                               */
 /*---------------------------------------------------------------------------*/
@@ -270,7 +273,9 @@ ReadCellStr( viocell * CellStr, PUSHORT Length, USHORT Row, USHORT Column )
     return VioReadCellStr( (PCH) CellStr, Length, Row, Column, VioHandle ) ;
 #endif /* NT */
 }
+#endif /* KUI */
 
+#ifndef KUI
 /*---------------------------------------------------------------------------*/
 /* WrtCellStr                                                                */
 /*---------------------------------------------------------------------------*/
@@ -487,7 +492,7 @@ WrtCellStr( viocell * CellStr, USHORT Length, USHORT Row, USHORT Column )
    return VioWrtCellStr( (PCH) CellStr, Length*sizeof(viocell), Row, Column, VioHandle ) ;
 #endif /* NT */
 }
-
+#endif /* ! KUI */
 
 
 
@@ -506,6 +511,7 @@ VscrnForceFullUpdate(void)
     os2settitle(NULL,1);                /* Force a Title update */
 }
 
+#ifndef KUI
 USHORT
 WrtCellStrDiff( viocell * CellStr, USHORT Length, USHORT Row, USHORT Column,
                 USHORT Height, USHORT Width )
@@ -591,7 +597,9 @@ WrtCellStrDiff( viocell * CellStr, USHORT Length, USHORT Row, USHORT Column,
     return rc ;
 
 }
+#endif /* ! KUI */
 
+#ifndef KUI
 /*---------------------------------------------------------------------------*/
 /* WrtNCell                                                                  */
 /*---------------------------------------------------------------------------*/
@@ -722,7 +730,9 @@ WrtNCell( viocell Cell, USHORT Times, USHORT Row, USHORT Column )
    return VioWrtNCell( (PCH) &Cell, Times, Row, Column, VioHandle ) ;
 #endif /* NT */
 }
+#endif /* ! KUI */
 
+#ifndef ONETERMUPD
 /*---------------------------------------------------------------------------*/
 /* WrtCharStrAtt                                                             */
 /*---------------------------------------------------------------------------*/
@@ -854,6 +864,7 @@ WrtCharStrAtt( PCH CharStr, USHORT Length, USHORT Row, USHORT Column,
    return VioWrtCharStrAtt( CharStr, Length, Row, Column, Attr, VioHandle ) ;
 #endif /* NT */
 }
+#endif /* ! ONETERMUPD */
 
 #ifndef KUI
 /*---------------------------------------------------------------------------*/
@@ -1265,6 +1276,7 @@ SetMode( PCK_VIDEOMODEINFO ModeData )
 }
 #endif /* KUI */
 
+#ifndef KUI
 /*---------------------------------------------------------------------------*/
 /* GetCurPos                                                                 */
 /*---------------------------------------------------------------------------*/
@@ -1294,7 +1306,9 @@ USHORT GetCurPos( PUSHORT Row, PUSHORT Column )
     return VioGetCurPos( Row, Column, VioHandle ) ;
 #endif /* NT */
 }
+#endif /* !KUI */
 
+#ifndef KUI
 /*---------------------------------------------------------------------------*/
 /* SetCurPos                                                                 */
 /*---------------------------------------------------------------------------*/
@@ -1321,7 +1335,9 @@ USHORT SetCurPos( USHORT Row, USHORT Column )
    return VioSetCurPos( Row, Column, VioHandle ) ;
 #endif /* NT */
 }
+#endif /* ! KUI */
 
+#ifndef KUI
 /*---------------------------------------------------------------------------*/
 /* GetCurType                                                                */
 /*---------------------------------------------------------------------------*/
@@ -1399,6 +1415,7 @@ USHORT SetCurType( PCK_CURSORINFO CursorData )
 #endif /* NT */
     return rc ;
 }
+#endif /* !KUI */
 
 BOOL
 IsOS2FullScreen( void )
@@ -4674,6 +4691,7 @@ os2ResetFont( void )
 /*---------------------------------------------------------------------------*/
 void
 killcursor( BYTE vmode ) {
+#ifndef KUI
     CK_CURSORINFO crsr_info;
     debug(F100,"killcursor","",0);
     if (!cursoron[vmode])                       /* It's already off */
@@ -4684,6 +4702,7 @@ killcursor( BYTE vmode ) {
     {
         cursoron[vmode] = FALSE;
     }
+#endif /* ! KUI */
 }
 
 /*---------------------------------------------------------------------------*/
@@ -4691,6 +4710,7 @@ killcursor( BYTE vmode ) {
 /*---------------------------------------------------------------------------*/
 void
 newcursor( BYTE vmode ) {
+#ifndef KUI
     CK_CURSORINFO vci;
 
     debug(F100,"newcursor","",0);
@@ -4732,6 +4752,7 @@ newcursor( BYTE vmode ) {
         cursoron[vmode] = TRUE;
         VscrnIsDirty(vmode);
     }
+#endif /* ! KUI */
 }
 
 void

--- a/kermit/k95/ckocon.c
+++ b/kermit/k95/ckocon.c
@@ -471,7 +471,9 @@ RestoreCmdMode() {
 #endif /* COMMENT */
     debug(F101,"x_rest wherex","",commandscreen.ox);
     debug(F101,"x_rest wherey","",commandscreen.oy);
+#ifndef KUI
     SetCurPos( commandscreen.oy-1, commandscreen.ox-1 ) ;
+#endif /* ! KUI */
    /* lgotoxy no longer moves */
    /* the physical cursor     */
     vmode = VCMD ;
@@ -699,10 +701,15 @@ clearcmdscreen(void) {
     viocell         cell ;
 
     ttgcwsz();
+    /* TODO: What should we do for KUI? */
+#ifndef KUI
+    /* WrtNCell does nothing useful for KUI as we don't have a console window
+     * to write to */
     cell.c = ' ' ;
     cell.a = colorcmd ;
     WrtNCell(cell, cmd_cols * (cmd_rows+1), 0, 0);
     SetCurPos( 0, 0 ) ;
+#endif /* ! KUI */
 }
 
 /*---------------------------------------------------------------------------*/
@@ -2305,6 +2312,7 @@ checkscreenmode() {
 
 void
 setcursormode() {
+#ifndef KUI
 #ifdef NT
     CK_CURSORINFO vci={88,0,8,1};
 #else
@@ -2354,12 +2362,15 @@ setcursormode() {
     vi.fs = 1;                          /* 0 = blinking, 1 = hi intensity */
     VioSetState((PVOID) &vi, VioHandle);
 #endif /* NT */
+#endif /* ! KUI */
 }
 
 void
 restorecursormode() {
+#ifndef KUI
     debug(F100,"restorecursormode","",0);
     SetCurType(&crsr_command);
+#endif /* ! KUI */
 }
 
 static void
@@ -3308,7 +3319,15 @@ conect(int async) {
 
     checkscreenmode();                  /* Initialize terminal emulator */
     setcursormode();
+#ifndef ONETERMUPD
     GetCurPos(&y, &x);                  /* Command screen cursor position */
+#else
+    {
+        position * ppos = VscrnGetCurPos(VCMD);
+        x = ppos->x;
+        y = ppos->y;
+    };
+#endif
     SaveCmdMode(x+1,y+1);               /* Remember Command screen */
     RestoreTermMode();                  /* Put up previous terminal screen */
 #ifndef KUI

--- a/kermit/k95/ckocon.h
+++ b/kermit/k95/ckocon.h
@@ -392,10 +392,14 @@ _PROTOTYP( int  scriptwrtbuf, (unsigned short) ) ;
 _PROTOTYP( void savescreen, (ascreen *,int,int) ) ;
 _PROTOTYP( int restorescreen, (ascreen *) ) ;
 _PROTOTYP( void reverserange, (SHORT, SHORT, SHORT, SHORT) ) ;
+#ifndef KUI
 _PROTOTYP( USHORT ReadCellStr, ( viocell *, PUSHORT, USHORT, USHORT ) );
+#endif
 _PROTOTYP( USHORT WrtCellStr, ( viocell *, USHORT, USHORT, USHORT ) );
 _PROTOTYP( USHORT ReadCharStr, ( viocell *, PUSHORT, USHORT, USHORT ) );
+#ifndef ONETERMUPD
 _PROTOTYP( USHORT WrtCharStrAtt, ( PCH, USHORT, USHORT, USHORT, PBYTE ) );
+#endif /* ONETERMUPD */
 _PROTOTYP( USHORT WrtNCell, ( viocell, USHORT, USHORT, USHORT ) );
 #ifndef KUI
 _PROTOTYP( USHORT GetMode, ( PCK_VIDEOMODEINFO ) );

--- a/kermit/k95/ckocon.h
+++ b/kermit/k95/ckocon.h
@@ -419,7 +419,9 @@ _PROTOTYP( USHORT VscrnWrtCharStrAtt, ( BYTE vmode, PCH CharStr, USHORT Length,
                          USHORT Row, USHORT Column, PBYTE Attr ) ) ;
 _PROTOTYP( USHORT VscrnWrtUCS2StrAtt, ( BYTE vmode, PUSHORT UCS2Str, USHORT Length,
                                         USHORT Row, USHORT Column, PBYTE Attr ) ) ;
+#ifndef KUI
 _PROTOTYP( void   TermScrnUpd, ( void * ) ) ;
+#endif /* ! KUI */
 
 _PROTOTYP( videoline * VscrnGetLineFromTop, ( BYTE, SHORT ) ) ;
 _PROTOTYP( videoline * VscrnGetLine, ( BYTE, SHORT ) ) ;

--- a/kermit/k95/ckosyn.c
+++ b/kermit/k95/ckosyn.c
@@ -72,11 +72,15 @@ UINT htimAlarm = (UINT) 0 ;
 UINT htimVscrn[VNUM] = {(UINT) 0, (UINT) 0, (UINT) 0} ;
 
 HANDLE hevVscrnTimer[VNUM] = { (HANDLE) 0, (HANDLE) 0,(HANDLE) 0 } ;
+
 HANDLE hevVscrnDirty[VNUM] = { (HANDLE) 0, (HANDLE) 0,(HANDLE) 0 } ;
 
+#ifndef KUI
 HANDLE hevVscrnUpdate[VNUM][2] = {{(HANDLE) NULL, (HANDLE) NULL},
    {(HANDLE) NULL, (HANDLE) NULL},
    {(HANDLE) NULL, (HANDLE) NULL}};
+#endif /* ! KUI */
+
 HANDLE hmuxCtrlC[4][2] = { { (HANDLE) NULL, (HANDLE) NULL },
                           { (HANDLE) NULL, (HANDLE) NULL },
                           { (HANDLE) NULL, (HANDLE) NULL },
@@ -1148,6 +1152,7 @@ CreateTermScrnUpdThreadSem( BOOL posted )
 #endif /* NT */
 }
 
+#ifndef KUI
 APIRET
 PostTermScrnUpdThreadSem( void )
 {
@@ -1160,6 +1165,7 @@ PostTermScrnUpdThreadSem( void )
     return DosPostEventSem( hevTermScrnUpdThread ) ;
 #endif /* NT */
 }
+#endif /* ! KUI */
 
 APIRET
 WaitTermScrnUpdThreadSem( ULONG timo )
@@ -1747,6 +1753,7 @@ TimeProc(
 }
 #endif /* NT */
 
+#ifndef KUI
 APIRET
 StartVscrnTimer( ULONG interval )
 {
@@ -1803,6 +1810,7 @@ StopVscrnTimer( void )
     }
     return rc;
 }
+#endif /* ! KUI */
 
 APIRET
 StartAlarmTimer( ULONG interval )
@@ -1848,6 +1856,7 @@ StopAlarmTimer( void )
 #endif /* NT */
 }
 
+#ifndef KUI
 APIRET
 CreateVscrnTimerSem( BOOL posted )
 {
@@ -1875,6 +1884,7 @@ CreateVscrnTimerSem( BOOL posted )
    }
    return 0;
 }
+#endif /* ! KUI */
 
 APIRET
 PostVscrnTimerSem( int vmode )
@@ -1926,6 +1936,7 @@ WaitAndResetVscrnTimerSem( int vmode, ULONG timo )
 #endif /* NT */
 }
 
+#ifndef KUI
 APIRET
 ResetVscrnTimerSem( int vmode )
 {
@@ -1942,6 +1953,7 @@ ResetVscrnTimerSem( int vmode )
     return semcount ;
 #endif /* NT */
 }
+#endif /* ! KUI */
 
 APIRET
 CloseVscrnTimerSem( void )
@@ -2088,6 +2100,7 @@ CloseVscrnDirtySem( void )
    return 0;
 }
 
+#ifndef KUI
 APIRET
 CreateVscrnMuxWait( int vmode )
 {
@@ -2148,6 +2161,7 @@ CloseVscrnMuxWait( int vmode )
     return rc ;
 #endif /* NT */
 }
+#endif /* ! KUI */
 
 /* Process and Thread management */
 

--- a/kermit/k95/ckosyn.h
+++ b/kermit/k95/ckosyn.h
@@ -103,7 +103,9 @@ _PROTOTYP( APIRET ResetConKbdHandlerThreadSem, (void) ) ;
 _PROTOTYP( APIRET CloseConKbdHandlerThreadSem, ( void ) ) ;
 
 _PROTOTYP( APIRET CreateTermScrnUpdThreadSem, (BOOL) ) ;
+#ifndef KUI
 _PROTOTYP( APIRET PostTermScrnUpdThreadSem, (void) ) ;
+#endif /* ! KUI */
 _PROTOTYP( APIRET WaitTermScrnUpdThreadSem, (unsigned long) ) ;
 _PROTOTYP( APIRET WaitAndResetTermScrnUpdThreadSem, (unsigned long) ) ;
 _PROTOTYP( APIRET ResetTermScrnUpdThreadSem, (void) ) ;
@@ -151,11 +153,15 @@ _PROTOTYP( APIRET WaitAndResetVscrnDirtySem, (int, unsigned long) ) ;
 _PROTOTYP( APIRET ResetVscrnDirtySem, (int) ) ;
 _PROTOTYP( APIRET CloseVscrnDirtySem, ( void ) ) ;
 
+#ifndef KUI
 _PROTOTYP( APIRET CreateVscrnTimerSem, (BOOL) ) ;
+#endif /* ! KUI */
 _PROTOTYP( APIRET PostVscrnTimerSem, (int) ) ;
 _PROTOTYP( APIRET WaitVscrnTimerSem, (int,unsigned long) ) ;
 _PROTOTYP( APIRET WaitAndResetVscrnTimerSem, (int,unsigned long) ) ;
+#ifndef KUI
 _PROTOTYP( APIRET ResetVscrnTimerSem, (int) ) ;
+#endif /* ! KUI */
 _PROTOTYP( APIRET CloseVscrnTimerSem, ( void ) ) ;
 
 _PROTOTYP( APIRET CreateKeyStrokeMutex, (BOOL) ) ;
@@ -206,12 +212,14 @@ _PROTOTYP( APIRET CloseDebugMutex, (void) ) ;
 _PROTOTYP( APIRET StartAlarmTimer, (unsigned long) ) ;
 _PROTOTYP( APIRET StopAlarmTimer, (void) ) ;
 
+#ifndef KUI
 _PROTOTYP( APIRET StartVscrnTimer, (unsigned long) ) ;
 _PROTOTYP( APIRET StopVscrnTimer, (void) ) ;
 
 _PROTOTYP( APIRET CreateVscrnMuxWait, ( int ) );
 _PROTOTYP( APIRET WaitVscrnMuxWait, ( int, unsigned long ) ) ;
 _PROTOTYP( APIRET CloseVscrnMuxWait, ( int ) ) ;
+#endif /* ! KUI */
 
 _PROTOTYP( APIRET ResetThreadPrty, (void) ) ;
 _PROTOTYP( APIRET SetThreadPrty, ( int, int ) ) ;

--- a/kermit/k95/ckotio.c
+++ b/kermit/k95/ckotio.c
@@ -485,12 +485,14 @@ int quitonbreak = FALSE ;               /* Should SIGBREAK result in Quit */
 static int nOldCP;
 static char szOldTitle[80];
 
+#ifndef KUI
 #ifdef NT
 HANDLE
 #else
 HVIO
 #endif /* NT */
 VioHandle = 0;
+#endif /* ! KUI */
 
 #ifndef NOLOCAL
 #ifndef KUI
@@ -2446,9 +2448,11 @@ syscleanup() {
 #endif /* KUI */
 #ifdef NT
     CloseSerialMutex() ;
+#ifndef KUI
     if ( !stdout )
         CloseHandle(VioHandle);
     VioHandle = 0 ;
+#endif /* ! KUI */
 #endif /* NT */
     CloseThreadMgmtMutex() ;
     debug(F100,"Close Mutexes and Semaphores done","",0);


### PR DESCRIPTION
K95G.EXE (the GUI version of K95) still includes a reasonable chunk of code for updating a text-mode console window as used by K95.EXE.

_Most_ of this code is never called so all its doing is bloating the executable size (and probably memory use). But surprisingly _ _some_ of it is actually still called. I can't imagine any of it is actually doing anything useful in the absence of a console window to work with and I suspect in most cases calling this code is unintentional. Just things missed in the port to a GUI.

In some cases I've just removed the calls, in other cases I've replaced the calls with what *should* be called, like replacing GetCurPos with VscrnGetCurPos as is done elsewhere where ONETERMUPD is defined.

The result *seems* ok, but its possible this could introduce subtle bugs. Testing required.