### PR TITLE
correct type mismatches for _beginthread calls

### DIFF
--- a/kermit/dialer/kconnect.cpp
+++ b/kermit/dialer/kconnect.cpp
@@ -3145,54 +3145,27 @@ Browse( ZIL_ICHAR * url )
             sprintf(cmdbuf,"%s %s",_config->_app_www,url);
 #ifdef WIN32
         return(system(cmdbuf));
-#else
-#ifdef __WATCOMC__
-        ZIL_UINT32 tid = _beginthread((void (*)(void *)) ExecuteBrowser,
-                                      0,
-                                      65535,
-                                      (void *)cmdbuf
-                                      ) ;
-#else
-        ZIL_UINT32 tid = _beginthread((void (* _Optlink)(void *)) ExecuteBrowser,
-                                      0,
-                                      65535, 
-                                      (void *)cmdbuf
-                                      ) ;
-#endif /* __WATCOMC__ */
-        return ((DWORD)tid != 0xffffffff);
 #endif
     }
-
-    if (browsopts[0]) {
-        s = strstr("%1",(char *)browsopts);
+    else {
+        if (browsopts[0]) {
+            s = strstr("%1",(char *)browsopts);
+            if (s)
+                *s = 's';
+            else
+                s = strstr("%s",(char *)browsopts);	
+        }
         if (s)
-            *s = 's';
+            sprintf(tmpbuf,browsopts,url);
         else
-            s = strstr("%s",(char *)browsopts);	
+            sprintf(tmpbuf,"%s %s",browsopts,url);
+        sprintf(cmdbuf,"%s %s",browser,tmpbuf);
     }
-    if (s)
-        sprintf(tmpbuf,browsopts,url);
-    else
-        sprintf(tmpbuf,"%s %s",browsopts,url);
-    sprintf(cmdbuf,"%s %s",browser,tmpbuf);
-
-    ZIL_UINT32 tid = _beginthread( 
-#ifndef WIN32
-#ifdef __WATCOMC__
-                                   (void (*)(void *))
+#ifdef WIN32
+    return (_beginthread(ExecuteBrowser, 65535, (void *)cmdbuf) != -1);
 #else
-                                   (void (* _Optlink)(void *))
-#endif /* __WATCOMC__ */
-#endif /* WIN32 */
-
-                                   ExecuteBrowser,
-#ifndef WIN32
-                            0,
-#endif /* WIN32 */
-                            65535, 
-                            (void *)url
-                            ) ;
-    return ((DWORD)tid != 0xffffffff);
+    return (_beginthread(ExecuteBrowser, 0, 65535, (void *)cmdbuf) != -1);
+#endif
 }
 
 
@@ -9340,14 +9313,7 @@ Win32ShellExecute( ZIL_ICHAR * object )
     ZIL_SCREENID frameID ;
     Information(I_GET_FRAMEID, &frameID);
     MyFrameID = frameID;
-    ZIL_UINT32 tid = _beginthread( Real_Win32ShellExecute, 
-#ifndef WIN32
-                            0,
-#endif /* WIN32 */
-                            65535, 
-                            (void *)object 
-                            ) ;
-    return ((DWORD)tid != 0xffffffff);
+    return (_beginthread( Real_Win32ShellExecute, 65535, (void *)object) != -1);
 }
 #endif /* WIN32 */
 

