### PR TITLE
correct use of _System calling convention

### DIFF
--- a/kermit/k95/ckonssh.c
+++ b/kermit/k95/ckonssh.c
@@ -402,7 +402,7 @@ int parse_displayname(char *displayname, int *familyp, char **hostp,
  * this DLL provides.
  * @param params SSH initialisation parameters from Kermit 95
  */
-int _System ssh_dll_init(ssh_init_parameters_t *params) {
+int CKSSHAPI ssh_dll_init(ssh_init_parameters_t *params) {
     p_get_current_terminal_dimensions = params->p_get_current_terminal_dimensions;
     p_get_current_terminal_type = params->p_get_current_terminal_type;
     p_ssh_get_uid = params->p_ssh_get_uid;
@@ -483,7 +483,7 @@ int _System ssh_dll_init(ssh_init_parameters_t *params) {
 #undef free
 #undef strdup
 
-static void
+void
 fatal(char *msg) {
     if (!msg) msg = "";
 

--- a/kermit/k95/ckop.c
+++ b/kermit/k95/ckop.c
@@ -37,7 +37,10 @@
 
 #include "p_type.h"
 #include "p.h"
+#ifdef XYZ_DLL
+#define XYZ_DLL_CLIENT
 #include "ckop.h"
+#endif /* XYZ_DLL */
 #include "p_global.h"
 #include "p_callbk.h"
 #include "p_common.h"
@@ -47,8 +50,7 @@ extern int rpackets, spackets, spktl, rpktl, what ;
 #ifdef XYZ_DLL
 #ifdef OS2
 static HMODULE dll_handle;
-typedef U32 (_System * p_transfer_t)(P_CFG *);
-p_transfer_t p_transfer = NULL;
+p_transfer_func *p_transfer = NULL;
 #endif /* OS2 */
 
 #define PINBUFSIZE 8192
@@ -71,7 +73,7 @@ load_p_dll(void) {
         debug(F101,"load_p_dll - Unable to load module: rc","",rc);
         return rc;
     }
-    p_transfer = (p_transfer_t)GetProcAddress( dll_handle, "p_transfer" ) ;
+    p_transfer = (p_transfer_func *)GetProcAddress( dll_handle, "p_transfer" ) ;
     if ( !p_transfer )
     {
         rc = GetLastError() ;
@@ -118,13 +120,15 @@ unload_p_dll(void) {
 #endif /* XYZ_DLL */
 
 
-U32 _System
+U32
+CKDEVAPI
 pushback_func( U8 * buf, U32 len )
 {
     return le_puts( buf, len );
 }
 
-U32 _System
+U32
+CKDEVAPI
 in_func( U8 * buf, U32 len, U32 * bytes_received )
 {
     extern int network, carrier;
@@ -172,7 +176,8 @@ in_func( U8 * buf, U32 len, U32 * bytes_received )
     return(ERROR_NO_DATA); /* Either no data was received or timeout */
 }
 
-U32 _System
+U32
+CKDEVAPI
 out_func( U8 * buf, U32 len, U32 * bytes_written )
 {
     int rc = 0 ;
@@ -205,7 +210,8 @@ USHORT DosDevIOCtl32(PVOID pData, USHORT cbData, PVOID pParms, USHORT cbParms,
                      USHORT usFunction, USHORT usCategory, HFILE hDevice);
 #endif /* OS2ONLY */
 
-U32 _System
+U32
+CKDEVAPI
 break_func( U8 on )
 {
    extern int ttmdm ;
@@ -245,7 +251,8 @@ break_func( U8 on )
     return 0;
 }
 
-U32 _System
+U32
+CKDEVAPI
 available_func( U32 * available )
 {
     int rc = ttchk() ;

--- a/kermit/k95/ckop.h
+++ b/kermit/k95/ckop.h
@@ -3,10 +3,25 @@
 /*        You may modify, recompile and distribute this file freely.         */
 /*****************************************************************************/
 
+#ifdef NT
+#define CKDEVDLLENTRY
+#else /* NT */
+#ifdef OS2
+#define CKDEVDLLENTRY	_System
+#else /* OS2 */
+#define CKDEVDLLENTRY
+#endif /* OS2 */
+#endif /* NT */
+
+typedef U32 CKDEVDLLENTRY p_transfer_func(P_CFG *);
 #ifdef XYZ_DLL
-extern U32 (_System * p_transfer)(P_CFG *);
+#ifdef XYZ_DLL_CLIENT
+extern p_transfer_func * p_transfer;
+#else /* XYZ_DLL_CLIENT */
+extern p_transfer_func p_transfer;
+#endif /* XYZ_DLL_CLIENT */
 #else /* XYZ_DLL */
-U32 _System p_transfer(P_CFG *);
+extern p_transfer_func p_transfer;
 #endif /* XYZ_DLL */
 extern int load_p_dll(void);
 extern int unload_p_dll(void);

--- a/kermit/k95/ckossh.c
+++ b/kermit/k95/ckossh.c
@@ -199,52 +199,52 @@ SOCKET ssh_open_socket(char* host, char* port) {
 
 /* Typedefs for all the function pointers we *could* receive from an SSH
  * subsystem DLL */
-typedef int (_System * p_ssh_dll_init_t)(ssh_init_parameters_t *);
-typedef int (_System * p_ssh_set_iparam_t)(int, int);
-typedef int (_System * p_ssh_get_iparam_t)(int);
-typedef int (_System * p_ssh_set_sparam_t)(int, const char*);
-typedef const char* (_System * p_ssh_get_sparam_t)(int);
-typedef int (_System * p_ssh_set_identity_files_t)(const char**);
-typedef int (_System * p_ssh_get_socket_t)();
-typedef int (_System * p_ssh_open_t)();
-typedef int (_System * p_ssh_clos_t)();
-typedef int (_System * p_ssh_tchk_t)();
-typedef int (_System * p_ssh_flui_t)();
-typedef int (_System * p_ssh_break_t)();
-typedef int (_System * p_ssh_inc_t)(int);
-typedef int (_System * p_ssh_xin_t)(int, char*);
-typedef int (_System * p_ssh_toc_t)(int);
-typedef int (_System * p_ssh_tol_t)(char*,int);
-typedef int (_System * p_ssh_snaws_t)();
-typedef const char* (_System * p_ssh_proto_ver_t)();
-typedef const char* (_System * p_ssh_impl_ver_t)();
-typedef int (_System * p_sshkey_create_t)(char *, int, char *, int, char *);
-typedef int (_System * p_sshkey_display_fingerprint_t)(char *, int);
-typedef int (_System * p_sshkey_display_public_t)(char *, char *);
-typedef int (_System * p_sshkey_display_public_as_ssh2_t)(char *,char *);
-typedef int (_System * p_sshkey_change_passphrase_t)(char *, char *, char *);
-typedef int (_System * p_ssh_fwd_remote_port_t)(char*, int, char *, int, BOOL);
-typedef int (_System * p_ssh_fwd_local_port_t)(char*, int,char *,int, BOOL);
-typedef int (_System * p_ssh_fwd_clear_local_ports_t)(BOOL);
-typedef int (_System * p_ssh_fwd_clear_remote_ports_t)(BOOL);
-typedef int (_System * p_ssh_fwd_remove_remote_port_t)(int, BOOL);
-typedef int (_System * p_ssh_fwd_remove_local_port_t)(int, BOOL);
-typedef ssh_port_forward_t* (_System * p_ssh_fwd_get_ports_t)();
+typedef int (CKSSHAPI * p_ssh_dll_init_t)(ssh_init_parameters_t *);
+typedef int (CKSSHAPI * p_ssh_set_iparam_t)(int, int);
+typedef int (CKSSHAPI * p_ssh_get_iparam_t)(int);
+typedef int (CKSSHAPI * p_ssh_set_sparam_t)(int, const char*);
+typedef const char* (CKSSHAPI * p_ssh_get_sparam_t)(int);
+typedef int (CKSSHAPI * p_ssh_set_identity_files_t)(const char**);
+typedef int (CKSSHAPI * p_ssh_get_socket_t)();
+typedef int (CKSSHAPI * p_ssh_open_t)();
+typedef int (CKSSHAPI * p_ssh_clos_t)();
+typedef int (CKSSHAPI * p_ssh_tchk_t)();
+typedef int (CKSSHAPI * p_ssh_flui_t)();
+typedef int (CKSSHAPI * p_ssh_break_t)();
+typedef int (CKSSHAPI * p_ssh_inc_t)(int);
+typedef int (CKSSHAPI * p_ssh_xin_t)(int, char*);
+typedef int (CKSSHAPI * p_ssh_toc_t)(int);
+typedef int (CKSSHAPI * p_ssh_tol_t)(char*,int);
+typedef int (CKSSHAPI * p_ssh_snaws_t)();
+typedef const char* (CKSSHAPI * p_ssh_proto_ver_t)();
+typedef const char* (CKSSHAPI * p_ssh_impl_ver_t)();
+typedef int (CKSSHAPI * p_sshkey_create_t)(char *, int, char *, int, char *);
+typedef int (CKSSHAPI * p_sshkey_display_fingerprint_t)(char *, int);
+typedef int (CKSSHAPI * p_sshkey_display_public_t)(char *, char *);
+typedef int (CKSSHAPI * p_sshkey_display_public_as_ssh2_t)(char *,char *);
+typedef int (CKSSHAPI * p_sshkey_change_passphrase_t)(char *, char *, char *);
+typedef int (CKSSHAPI * p_ssh_fwd_remote_port_t)(char*, int, char *, int, BOOL);
+typedef int (CKSSHAPI * p_ssh_fwd_local_port_t)(char*, int,char *,int, BOOL);
+typedef int (CKSSHAPI * p_ssh_fwd_clear_local_ports_t)(BOOL);
+typedef int (CKSSHAPI * p_ssh_fwd_clear_remote_ports_t)(BOOL);
+typedef int (CKSSHAPI * p_ssh_fwd_remove_remote_port_t)(int, BOOL);
+typedef int (CKSSHAPI * p_ssh_fwd_remove_local_port_t)(int, BOOL);
+typedef ssh_port_forward_t* (CKSSHAPI * p_ssh_fwd_get_ports_t)();
 #ifdef SSHTEST
-typedef int (_System * p_sshkey_v1_change_comment_t)(char *, char *, char *);
+typedef int (CKSSHAPI * p_sshkey_v1_change_comment_t)(char *, char *, char *);
 #endif /* SSHTEST */
 /*typedef char * (*p_sshkey_default_file_t)(int);*/
-typedef void (_System * p_ssh_v2_rekey_t)();
-typedef int (_System * p_ssh_agent_delete_file_t)(const char *);
-typedef int (_System * p_ssh_agent_delete_all_t)();
-typedef int (_System * p_ssh_agent_add_file_t)(const char*);
-typedef int (_System * p_ssh_agent_list_identities_t)(int);
-typedef void (_System * p_ssh_unload_t)();
-typedef const char* (_System * p_ssh_dll_ver_t)();
-typedef ktab_ret (_System * p_ssh_get_keytab_t)(int keytab_id);
-typedef int (_System * p_ssh_feature_supported_t)(int feature_id);
-typedef const char** (_System *p_ssh_get_set_help_t)();
-typedef const char** (_System *p_ssh_get_help_t)();
+typedef void (CKSSHAPI * p_ssh_v2_rekey_t)();
+typedef int (CKSSHAPI * p_ssh_agent_delete_file_t)(const char *);
+typedef int (CKSSHAPI * p_ssh_agent_delete_all_t)();
+typedef int (CKSSHAPI * p_ssh_agent_add_file_t)(const char*);
+typedef int (CKSSHAPI * p_ssh_agent_list_identities_t)(int);
+typedef void (CKSSHAPI * p_ssh_unload_t)();
+typedef const char* (CKSSHAPI * p_ssh_dll_ver_t)();
+typedef ktab_ret (CKSSHAPI * p_ssh_get_keytab_t)(int keytab_id);
+typedef int (CKSSHAPI * p_ssh_feature_supported_t)(int feature_id);
+typedef const char** (CKSSHAPI *p_ssh_get_set_help_t)();
+typedef const char** (CKSSHAPI *p_ssh_get_help_t)();
 
 /* Function pointers received from the currently loaded SSH subsystem DLL */
 static p_ssh_dll_init_t p_ssh_init = NULL;

--- a/kermit/k95/ckossh.h
+++ b/kermit/k95/ckossh.h
@@ -1,6 +1,16 @@
 #ifndef _CKOSSH_H
 #define _CKOSSH_H
 
+#ifdef NT
+#define CKSSHAPI
+#else /* NT */
+#ifdef OS2
+#define CKSSHAPI	_System
+#else /* OS2 */
+#define CKSSHAPI
+#endif /* OS2 */
+#endif /* NT */
+
 #ifndef SSH_PF_T
 #define SSH_PF_T
 /* Note: This also exists in ckolsshs.h */
@@ -198,12 +208,6 @@ _PROTOTYP(int ssh_feature_supported,(int feature_id));
 _PROTOTYP(void ssh_initialise,(void));
 #endif
 
-#ifdef NT
-#ifndef _System
-#define _System
-#endif /* _System */
-#endif /* NT */
-
 #ifndef SOCKET
 /* On OS/2, SOCKET is just int. */
 #define SOCKET int
@@ -217,34 +221,34 @@ typedef struct  {
 
     /* Version 1 */
     int version;
-    void (* _System p_install_funcs)(const char*, const void*);
-    void (* _System p_get_current_terminal_dimensions)(int* rows, int* cols);
-    const char* (* _System p_get_current_terminal_type)();
-    const char* (* _System p_ssh_get_uid)();
-    const char* (* _System p_ssh_get_pw)();
-    int (* _System p_ssh_get_nodelay_enabled)();
-    SOCKET (* _System p_ssh_open_socket)(char* host, char* port);
-    int (* _System p_dodebug)(int,char *,char *,CK_OFF_T);
-    int (* _System p_vscrnprintf)(const char *, ...);
-    int (* _System p_uq_txt)(char *,char *,int,char **,char *,int,char *,int);
-    int (* _System p_uq_mtxt) (char *,char **,int,struct txtbox[]);
-    int (* _System p_uq_ok)(char *,char *,int,char **,int);
-    int (* _System p_uq_file)(char *,char *,int,char **,char *,char *,int);
-	int (* _System p_zmkdir)(char *);
-	int (* _System p_ckmakxmsg)(char * buf, int len, char *s1, char *s2, char *s3,
+    void (* CKSSHAPI p_install_funcs)(const char*, const void*);
+    void (* CKSSHAPI p_get_current_terminal_dimensions)(int* rows, int* cols);
+    const char* (* CKSSHAPI p_get_current_terminal_type)();
+    const char* (* CKSSHAPI p_ssh_get_uid)();
+    const char* (* CKSSHAPI p_ssh_get_pw)();
+    int (* CKSSHAPI p_ssh_get_nodelay_enabled)();
+    SOCKET (* CKSSHAPI p_ssh_open_socket)(char* host, char* port);
+    int (* CKSSHAPI p_dodebug)(int,char *,char *,CK_OFF_T);
+    int (* CKSSHAPI p_vscrnprintf)(const char *, ...);
+    int (* CKSSHAPI p_uq_txt)(char *,char *,int,char **,char *,int,char *,int);
+    int (* CKSSHAPI p_uq_mtxt) (char *,char **,int,struct txtbox[]);
+    int (* CKSSHAPI p_uq_ok)(char *,char *,int,char **,int);
+    int (* CKSSHAPI p_uq_file)(char *,char *,int,char **,char *,char *,int);
+	int (* CKSSHAPI p_zmkdir)(char *);
+	int (* CKSSHAPI p_ckmakxmsg)(char * buf, int len, char *s1, char *s2, char *s3,
             char *s4, char *s5, char *s6, char *s7, char *s8, char *s9,
             char *s10, char *s11, char *s12);
-	char* (* _System p_whoami)();
-    char* (* _System p_GetAppData)(int);
-	char* (* _System p_GetHomePath)();
-	char* (* _System p_GetHomeDrive)();
-    int (* _System p_ckstrncpy)(char * dest, const char * src, int len);
-    int (* _System p_debug_logging)();
+	char* (* CKSSHAPI p_whoami)();
+    char* (* CKSSHAPI p_GetAppData)(int);
+	char* (* CKSSHAPI p_GetHomePath)();
+	char* (* CKSSHAPI p_GetHomeDrive)();
+    int (* CKSSHAPI p_ckstrncpy)(char * dest, const char * src, int len);
+    int (* CKSSHAPI p_debug_logging)();
 
     /* Returns a statically allocated string containing the currently
      * configured X11 display
      */
-    unsigned char* (* _System p_get_display)();
+    unsigned char* (* CKSSHAPI p_get_display)();
 
     /* Utility function for parsing the display name. Result is returned
      * via:
@@ -254,7 +258,7 @@ typedef struct  {
      *   *scrnump   - Screen number
      *   **restp    - Anything else at the end
      */
-    int (* _System p_parse_displayname)(char *displayname, int *familyp,
+    int (* CKSSHAPI p_parse_displayname)(char *displayname, int *familyp,
             char **hostp, int *dpynump, int *scrnump, char **restp);
 } ssh_init_parameters_t;
 

--- a/kermit/k95/p.h
+++ b/kermit/k95/p.h
@@ -33,10 +33,20 @@
 #include "p_type.h"             /* U32, U16, U8, etc typedefs */
 
 #ifdef __EMX__
-#define _System                 /* EMX/GCC doesn't have _System */
-#endif
+#define CKDEVAPI
+#else /* __EMX__ */
 #ifdef NT
-#define _System         /* Neither does Win32 */
+#define CKDEVAPI
+#else /* NT */
+#ifdef OS2
+#define CKDEVAPI	_System
+#else /* OS2 */
+#define CKDEVAPI
+#endif /* OS2 */
+#endif /* NT */
+#endif /* __EMX__ */
+
+#ifdef NT
 #define _Inline __inline
 #define APIRET DWORD
 #else
@@ -44,6 +54,7 @@
 #define _Inline inline
 #endif /* __WATCOMC__ */
 #endif /* NT */
+
 /******************/
 /* Protocol types */
 /******************/
@@ -1038,7 +1049,7 @@ typedef struct _P_CFG {
    functions.
 */
 
-  U32 (_System * status_func)(U32, ...);
+  U32 (CKDEVAPI * status_func)(U32, ...);
 /*
    This function is called to inform the calling program about
    progress of file transfer.
@@ -1056,7 +1067,7 @@ typedef struct _P_CFG {
         the comments in PS_* defines above.
 */
 
-  U32 (_System * r_open_func)(U8 **,
+  U32 (CKDEVAPI * r_open_func)(U8 **,
                                 U32,
                                 U32,
                                 U32,
@@ -1142,7 +1153,7 @@ typedef struct _P_CFG {
         the offset where at the sender should start sending the file.
 */
 
-  U32 (_System * s_open_func)(U8 **,
+  U32 (CKDEVAPI * s_open_func)(U8 **,
                                 U32 *,
                                 U32 *,
                                 U32 *,
@@ -1211,7 +1222,7 @@ typedef struct _P_CFG {
 
 */
 
-  U32 (_System * close_func)(U8 **,
+  U32 (CKDEVAPI * close_func)(U8 **,
                                U32,
                                U32,
                                U32,
@@ -1259,7 +1270,7 @@ typedef struct _P_CFG {
         transfer.
 
 */
-  U32 (_System * seek_func)(U32);
+  U32 (CKDEVAPI * seek_func)(U32);
 /*
    This function is called when we are starting to send a file with Zmodem
    protocol and the remote indicates that it already has a part of that
@@ -1274,7 +1285,7 @@ typedef struct _P_CFG {
         from, rather than from the beginning of the file.
 */
 
-  U32 (_System * read_func)(U8 *,
+  U32 (CKDEVAPI * read_func)(U8 *,
                               U32,
                               U32 *);
   /*
@@ -1300,7 +1311,7 @@ typedef struct _P_CFG {
         transmission error).
 */
 
-  U32 (_System * write_func)(U8 *,
+  U32 (CKDEVAPI * write_func)(U8 *,
                                U32);
 /*
    This function is called when we have received data to be written to the
@@ -1317,7 +1328,7 @@ typedef struct _P_CFG {
         The number of bytes to write from buf.
 */
 
-  U32 (_System * exe_in_func)(U8 *,
+  U32 (CKDEVAPI * exe_in_func)(U8 *,
                               U32,
                               U32 *);
   /*
@@ -1343,7 +1354,7 @@ typedef struct _P_CFG {
         transmission error).
 */
 
-  U32 (_System * exe_out_func)(U8 *,
+  U32 (CKDEVAPI * exe_out_func)(U8 *,
                                U32, U32 *);
 /*
    This function is called when we have data to send to the host.
@@ -1362,7 +1373,7 @@ typedef struct _P_CFG {
 
         Returns number of bytes actually written.
 */
-  U32 (_System * exe_break_func)(U8);
+  U32 (CKDEVAPI * exe_break_func)(U8);
 
 /*
    This function is called to manipulate the Break Signal
@@ -1374,7 +1385,7 @@ typedef struct _P_CFG {
        0 for Off; 1 for On.
 */
 
-  U32 (_System * exe_available_func)(U32 *);
+  U32 (CKDEVAPI * exe_available_func)(U32 *);
 /*
   This function is called to check the number of available bytes
 
@@ -1392,7 +1403,7 @@ typedef struct _P_CFG {
     /* 0 or 1 depending on whether that character position is to be  */
     /* prefixed.                                                     */
 
-    U32 (_System * exe_pushback_func)(U8 *, U32);
+    U32 (CKDEVAPI * exe_pushback_func)(U8 *, U32);
     /*
     This function is called to push back the unused bytes left over
     at the end of the transfer.
@@ -1409,12 +1420,5 @@ typedef struct _P_CFG {
 } P_CFG;
 
 #pragma pack()                  /* Back to default alignment */
-
-/*
-   Prototype for p_transfer() function. Commented because one might want to
-   use DosLoadLibrary instead of import library.
-
-   extern U32 _System p_transfer(P_CFG *);
-*/
 
 #endif /* _P_H_ */

--- a/kermit/k95/p_callbk.c
+++ b/kermit/k95/p_callbk.c
@@ -148,7 +148,7 @@ U8 *z_frame_end[] = {
 static char errbuf[512];
 
 /*
- * TODO: Definition in p.h is: U32 (* _System status_func)(U32, ...);
+ * TODO: Definition in p.h is: U32 (* CKDEVAPI status_func)(U32, ...);
  *       This results in a type mismatch error over in ckop.c:
  *          ckop.c(534): Warning! W102: Type mismatch (warning)
  *          ckop.c(534): Note! I2003: source conversion type is 'unsigned long (*)(unsigned long __p1,int __p2,unsigned long __p3,unsigned long __p4,unsigned long __p5,int __p6)'
@@ -157,7 +157,8 @@ static char errbuf[512];
  *       That might also make dealing with arg4 and arg0 which might not always
  *       need to be an intptr_t (they were just U32s before the 64bit port)
  */
-U32 _System
+U32
+CKDEVAPI
 status_func(U32 type, ...)
 {
     va_list args;

--- a/kermit/k95/p_callbk.h
+++ b/kermit/k95/p_callbk.h
@@ -31,18 +31,18 @@
  * when we pretend it isn't. This breaks compatibility with K&R C compilers,
  * but in practice we *never* use a K&R C compiler to target Win32 or OS/2. I'm
  * not even sure there exists a compatible K&R C compiler for these platforms. */
-/*_PROTOTYP( U32 _System status_func, (U32, intptr_t, U32, U32, U32, intptr_t));*/
-U32 _System status_func(U32, ...);
+/*_PROTOTYP( U32 CKDEVAPI status_func, (U32, intptr_t, U32, U32, U32, intptr_t));*/
+U32 CKDEVAPI status_func(U32, ...);
 
-_PROTOTYP( U32 _System s_open_func, (U8 **, U32 *, U32 *, U32 *,
+_PROTOTYP( U32 CKDEVAPI s_open_func, (U8 **, U32 *, U32 *, U32 *,
                        U32 *, U32 *,
                        U8 *, U8 *, U8 *));
-_PROTOTYP( U32 _System r_open_func, (U8 **, U32, U32, U32,
+_PROTOTYP( U32 CKDEVAPI r_open_func, (U8 **, U32, U32, U32,
                        U32, U32,
                        U8, U8, U8,
                        U32 *));
-_PROTOTYP( U32 _System close_func, (U8 **, U32, U32, U32, BOOLEAN, U32));
-_PROTOTYP( U32 _System seek_func, (U32));
-_PROTOTYP( U32 _System read_func, (U8 *, U32, U32 *));
-_PROTOTYP( U32 _System write_func, (U8 *, U32));
+_PROTOTYP( U32 CKDEVAPI close_func, (U8 **, U32, U32, U32, BOOLEAN, U32));
+_PROTOTYP( U32 CKDEVAPI seek_func, (U32));
+_PROTOTYP( U32 CKDEVAPI read_func, (U8 *, U32, U32 *));
+_PROTOTYP( U32 CKDEVAPI write_func, (U8 *, U32));
 

--- a/kermit/k95/p_type.h
+++ b/kermit/k95/p_type.h
@@ -81,10 +81,6 @@ typedef long APIRET ;
 #endif /* VOID */
 #endif /* OS2 */
 
-#ifndef OS2
-#define _System
-#endif /* OS2 */
-
 #ifndef _PROTOTYP
 #ifdef CK_ANSIC
 #define _PROTOTYP( func, parms ) func parms

--- a/kermit/p95/pdll_main.c
+++ b/kermit/p95/pdll_main.c
@@ -52,6 +52,7 @@
 #include "pdll_x_global.h"
 #include "pdll_z.h"
 #include "pdll_z_global.h"
+#include "ckop.h"
 
 jmp_buf p_jmp_buf;
 
@@ -82,7 +83,8 @@ cleanup()
     }
 }
 
-U32 _System 
+U32
+CKDEVDLLENTRY
 #ifdef CK_ANSIC
 p_transfer(P_CFG *param_p_cfg) 
 #else


### PR DESCRIPTION
now appropriate macros with calling convention is used
no manipulation with _System calling convention which is incorrect (OS API use it in header files)
it enable define calling convention consistently
Anyway I think that CKDEVAPI can be any fixed calling convention by example cdecl for better interoperatibility
_System is not required.
if CKDEVAPI is blank then compiler default calling convention is used therefore you cannot combine DLL build by one compiler with Kermit build by another one, it depend on default calling convention.
simply 
`
#define CKDEVAPI cdecl
`
ensure interoperability, all compilers will use cdecl calling convention.
