### PR TITLE
cleanup OS/2 build batch files

### DIFF
--- a/kermit/dialer/mkos2.bat
+++ b/kermit/dialer/mkos2.bat
@@ -5,21 +5,20 @@ REM
 REM You should have already run owsetenv.bat to at a minimum to do the
 REM following:
 REM     SET WATCOM=C:\WATCOM
-REM     SET PATH=%WATCOM%\BINW;%WATCOM%\BINNT;%PATH%
+REM     SET PATH=%WATCOM%\BINNT;%WATCOM%\BINW;%PATH%
 REM And also modified and run setenv.bat to set at least %CKINCLUDE%
 REM
 if "%CK_HAVE_ZINC_OS2%" == "no" goto :nozinc
 
-REM On windows owsetenv.bat only sets up the include and library paths for
-REM targeting 32bit Windows. So we'll temporarily replace these with with
-REM values suitable for cross-compiling OS/2 applications and restore them
-REM at the end
+REM The owsetenv.bat sets up the include paths for targeting host system.
+REM So we'll temporarily replace these with with values suitable for 
+REM cross-compiling OS/2 applications and restore them at the end
 
 set OLDINCLUDE=%INCLUDE%
 set INCLUDE=%WATCOM%\H;%WATCOM%\H\OS2;%CKINCLUDE%;%ck_zinc_include%
 
 set OLDLIB=%LIB%
-set LIB=%WATCOM%\lib386\os2\;%WATCOM%\lib386;%ck_zinc_lib%
+set LIB=%ck_zinc_lib%
 
 nmake -f k95dial.mak PLATFORM=OS2 os2
 

--- a/kermit/dialer/mkos2.cmd
+++ b/kermit/dialer/mkos2.cmd
@@ -4,7 +4,7 @@ REM
 REM You should have already run owsetenv.cmd to at a minimum to do the
 REM following:
 REM     SET WATCOM=C:\WATCOM
-REM     SET PATH=%WATCOM%\BINW;%WATCOM%\BINP;%PATH%
+REM     SET PATH=%WATCOM%\BINP;%WATCOM%\BINW;%PATH%
 REM And also modified and run setenv.cmd to add \kermit\k95 to the include path
 REM
 REM Note that OpenZinc is *required* for building the dialer. If you don't

--- a/kermit/k95/mkos2.bat
+++ b/kermit/k95/mkos2.bat
@@ -4,19 +4,15 @@ REM
 REM You should have already run owsetenv.bat to at a minimum to do the
 REM following:
 REM     SET WATCOM=C:\WATCOM
-REM     SET PATH=%WATCOM%\BINW;%WATCOM%\BINNT;%PATH%
+REM     SET PATH=%WATCOM%\BINNT;%WATCOM%\BINW;%PATH%
 REM And also modified and run setenv.bat to set at least %CKINCLUDE%
 REM
-REM On windows owsetenv.bat only sets up the include and library paths for
-REM targeting 32bit Windows. So we'll temporarily replace these with with
-REM values suitable for cross-compiling OS/2 applications and restore them
-REM at the end
+REM The owsetenv.bat sets up the include paths for targeting host system.
+REM So we'll temporarily replace these with with values suitable for 
+REM cross-compiling OS/2 applications and restore them at the end
 
 set OLDINCLUDE=%INCLUDE%
 set INCLUDE=%WATCOM%\H;%WATCOM%\H\OS2;%CKINCLUDE%
-
-set OLDLIB=%LIB%
-set LIB=%WATCOM%\lib386\os2\;%WATCOM%\lib386
 
 if not exist os2\NUL mkdir os2
 move os2\*.obj . > nul
@@ -26,7 +22,6 @@ move *.obj os2  > nul
 
 REM Restore old include and lib paths.
 set INCLUDE=%OLDINCLUDE%
-set LIB=%OLDLIB%
 
 
 REM Open Watcom 1.9s nmake clone doesn't seem to set errorlevel when the build

--- a/kermit/k95/mkos2.cmd
+++ b/kermit/k95/mkos2.cmd
@@ -4,7 +4,7 @@ REM
 REM You should have already run owsetenv.cmd to at a minimum to do the
 REM following:
 REM     SET WATCOM=C:\WATCOM
-REM     SET PATH=%WATCOM%\BINW;%WATCOM%\BINP;%PATH%
+REM     SET PATH=%WATCOM%\BINP;%WATCOM%\BINW;%PATH%
 REM And also modified and run setenv.cmd to add \kermit\k95 to the include path
 
 del ckcmai.obj ckuus5.obj

--- a/kermit/k95/mkos2d.bat
+++ b/kermit/k95/mkos2d.bat
@@ -5,19 +5,15 @@ REM
 REM You should have already run owsetenv.bat to at a minimum to do the
 REM following:
 REM     SET WATCOM=C:\WATCOM
-REM     SET PATH=%WATCOM%\BINW;%WATCOM%\BINNT;%PATH%
+REM     SET PATH=%WATCOM%\BINNT;%WATCOM%\BINW;%PATH%
 REM And also modified and run setenv.bat to set at least %CKINCLUDE%
 REM
-REM On windows owsetenv.bat only sets up the include and library paths for
-REM targeting 32bit Windows. So we'll temporarily replace these with with
-REM values suitable for cross-compiling OS/2 applications and restore them
-REM at the end
+REM The owsetenv.bat sets up the include paths for targeting host system.
+REM So we'll temporarily replace these with with values suitable for 
+REM cross-compiling OS/2 applications and restore them at the end
 
 set OLDINCLUDE=%INCLUDE%
 set INCLUDE=%WATCOM%\H;%WATCOM%\H\OS2;%CKINCLUDE%
-
-set OLDLIB=%LIB%
-set LIB=%WATCOM%\lib386\os2\;%WATCOM%\lib386
 
 if not exist os2\NUL mkdir os2
 move os2\*.obj . > nul
@@ -27,4 +23,3 @@ move *.obj os2  > nul
 
 REM Restore old include and lib paths.
 set INCLUDE=%OLDINCLUDE%
-set LIB=%OLDLIB%

--- a/kermit/k95/mkos2d.cmd
+++ b/kermit/k95/mkos2d.cmd
@@ -5,7 +5,7 @@ REM
 REM You should have already run owsetenv.cmd to at a minimum to do the
 REM following:
 REM     SET WATCOM=C:\WATCOM
-REM     SET PATH=%WATCOM%\BINW;%WATCOM%\BINP;%PATH%
+REM     SET PATH=%WATCOM%\BINP;%WATCOM%\BINW;%PATH%
 REM And also modified and run setenv.cmd to add \kermit\k95 to the include path
 
 mkdir os2


### PR DESCRIPTION
remove hardcoded library search path for OS/2
it is handled by OW linker