--- a/kermit/k95/cknalm.c
+++ b/kermit/k95/cknalm.c
@@ -93,7 +93,7 @@ ckTimerStart( UINT interval, UINT precision, LPTIMECALLBACK pTimeProc, DWORD use
    timers[i].event = event ;
    timers[i].inuse = 1 ;
 
-   if ( (HANDLE) _beginthread( TimerThread, 65536, &timers[i] ) != (HANDLE) INVALID_HANDLE_VALUE )
+   if ( (HANDLE) _beginthread( TimerThread, 65536, (void *)&timers[i] ) != (HANDLE) INVALID_HANDLE_VALUE )
       return i ;
    else
       return 0 ;

--- a/kermit/k95/ckntap.c
+++ b/kermit/k95/ckntap.c
@@ -4653,7 +4653,7 @@ cktapidisconnect( void )
 {
     int i=5;
     if ( !g_bHangingUp && !g_bClosing ) {
-        _beginthread( cktapihangup_thr, 65535, 0 );
+        _beginthread( cktapihangup_thr, 65535, NULL );
     }
     do {
         msleep(50);
@@ -4666,7 +4666,7 @@ cktapicloseasync( void )
 {
     int i=5;
     if ( !g_bClosing ) {
-        _beginthread( cktapiclose_thr, 65535, 0 );
+        _beginthread( cktapiclose_thr, 65535, NULL );
     }
     do {
         msleep(50);

--- a/kermit/k95/cknwin.c
+++ b/kermit/k95/cknwin.c
@@ -321,7 +321,7 @@ ckMainThread( void * param )
 HANDLE
 MainThreadInit( HINSTANCE hInst )
 {
-    MainThread = (HANDLE) _beginthread( ckMainThread, 65535, hInst ) ;
+    MainThread = (HANDLE) _beginthread( ckMainThread, 65535, (void *)hInst ) ;
     return(MainThread);
 }
 

--- a/kermit/k95/ckoclip.c
+++ b/kermit/k95/ckoclip.c
@@ -19,6 +19,7 @@
 #undef COMMENT
 #include <stdlib.h>
 #include <string.h>
+#include <process.h>
 
 #include "ckoclip.h"
 

--- a/kermit/k95/ckocon.c
+++ b/kermit/k95/ckocon.c
@@ -3377,7 +3377,7 @@ conect(int async) {
 #ifdef OS2ONLY
                       0,
 #endif /* OS2ONLY */
-                      65536, 0);
+                      65536, NULL);
 
     if (tt_timelimit && (now_t - start_t >= tt_timelimit))
         return(0);

--- a/kermit/k95/ckomou.c
+++ b/kermit/k95/ckomou.c
@@ -15,6 +15,7 @@ char *ckomouv = "Mouse Support 10.0, 1 Oct 2022";
 #ifdef NT
 #include <windows.h>
 #else /* NT */
+#include <process.h>
 #define INCL_WINSHELLDATA
 #define INCL_VIO
 #define INCL_MOU
@@ -448,7 +449,7 @@ extern    BYTE vmode ;
     dblclickspeed = querydblclickspeed() ;
 
         if (!tidMouse) {
-        tidMouse = _beginthread( &os2_mouseevt, 0, THRDSTKSIZ, 0 ) ;
+        tidMouse = _beginthread( &os2_mouseevt, 0, THRDSTKSIZ, NULL ) ;
         }
     }
 #endif /* NT */

--- a/kermit/k95/ckonet.c
+++ b/kermit/k95/ckonet.c
@@ -92,9 +92,9 @@ os2_netxout(char *s, int n) {
 extern char pipename[PIPENAML+1];
 #endif /* NPIPE */
 
+#include <process.h>
 #ifdef NT
 #include <windows.h>
-#include <process.h>
 #define itoa _itoa
 #else /* NT */
 #define INCL_NOPM
@@ -466,14 +466,14 @@ NetCmdGetChar( char * pch )
 
 #ifdef NT
 void
-NetCmdReadThread( HANDLE pipe )
+NetCmdReadThread( void *pipe )
 {
     int success = 1;
     CHAR c;
     DWORD io;
 
     while ( success && ttyfd != -1 ) {
-        if ( success = ReadFile(pipe, &c, 1, &io, NULL ) )
+        if ( success = ReadFile((HANDLE)pipe, &c, 1, &io, NULL ) )
         {
             NetCmdPutChar(c);
         }
@@ -481,14 +481,14 @@ NetCmdReadThread( HANDLE pipe )
 }
 #else /* NT */
 void
-NetCmdReadThread( HFILE pipe )
+NetCmdReadThread( void *pipe )
 {
     int success = 1;
     CHAR c;
     ULONG io;
 
     while ( success && ttyfd != -1 ) {
-        if ( success = !DosRead(pipe, &c, 1, &io) )
+        if ( success = !DosRead((HFILE)pipe, &c, 1, &io) )
         {
             NetCmdPutChar(c);
         }
@@ -792,7 +792,7 @@ os2_netopen(name, lcl, nett) char *name; int *lcl, nett; {
 
             ttyfd = NetBiosLSN = 0 ;
 
-            ListenThreadID = _beginthread( &NetbiosListenThread, 0, 16384, 0 );
+            ListenThreadID = _beginthread( &NetbiosListenThread, 0, 16384, NULL );
             if ( ListenThreadID == -1 ) {
                 Dos16SemWait( pListenNCB->basic_ncb.ncb_semaphore,
                               SEM_INDEFINITE_WAIT ) ;
@@ -1608,7 +1608,7 @@ os2_netopen(name, lcl, nett) char *name; int *lcl, nett; {
 #ifndef NT
                      0,
 #endif /* NT */
-                     65536, hChildStdoutRdDup );
+                     65536, (void *)hChildStdoutRdDup );
         rc = 0;
     }
 #endif /* NETCMD */

--- a/kermit/k95/ckoreg.c
+++ b/kermit/k95/ckoreg.c
@@ -773,16 +773,7 @@ Real_Win32ShellExecute( void* param )
 int
 Win32ShellExecute( char * object )
 {
-    int rc = 0;
-    DWORD tid = _beginthread( Real_Win32ShellExecute,
-#ifndef NT
-                            0,
-#endif /* NT */
-                            65535,
-                            (void *)object
-                            ) ;
-    rc = (DWORD)tid != 0xffffffff;
-    return (rc);
+    return (_beginthread(Real_Win32ShellExecute, 65535, (void *)object) != -1);
 }
 #endif /* NT */
 #endif /* BROWSER */

--- a/kermit/k95/ckothr.c
+++ b/kermit/k95/ckothr.c
@@ -9,9 +9,9 @@
 */
 
 #include "ckcdeb.h"                     /* Debug & other symbols */
+#include <process.h>
 #ifdef NT
 #include <windows.h>
-#include <process.h>
 #else /* NT */
 #define INCL_WIN
 #define INCL_VIO

--- a/kermit/k95/ckotio.c
+++ b/kermit/k95/ckotio.c
@@ -8953,14 +8953,14 @@ pclose(FILE *pipe) {
 static DWORD exitcode;
 
 void
-ttruncmd2( HANDLE pipe )
+ttruncmd2( void *pipe )
 {
     int success = 1;
     CHAR outc;
     DWORD io;
 
     while ( success && exitcode == STILL_ACTIVE ) {
-        if ( success = ReadFile( pipe, &outc, 1, &io, NULL ) )
+        if ( success = ReadFile( (HANDLE)pipe, &outc, 1, &io, NULL ) )
         {
             ttoc(outc) ;
         }
@@ -9181,7 +9181,7 @@ ttruncmd(char * cmd)
         CloseHandle(procinfo.hThread);
 
         exitcode = STILL_ACTIVE;
-        _beginthread( ttruncmd2, 65536, hChildStdoutRd );
+        _beginthread( ttruncmd2, 65536, (void *)hChildStdoutRd );
         do {
             DWORD io ;
             int  inc ;
@@ -9226,14 +9226,14 @@ ttruncmd(char * cmd)
 #define STILL_ACTIVE -1L
 static ULONG exitcode = 0;
 void
-ttruncmd2( HFILE pipe )
+ttruncmd2( void *pipe )
 {
     int success = 1;
     CHAR outc;
     ULONG io;
 
     while ( success && exitcode == STILL_ACTIVE ) {
-        if ( success = !DosRead( pipe, &outc, 1, &io ) )
+        if ( success = !DosRead( (HFILE)pipe, &outc, 1, &io ) )
         {
             ttoc(outc) ;
         }
@@ -9330,7 +9330,7 @@ ttruncmd(cmd) char *cmd; { /* Return: 0 = failure, 1 = success */
     debug(F111,"ttruncmd","PID",pid);
 
     exitcode = STILL_ACTIVE;
-    _beginthread( ttruncmd2, 0, 65536, hChildStdoutRd );
+    _beginthread( ttruncmd2, 0, 65536, (void *)hChildStdoutRd );
     do {
         ULONG io ;
         int inc ;

--- a/kermit/k95/iksdsvc.c
+++ b/kermit/k95/iksdsvc.c
@@ -475,7 +475,7 @@ IKSDStart (DWORD argc, LPTSTR *argv)
     }
 
     iksd_started = 1;
-    _beginthread(listen_thread,65536, 0);
+    _beginthread(listen_thread,65536, NULL);
 
     // Initialization complete - report running status.
     IKSDStatus.dwCurrentState       = SERVICE_RUNNING;


### PR DESCRIPTION
remove incorrect calling convention for ExecuteBrowser
it is used as thread start function and should use default calling convention