### PR TITLE
build: remove message about missing wcc386 if Open Watcom is not inst…

### DIFF
--- a/kermit/k95/compiler_detect.mak
+++ b/kermit/k95/compiler_detect.mak
@@ -26,7 +26,7 @@ ISJOM=yes
 CMP = VCXX
 COMPILER = Visual C++
 
-!IF ([wcc386 . <nul 2>&1 > nul] == 0)
+!IF ([wcc386 . <nul >nul 2>&1] == 0)
 # Open Watcom
 CMP = OWCL
 COMPILER = Open Watcom C/C++ CL clone

--- a/setenv.bat
+++ b/setenv.bat
@@ -105,7 +105,7 @@ REM This should match the %PROCESSOR_ARCHITECTURE% on the target machine
 set CKB_TARGET_ARCH=x86
 
 set CKB_OPENSSL_SUFFIX=
-wcc386 . <nul 2>&1 > nul
+wcc386 . <nul >nul 2>&1
 if %errorlevel% == 0 goto :bitcheckdone
 
 cl 2>&1 | findstr /C:"for x64" > nul
@@ -574,7 +574,7 @@ set CKB_NT_COMPATIBLE=no
 set CKB_XP_COMPATIBLE=no
 set CKB_OS2_COMPATIBLE=no
 
-wcc386 . <nul 2>&1 > nul
+wcc386 . <nul >nul 2>&1
 if %errorlevel% == 0 goto :watcomc
 cl 2>&1 | findstr /C:"Version 19.4" > nul
 if %errorlevel% == 0 goto :vc144

--- a/setenv.cmd
+++ b/setenv.cmd
@@ -16,7 +16,7 @@ REM CKB_IBMTCP20=yes
 REM ================== No changes required beyond this point ===================
 
 set ZINCBUILD=
-wcc386 . <nul 2>&1 > nul
+wcc386 . <nul >nul 2>&1
 if not %errorlevel% == 0 goto :unsupported
 wcc386 . <nul 2>&1 | findstr /C:"Version 1.9" > nul
 if %errorlevel% == 0 set ZINCBUILD=ow19


### PR DESCRIPTION
…alled

it looks like first must be stdout redirection then stderr redirection to stdout