### PR TITLE
build: cleanup build make and batch files

### DIFF
--- a/kermit/k95/mkdist.bat
+++ b/kermit/k95/mkdist.bat
@@ -22,14 +22,14 @@ if not exist dist\users\NUL mkdir dist\users
 
 @echo Move build outputs...
 move *.exe dist
-move *.pdb dist
+if exist *.pdb move *.pdb dist
 if exist dist\nullssh.pdb delete dist\nullssh.pdb
-move k95ssh*.dll dist
+if exist k95ssh*.dll move k95ssh*.dll dist
 if exist k95crypt.dll move k95crypt.dll dist
 copy *.manifest dist
 copy iksd.ksc dist\iksd.ksc.sample
 ren dist\cknker.exe k95.exe
-ren dist\cknker.pdb k95.pdb
+if exist dist\cknker.pdb ren dist\cknker.pdb k95.pdb
 ren dist\cknker.exe.manifest k95.exe.manifest
 if exist dist\cknker.exe.manifest del dist\cknker.exe.manifest
 REM del dist\ctl3dins.exe   -- this can trip up virus scanners but its required by the dialer

--- a/kermit/k95/mkg.bat
+++ b/kermit/k95/mkg.bat
@@ -17,8 +17,8 @@ cd ..
 REM UNSET NODEBUG
 SET OUTDIR=.\kui\win95%SUFFIX%
 SET K95BUILD=K95
-move kui\win95%SUFFIX%\ck*.obj . > nul
-move kui\win95%SUFFIX%\p_*.obj . > nul
+if exist kui\win95%SUFFIX%\ck*.obj move kui\win95%SUFFIX%\ck*.obj . > nul
+if exist kui\win95%SUFFIX%\p_*.obj move kui\win95%SUFFIX%\p_*.obj . > nul
 if exist ckcmai.obj del ckcmai.obj
 if exist ckuus5.obj del ckuus5.obj
 %MAKE% /nologo /e /f ckoker.mak k95g

--- a/kermit/k95/mkiksd.bat
+++ b/kermit/k95/mkiksd.bat
@@ -1,7 +1,7 @@
 SET PLATFORM=NT
 SET K95BUILD=IKSD
 if not exist iksd\NUL mkdir iksd
-move iksd\*.obj . > nul
+if exist iksd\*.obj move iksd\*.obj . > nul
 if exist ckcmai.obj del ckcmai.obj
 if exist ckuus5.obj del ckuus5.obj
 nmake /nologo /e /f ckoker.mak msvc-iksd

--- a/kermit/k95/mkkui.bat
+++ b/kermit/k95/mkkui.bat
@@ -8,8 +8,8 @@ cd kui
 nmake /e
 cd ..
 SET OUTDIR=.\kui\win95
-move kui\win95\ck*.obj . > nul
-move kui\win95\p_*.obj . > nul
+if exist kui\win95\ck*.obj move kui\win95\ck*.obj . > nul
+if exist  kui\win95\p_*.obj move kui\win95\p_*.obj . > nul
 nmake /nologo /e /f ckoker.mak kuid 
 move *.obj kui\win95 > nul
 

--- a/kermit/k95/mknt.bat
+++ b/kermit/k95/mknt.bat
@@ -11,7 +11,7 @@ SET PLATFORM=NT
 SET K95BUILD=K95
 set OUTDIR=nt%SUFFIX%
 if not exist %OUTDIR%\NUL mkdir %OUTDIR%
-move %OUTDIR%\*.obj . > nul
+if exist %OUTDIR%\*.obj move %OUTDIR%\*.obj . > nul
 if exist ckcmai.obj del ckcmai.obj
 if exist ckuus5.obj del ckuus5.obj
 %MAKE% /nologo /e /f ckoker.mak msvc

--- a/kermit/k95/mkntd.bat
+++ b/kermit/k95/mkntd.bat
@@ -1,7 +1,7 @@
 SET PLATFORM=NT
 SET K95BUILD=K95
 if not exist ntd\NUL mkdir ntd
-move ntd\*.obj . > nul
+if exist ntd\*.obj move ntd\*.obj . > nul
 if exist ckcmai.obj del ckcmai.obj
 if exist ckuus5.obj del ckuus5.obj
 nmake /nologo /e /f ckoker.mak msvcd

--- a/kermit/k95/mkos2.bat
+++ b/kermit/k95/mkos2.bat
@@ -17,7 +17,7 @@ set INCLUDE=%CKINCLUDE%;%WATCOM%\H;%WATCOM%\H\OS2;
 echo %INCLUDE%
 
 if not exist os2\NUL mkdir os2
-move os2\*.obj . > nul
+if exist os2\*.obj move os2\*.obj . > nul
 if exist ckcmai.obj del ckcmai.obj
 if exist ckuus5.obj del ckuus5.obj
 nmake /nologo /f ckoker.mak PLATFORM=OS2 wcos2

--- a/kermit/k95/mkos2d.bat
+++ b/kermit/k95/mkos2d.bat
@@ -16,7 +16,7 @@ set OLDINCLUDE=%INCLUDE%
 set INCLUDE=%WATCOM%\H;%WATCOM%\H\OS2;%CKINCLUDE%
 
 if not exist os2\NUL mkdir os2
-move os2\*.obj . > nul
+if exist os2\*.obj move os2\*.obj . > nul
 if exist ckcmai.obj del ckcmai.obj
 if exist ckuus5.obj del ckuus5.obj
 nmake /nologo /f ckoker.mak PLATFORM=OS2 wcos2d

--- a/kermit/k95/mkos2d.cmd
+++ b/kermit/k95/mkos2d.cmd
@@ -9,7 +9,8 @@ REM     SET PATH=%WATCOM%\BINP;%WATCOM%\BINW;%PATH%
 REM And also modified and run setenv.cmd to add \kermit\k95 to the include path
 
 mkdir os2
-move os2\*.obj . > nul
-del ckcmai.obj ckuus5.obj
+if exist os2\*.obj move os2\*.obj . > nul
+if exist ckcmai.obj del ckcmai.obj
+if exist ckuus5.obj del ckuus5.obj
 wmake -h -ms -f ckoker.mak PLATFORM=OS2 MAKE="wmake -h -ms" wcos2d
 move *.obj os2  > nul

--- a/kermit/k95/mksshdll.bat
+++ b/kermit/k95/mksshdll.bat
@@ -11,9 +11,8 @@ SET PLATFORM=NT
 SET K95BUILD=K95
 set OUTDIR=nt%SUFFIX%
 if not exist %OUTDIR%\NUL mkdir %OUTDIR%
-move %OUTDIR%\*.obj . > nul
+if exist %OUTDIR%\*.obj move %OUTDIR%\*.obj . > nul
 %MAKE% /nologo /e /f ckoker.mak msvc-sshdll
-del ckolssh.obj ckolsshs.obj
 if exist ckolssh.obj del ckolssh.obj
 if exist ckolsshs.obj del ckolsshs.obj
 move *.obj %OUTDIR%  > nul


### PR DESCRIPTION
all *.pdb must be handled conditionaly because Open Watcom doesn't use it also if subdirectory is created conditionaly then files in this subdirectory must be processed conditionaly all deletes must be also conditionaly handled