### PR TITLE
fix intptr_t type on OS/2

### DIFF
--- a/kermit/k95/ckcdeb.h
+++ b/kermit/k95/ckcdeb.h
@@ -7177,13 +7177,7 @@ _PROTOTYP( int readtext, (char *, char *, int));
 #ifdef OS2
 _PROTOTYP(int ck_auth_loaddll, (VOID));
 _PROTOTYP(int ck_auth_unloaddll, (VOID));
-#endif /* OS2 */
 
-#ifdef NT
-_PROTOTYP(DWORD ckGetLongPathname,(LPCSTR lpFileName, 
-                                   LPSTR lpBuffer, DWORD cchBuffer));
-_PROTOTYP(DWORD ckGetShortPathName,(LPCSTR lpszLongPath,
-                                    LPSTR lpszShortPath, DWORD cchBuffer));
 #ifndef CK_HAVE_INTPTR_T
 /* Any windows compiler too old to support this will be 32-bits (or less) */
 #ifndef _INTPTR_T_DEFINED
@@ -7192,6 +7186,13 @@ typedef int intptr_t;
 typedef unsigned long DWORD_PTR;
 #define CK_HAVE_INTPTR_T
 #endif /* CK_HAVE_INTPTR_T */
+#endif /* OS2 */
+
+#ifdef NT
+_PROTOTYP(DWORD ckGetLongPathname,(LPCSTR lpFileName, 
+                                   LPSTR lpBuffer, DWORD cchBuffer));
+_PROTOTYP(DWORD ckGetShortPathName,(LPCSTR lpszLongPath,
+                                    LPSTR lpszShortPath, DWORD cchBuffer));
 #endif /* NT */
 
 /*


### PR DESCRIPTION
intprt_t type is used not only on Windows but also on OS/2 etc. it duplicit intptr_t definition for OS/2 (Open Watcom 2.0)