### PR TITLE
correct missing prototype for getpid function

### DIFF
--- a/kermit/k95/ckcmai.c
+++ b/kermit/k95/ckcmai.c
@@ -611,6 +611,7 @@ ACKNOWLEDGMENTS:
 #ifdef OS2ONLY
 #define INCL_VIO                        /* Needed for ckocon.h */
 #include <os2.h>
+#include <process.h>                    /* for getpid() */
 #undef COMMENT
 #endif /* OS2ONLY */
 

--- a/kermit/k95/ckuusx.c
+++ b/kermit/k95/ckuusx.c
@@ -89,9 +89,7 @@ char * tgoto (const char *, int, int);
 
 #ifdef OS2
 #include <string.h>
-#if NT
 #include <process.h>  /* for getpid() */
-#endif /* NT */
 _PROTOTYP(char * os2_gethostname, (void));
 #ifndef __WATCOMC__
 #define getpid _getpid


### PR DESCRIPTION
Use guard for OS/2 only