### PR TITLE
build: remove /noBool option for Watcom and Open Watcom

### DIFF
--- a/kermit/dialer/k95dial.mak
+++ b/kermit/dialer/k95dial.mak
@@ -31,7 +31,11 @@ WNT_CPP=cl
 WNT_LINK=link
 WNT_LIBRARIAN=lib
 
-WNT_CPP_OPTS= -c -W3 -MT -DWIN32 -DOS2 -DNT -DCKODIALER -I..\k95 -noBool
+WNT_CPP_OPTS= -c -W3 -MT -DWIN32 -DOS2 -DNT -DCKODIALER -I..\k95
+!if "$(CMP)" == "VCXX"
+# noBool option isn't supported by any WATCOM or Open Watcom compilers
+WNT_CPP_OPTS=$(WNT_CPP_OPTS) -noBool
+!endif
 !if $(MSC_VER) < 100
 # Visual C++ 2.0 or older
 WNT_CPP_OPTS=$(WNT_CPP_OPTS) -DNODIAL -DCKT_NT31

--- a/kermit/dialer/registry/registry.mak
+++ b/kermit/dialer/registry/registry.mak
@@ -30,7 +30,11 @@ WNT_CPP=cl
 WNT_LINK=link
 WNT_LIBRARIAN=lib
 
-WNT_CPP_OPTS= -c -MT -W3 -DWIN32 -DOS2 -DNT -I.\.. -J -noBool
+WNT_CPP_OPTS= -c -MT -W3 -DWIN32 -DOS2 -DNT -I.\.. -J
+!if "$(CMP)" == "VCXX"
+# noBool option isn't supported by any WATCOM or Open Watcom compilers
+WNT_CPP_OPTS=$(WNT_CPP_OPTS) -noBool
+!endif
 
 !if "$(CMP)" == "OWCL"
 # The Open Watcom 1.9 linker fails with an internal error using the normal linker options.

--- a/kermit/dialer/setup/setup.mak
+++ b/kermit/dialer/setup/setup.mak
@@ -16,7 +16,11 @@ WNT_LIBRARIAN=lib
 
 #WNT_CPP_OPTS= -c -W3 -MT -DWIN32 -DOS2 -DNT -I.\.. -noBool
 #WNT_LINK_OPTS=-align:0x1000 -subsystem:windows -entry:WinMainCRTStartup /MAP /NODEFAULTLIB:libc
-WNT_CPP_OPTS= -c -W3 -MT -DWIN32 -DOS2 -DNT -I.\.. /Zi -noBool
+WNT_CPP_OPTS= -c -W3 -MT -DWIN32 -DOS2 -DNT -I.\.. /Zi
+!if "$(CMP)" == "VCXX"
+# noBool option isn't supported by any WATCOM or Open Watcom compilers
+WNT_CPP_OPTS=$(WNT_CPP_OPTS) -noBool
+!endif
 WNT_LINK_OPTS=-align:0x1000 -subsystem:windows -entry:WinMainCRTStartup /MAP /NODEFAULTLIB:libc /Debug:full /Debugtype:cv 
 WNT_CON_LINK_OPTS=-align:0x1000 -subsystem:console -entry:mainCRTStartup 
 WNT_LIB_OPTS=/machine:i386 /subsystem:WINDOWS

--- a/kermit/k95/kui/makefile
+++ b/kermit/k95/kui/makefile
@@ -177,7 +177,10 @@ RCDEFINES = $(RCDEFINES) /dNOTOOLBAR
 
 !if ($(MSC_VER) > 102)
 # This switch is new to Visual C++ 5.0 (along with bool support) (102 == Visual C++ 4.2)
+!if "$(CMP)" == "VCXX"
+# noBool option isn't supported by any WATCOM or Open Watcom compilers
 CFLAGS = $(CFLAGS) /noBool
+!endif
 !endif
 
 # Visual C++ 7.1 - nothing required


### PR DESCRIPTION
this option is not supported by any version of Watcom or Open Watcom