### PR TITLE
fix issues with calling convention in Kermit SSH DLL

### DIFF
--- a/kermit/k95/ckoker.mak
+++ b/kermit/k95/ckoker.mak
@@ -1387,7 +1387,7 @@ nullssh.dll: ckonssh.obj ckoker.mak
 !else
 !if "$(CMP)" == "OWWCL"
     $(CC) $(CC2) $(DEBUG) $(DLL) ckonssh.obj $(OUT)$@ \
-	    $(LINKFLAGS_DLL) $(LIBS) -"export ssh_dll_init"
+	    $(LINKFLAGS_DLL) $(LIBS) -"export ssh_dll_init=_ssh_dll_init"
 !endif
 !endif
 

--- a/kermit/k95/ckolssh.c
+++ b/kermit/k95/ckolssh.c
@@ -553,62 +553,58 @@ HANDLE hSSHClientThread = NULL;   /* SSH subsystem thread */
 
 #ifdef SSH_DLL
 
-void ssh_initialise();
-
-static void (*p_get_current_terminal_dimensions)(int* rows, int* cols) = NULL;
-const char* (*p_get_current_terminal_type)() = NULL;
-const char* (*p_ssh_get_uid)();
-const char* (*p_ssh_get_pw)();
-int (*p_ssh_get_nodelay_enabled)();
-SOCKET (*p_ssh_open_socket)(char* host, char* port);
-static int (*p_dodebug)(int,char *,char *,CK_OFF_T)=NULL;
-static int (*p_vscrnprintf)(const char *, ...)=NULL;
-static int (*p_uq_txt)(char *,char *,int,char **,char *,int,char *,int) = NULL;
-static int (*p_uq_mtxt) (char *,char **,int,struct txtbox[]) = NULL;
-int (*p_uq_ok)(char *,char *,int,char **,int) = NULL;
-int (*p_uq_file)(char *,char *,int,char **,char *,char *,int) = NULL;
-int (*p_zmkdir)(char *) = NULL;
-int (*p_ckmakxmsg)(char * buf, int len, char *s1, char *s2, char *s3,
-        char *s4, char *s5, char *s6, char *s7, char *s8, char *s9,
-        char *s10, char *s11, char *s12) = NULL;
-char* (*p_whoami)() = NULL;
-char* (*p_GetAppData)(int common) = NULL;
-char* (*p_GetHomePath)() = NULL;
-char* (*p_GetHomeDrive)() = NULL;
-int (*p_ckstrncpy)(char * dest, const char * src, int len) = NULL;
-int (*p_debug_logging)() = NULL;
-unsigned char* (*p_get_display)() = NULL;
-int (*p_parse_displayname)(char *displayname, int *familyp, char **hostp,
-                        int *dpynump, int *scrnump, char **restp) = NULL;
+/* define callback function pointers */
+static get_current_terminal_dimensions_callback *callbackp_get_current_terminal_dimensions = NULL;
+static get_current_terminal_type_callback   *callbackp_get_current_terminal_type = NULL;
+static ssh_get_uid_callback                 *callbackp_ssh_get_uid = NULL;
+static ssh_get_pw_callback                  *callbackp_ssh_get_pw = NULL;
+static ssh_get_nodelay_enabled_callback     *callbackp_ssh_get_nodelay_enabled = NULL;
+static ssh_open_socket_callback             *callbackp_ssh_open_socket = NULL;
+static dodebug_callback                     *callbackp_dodebug = NULL;
+static vscrnprintf_callback                 *callbackp_vscrnprintf = NULL;
+static uq_txt_callback                      *callbackp_uq_txt = NULL;
+static uq_mtxt_callback                     *callbackp_uq_mtxt = NULL;
+static uq_ok_callback                       *callbackp_uq_ok = NULL;
+static uq_file_callback                     *callbackp_uq_file = NULL;
+static zmkdir_callback                      *callbackp_zmkdir = NULL;
+static ckmakxmsg_callback                   *callbackp_ckmakxmsg = NULL;
+static whoami_callback                      *callbackp_whoami = NULL;
+static GetAppData_callback                  *callbackp_GetAppData = NULL;
+static GetHomePath_callback                 *callbackp_GetHomePath = NULL;
+static GetHomeDrive_callback                *callbackp_GetHomeDrive = NULL;
+static ckstrncpy_callback                   *callbackp_ckstrncpy = NULL;
+static debug_logging_callback               *callbackp_debug_logging = NULL;
+static get_display_callback                 *callbackp_get_display = NULL;
+static parse_displayname_callback           *callbackp_parse_displayname = NULL;
 
 void get_current_terminal_dimensions(int* rows, int* cols) {
-    p_get_current_terminal_dimensions(rows, cols);
+    callbackp_get_current_terminal_dimensions(rows, cols);
 }
 
-const char* get_current_terminal_type() {
-    return p_get_current_terminal_type();
+const char* get_current_terminal_type(void) {
+    return callbackp_get_current_terminal_type();
 }
 
-const char* ssh_get_uid() {
-    return p_ssh_get_uid();
+const char* ssh_get_uid(void) {
+    return callbackp_ssh_get_uid();
 }
 
-const char* ssh_get_pw() {
-    return p_ssh_get_pw();
+const char* ssh_get_pw(void) {
+    return callbackp_ssh_get_pw();
 }
 
-int ssh_get_nodelay_enabled() {
-    return p_ssh_get_nodelay_enabled();
+int ssh_get_nodelay_enabled(void) {
+    return callbackp_ssh_get_nodelay_enabled();
 }
 
 SOCKET ssh_open_socket(char* host, char* port) {
-    return p_ssh_open_socket(host, port);
+    return callbackp_ssh_open_socket(host, port);
 }
 
 int dodebug(int flag, char * s1, char * s2, CK_OFF_T n)
 {
-    if ( p_dodebug )
-        return(p_dodebug(flag,s1,s2,n));
+    if ( callbackp_dodebug )
+        return(callbackp_dodebug(flag,s1,s2,n));
     else
         return(-1);
 }
@@ -627,78 +623,352 @@ int Vscrnprintf(const char * format, ...) {
 #endif /* NT */
     va_end(ap);
 
-    if ( p_vscrnprintf )
-        return(p_vscrnprintf(myprtfstr));
+    if ( callbackp_vscrnprintf )
+        return(callbackp_vscrnprintf(myprtfstr));
     else
         return(-1);
 }
 
 int uq_txt(char * preface, char * prompt, int echo, char ** help, char * buf,
        int buflen, char *dflt, int timer) {
-    return p_uq_txt(preface, prompt, echo, help, buf, buflen, dflt, timer);
+    return callbackp_uq_txt(preface, prompt, echo, help, buf, buflen, dflt, timer);
 }
 
 int uq_mtxt(char * preface,char **help, int n, struct txtbox field[]) {
-    return p_uq_mtxt(preface, help, n, field);
+    return callbackp_uq_mtxt(preface, help, n, field);
 }
 
 int uq_ok(char * preface, char * prompt, int mask,char ** help, int dflt) {
-    return p_uq_ok(preface, prompt, mask, help, dflt);
+    return callbackp_uq_ok(preface, prompt, mask, help, dflt);
 }
 
 int uq_file(char * preface, char * fprompt, int fc, char ** help,
 	char * dflt, char * result, int rlength) {
-    return p_uq_file(preface, fprompt, fc, help, dflt, result, rlength);
+    return callbackp_uq_file(preface, fprompt, fc, help, dflt, result, rlength);
 }
 
-
 int zmkdir(char *path) {
-    return p_zmkdir(path);
+    return callbackp_zmkdir(path);
 }
 
 int ckmakxmsg(char * buf, int len, char *s1, char *s2, char *s3,
         char *s4, char *s5, char *s6, char *s7, char *s8, char *s9,
         char *s10, char *s11, char *s12) {
-    return p_ckmakxmsg(buf, len, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11,
+    return callbackp_ckmakxmsg(buf, len, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11,
                        s12);
 }
 
-#define ckmakmsg(buf,len,s1,s2,s3,s4) ckmakxmsg(buf, len, s1, s2, s3, s4, \
-            NULL, NULL,NULL, NULL, NULL, NULL, NULL, NULL)
-
-char* whoami() {
-    return p_whoami();
+char* whoami(void) {
+    return callbackp_whoami();
 }
 
 char* GetAppData(int common) {
-    return p_GetAppData(common);
+    return callbackp_GetAppData(common);
 }
 
-char* GetHomePath() {
-    return p_GetHomePath();
+char* GetHomePath(void) {
+    return callbackp_GetHomePath();
 }
 
-char* GetHomeDrive() {
-    return p_GetHomeDrive();
+char* GetHomeDrive(void) {
+    return callbackp_GetHomeDrive();
 }
 
 int ckstrncpy(char * dest, const char * src, int len) {
-    return p_ckstrncpy(dest, src, len);
+    return callbackp_ckstrncpy(dest, src, len);
 }
 
-int debug_logging() {
-    return p_debug_logging();
+int debug_logging(void) {
+    return callbackp_debug_logging();
 }
 
-unsigned char* get_display() {
-    return p_get_display();
+unsigned char* get_display(void) {
+    return callbackp_get_display();
 }
 
 int parse_displayname(char *displayname, int *familyp, char **hostp,
                         int *dpynump, int *scrnump, char **restp) {
-    return p_parse_displayname(displayname, familyp, hostp,
+    return callbackp_parse_displayname(displayname, familyp, hostp,
                                dpynump, scrnump, restp);
 }
+
+#ifdef SSH_DLL_CALLCONV
+
+/* define prototypes for DLL functions */
+static ssh_set_iparam_dllfunc               dllfunc_ssh_set_iparam;
+static ssh_get_iparam_dllfunc               dllfunc_ssh_get_iparam;
+static ssh_set_sparam_dllfunc               dllfunc_ssh_set_sparam;
+static ssh_get_sparam_dllfunc               dllfunc_ssh_get_sparam;
+static ssh_set_identity_files_dllfunc       dllfunc_ssh_set_identity_files;
+static ssh_get_socket_dllfunc               dllfunc_ssh_get_socket;
+static ssh_open_dllfunc                     dllfunc_ssh_open;
+static ssh_clos_dllfunc                     dllfunc_ssh_clos;
+static ssh_tchk_dllfunc                     dllfunc_ssh_tchk;
+static ssh_flui_dllfunc                     dllfunc_ssh_flui;
+static ssh_break_dllfunc                    dllfunc_ssh_break;
+static ssh_inc_dllfunc                      dllfunc_ssh_inc;
+static ssh_xin_dllfunc                      dllfunc_ssh_xin;
+static ssh_toc_dllfunc                      dllfunc_ssh_toc;
+static ssh_tol_dllfunc                      dllfunc_ssh_tol;
+static ssh_snaws_dllfunc                    dllfunc_ssh_snaws;
+static ssh_proto_ver_dllfunc                dllfunc_ssh_proto_ver;
+static ssh_impl_ver_dllfunc                 dllfunc_ssh_impl_ver;
+static sshkey_create_dllfunc                dllfunc_sshkey_create;
+static sshkey_display_fingerprint_dllfunc   dllfunc_sshkey_display_fingerprint;
+static sshkey_display_public_dllfunc        dllfunc_sshkey_display_public;
+static sshkey_display_public_as_ssh2_dllfunc dllfunc_sshkey_display_public_as_ssh2;
+static sshkey_change_passphrase_dllfunc     dllfunc_sshkey_change_passphrase;
+static ssh_fwd_remote_port_dllfunc          dllfunc_ssh_fwd_remote_port;
+static ssh_fwd_local_port_dllfunc           dllfunc_ssh_fwd_local_port;
+static ssh_fwd_clear_remote_ports_dllfunc   dllfunc_ssh_fwd_clear_remote_ports;
+static ssh_fwd_clear_local_ports_dllfunc    dllfunc_ssh_fwd_clear_local_ports;
+static ssh_fwd_remove_remote_port_dllfunc   dllfunc_ssh_fwd_remove_remote_port;
+static ssh_fwd_remove_local_port_dllfunc    dllfunc_ssh_fwd_remove_local_port;
+static ssh_fwd_get_ports_dllfunc            dllfunc_ssh_fwd_get_ports;
+static sshkey_v1_change_comment_dllfunc     dllfunc_sshkey_v1_change_comment;
+static sshkey_default_file_dllfunc          dllfunc_sshkey_default_file;
+static ssh_v2_rekey_dllfunc                 dllfunc_ssh_v2_rekey;
+static ssh_agent_delete_file_dllfunc        dllfunc_ssh_agent_delete_file;
+static ssh_agent_delete_all_dllfunc         dllfunc_ssh_agent_delete_all;
+static ssh_agent_add_file_dllfunc           dllfunc_ssh_agent_add_file;
+static ssh_agent_list_identities_dllfunc    dllfunc_ssh_agent_list_identities;
+static ssh_unload_dllfunc                   dllfunc_ssh_unload;
+static ssh_dll_ver_dllfunc                  dllfunc_ssh_dll_ver;
+static ssh_get_keytab_dllfunc               dllfunc_ssh_get_keytab;
+static ssh_feature_supported_dllfunc        dllfunc_ssh_feature_supported;
+static ssh_get_set_help_dllfunc             dllfunc_ssh_get_set_help;
+static ssh_get_help_dllfunc                 dllfunc_ssh_get_help;
+
+/* calling convention layer for DLL functions on DLL side */
+static int CKSSHAPI dllfunc_ssh_set_iparam(int param, int value) {
+    return ssh_set_iparam(param, value);
+}
+
+static int CKSSHAPI dllfunc_ssh_get_iparam(int param) {
+    return ssh_get_iparam(param);
+}
+
+static int CKSSHAPI dllfunc_ssh_set_sparam(int param, const char* value) {
+    return ssh_set_sparam(param, value);
+}
+
+static const char* CKSSHAPI dllfunc_ssh_get_sparam(int param) {
+    return ssh_get_sparam(param);
+}
+
+static int CKSSHAPI dllfunc_ssh_set_identity_files(const char** identity_files) {
+    return ssh_set_identity_files(identity_files);
+}
+
+static int CKSSHAPI dllfunc_ssh_get_socket(void) {
+    return ssh_get_socket();
+}
+
+static int CKSSHAPI dllfunc_ssh_open(void) {
+    return ssh_open();
+}
+
+static int CKSSHAPI dllfunc_ssh_clos(void) {
+    return ssh_clos();
+}
+
+static int CKSSHAPI dllfunc_ssh_tchk(void) {
+    return ssh_tchk();
+}
+
+static int CKSSHAPI dllfunc_ssh_flui(void) {
+    return ssh_flui();
+}
+
+static int CKSSHAPI dllfunc_ssh_break(void) {
+    return ssh_break();
+}
+
+static int CKSSHAPI dllfunc_ssh_inc(int timeout) {
+    return ssh_inc(timeout);
+}
+
+static int CKSSHAPI dllfunc_ssh_xin(int count, char * buffer) {
+    return ssh_xin(count, buffer);
+}
+
+static int CKSSHAPI dllfunc_ssh_toc(int c) {
+    return ssh_toc(c);
+}
+
+static int CKSSHAPI dllfunc_ssh_tol(char * buffer, int count) {
+    return ssh_tol(buffer, count);
+}
+
+static int CKSSHAPI dllfunc_ssh_snaws(void) {
+    return ssh_snaws();
+}
+
+static const char * CKSSHAPI dllfunc_ssh_proto_ver(void) {
+    return ssh_proto_ver();
+}
+
+static const char * CKSSHAPI dllfunc_ssh_impl_ver(void) {
+    return ssh_impl_ver();
+}
+
+static int CKSSHAPI dllfunc_sshkey_create(char * filename, int bits, char * pp,
+                             int type, char * cmd_comment) {
+    return sshkey_create(filename, bits, pp, type, cmd_comment);
+}
+
+static int CKSSHAPI dllfunc_sshkey_display_fingerprint(char * filename, int babble) {
+    return sshkey_display_fingerprint(filename, babble);
+}
+
+static int CKSSHAPI dllfunc_sshkey_display_public(char * filename, char *identity_passphrase) {
+    return sshkey_display_public(filename, identity_passphrase);
+}
+
+static int CKSSHAPI dllfunc_sshkey_display_public_as_ssh2(char * filename,char *identity_passphrase) {
+    return sshkey_display_public_as_ssh2(filename, identity_passphrase);
+}
+
+static int CKSSHAPI dllfunc_sshkey_change_passphrase(char * filename, char * oldpp, char * newpp) {
+    return sshkey_change_passphrase(filename, oldpp, newpp);
+}
+
+static int CKSSHAPI dllfunc_ssh_fwd_remote_port(char* address, int port, char * host, int host_port, BOOL apply) {
+    return ssh_fwd_remote_port(address, port, host, host_port, apply);
+}
+
+static int CKSSHAPI dllfunc_ssh_fwd_local_port(char* address, int port,char * host, int host_port, BOOL apply) {
+    return ssh_fwd_local_port(address, port, host, host_port, apply);
+}
+
+static int CKSSHAPI dllfunc_ssh_fwd_clear_remote_ports(BOOL apply) {
+    return ssh_fwd_clear_remote_ports(apply);
+}
+
+static int CKSSHAPI dllfunc_ssh_fwd_clear_local_ports(BOOL apply) {
+    return ssh_fwd_clear_local_ports(apply);
+}
+
+static int CKSSHAPI dllfunc_ssh_fwd_remove_remote_port(int port, BOOL apply) {
+    return ssh_fwd_remove_remote_port(port, apply);
+}
+
+static int CKSSHAPI dllfunc_ssh_fwd_remove_local_port(int port, BOOL apply) {
+    return ssh_fwd_remove_local_port(port, apply);
+}
+
+static const ssh_port_forward_t* CKSSHAPI dllfunc_ssh_fwd_get_ports(void) {
+    return ssh_fwd_get_ports();
+}
+
+#ifdef SSHTEST
+static int CKSSHAPI dllfunc_sshkey_v1_change_comment(char * filename, char * comment, char * pp) {
+    return sshkey_v1_change_comment(filename, comment, pp);
+}
+#endif /* SSHTEST */
+
+#ifdef COMMENT
+static char * CKSSHAPI dllfunc_sshkey_default_file(int a) {
+    return sshkey_default_file(a);
+}
+#endif /* COMMENT */
+
+static void CKSSHAPI dllfunc_ssh_v2_rekey(void) {
+    ssh_v2_rekey();
+}
+
+static int CKSSHAPI dllfunc_ssh_agent_delete_file(const char *filename) {
+    return ssh_agent_delete_file(filename);
+}
+
+static int CKSSHAPI dllfunc_ssh_agent_delete_all(void) {
+    return ssh_agent_delete_all();
+}
+
+static int CKSSHAPI dllfunc_ssh_agent_add_file(const char *filename) {
+    return ssh_agent_add_file(filename);
+}
+
+static int CKSSHAPI dllfunc_ssh_agent_list_identities(int do_fp) {
+    return ssh_agent_list_identities(do_fp);
+}
+
+static void CKSSHAPI dllfunc_ssh_unload(void) {
+    ssh_unload();
+}
+
+static const char * CKSSHAPI dllfunc_ssh_dll_ver(void) {
+    return ssh_dll_ver();
+}
+
+static ktab_ret CKSSHAPI dllfunc_ssh_get_keytab(int keytab_id) {
+    return ssh_get_keytab(keytab_id);
+}
+
+static int CKSSHAPI dllfunc_ssh_feature_supported(int feature_id) {
+    return ssh_feature_supported(feature_id);
+}
+
+static const char ** CKSSHAPI dllfunc_ssh_get_set_help(void) {
+    return ssh_get_set_help();
+}
+
+static const char ** CKSSHAPI dllfunc_ssh_get_help(void) {
+    return ssh_get_help();
+}
+
+#else /* SSH_DLL_CALLCONV */
+
+/* directly use DLL functions without calling convention layer */
+#define dllfunc_ssh_set_iparam              ssh_set_iparam
+#define dllfunc_ssh_get_iparam              ssh_get_iparam
+#define dllfunc_ssh_set_sparam              ssh_set_sparam
+#define dllfunc_ssh_get_sparam              ssh_get_sparam
+#define dllfunc_ssh_set_identity_files      ssh_set_identity_files
+#define dllfunc_ssh_get_socket              ssh_get_socket
+#define dllfunc_ssh_open                    ssh_open
+#define dllfunc_ssh_clos                    ssh_clos
+#define dllfunc_ssh_tchk                    ssh_tchk
+#define dllfunc_ssh_flui                    ssh_flui
+#define dllfunc_ssh_break                   ssh_break
+#define dllfunc_ssh_inc                     ssh_inc
+#define dllfunc_ssh_xin                     ssh_xin
+#define dllfunc_ssh_toc                     ssh_toc
+#define dllfunc_ssh_tol                     ssh_tol
+#define dllfunc_ssh_snaws                   ssh_snaws
+#define dllfunc_ssh_proto_ver               ssh_proto_ver
+#define dllfunc_ssh_impl_ver                ssh_impl_ver
+#define dllfunc_sshkey_create               sshkey_create
+#define dllfunc_sshkey_display_fingerprint  sshkey_display_fingerprint
+#define dllfunc_sshkey_display_public       sshkey_display_public
+#define dllfunc_sshkey_display_public_as_ssh2 sshkey_display_public_as_ssh2
+#define dllfunc_sshkey_change_passphrase    sshkey_change_passphrase
+#define dllfunc_ssh_fwd_remote_port         ssh_fwd_remote_port
+#define dllfunc_ssh_fwd_local_port          ssh_fwd_local_port
+#define dllfunc_ssh_fwd_clear_remote_ports  ssh_fwd_clear_remote_ports
+#define dllfunc_ssh_fwd_clear_local_ports   ssh_fwd_clear_local_ports
+#define dllfunc_ssh_fwd_remove_remote_port  ssh_fwd_remove_remote_port
+#define dllfunc_ssh_fwd_remove_local_port   ssh_fwd_remove_local_port
+#define dllfunc_ssh_fwd_get_ports           ssh_fwd_get_ports
+#ifdef SSHTEST
+#define dllfunc_sshkey_v1_change_comment    sshkey_v1_change_comment
+#endif /* SSHTEST */
+#ifdef COMMENT
+#define dllfunc_sshkey_default_file         sshkey_default_file
+#endif /* COMMENT */
+#define dllfunc_ssh_v2_rekey                ssh_v2_rekey
+#define dllfunc_ssh_agent_delete_file       ssh_agent_delete_file
+#define dllfunc_ssh_agent_delete_all        ssh_agent_delete_all
+#define dllfunc_ssh_agent_add_file          ssh_agent_add_file
+#define dllfunc_ssh_agent_list_identities   ssh_agent_list_identities
+#define dllfunc_ssh_unload                  ssh_unload
+#define dllfunc_ssh_dll_ver                 ssh_dll_ver
+#define dllfunc_ssh_get_keytab              ssh_get_keytab
+#define dllfunc_ssh_feature_supported       ssh_feature_supported
+#define dllfunc_ssh_get_set_help            ssh_get_set_help
+#define dllfunc_ssh_get_help                ssh_get_help
+
+#endif /* SSH_DLL_CALLCONV */
 
 #undef malloc
 #undef realloc
@@ -772,6 +1042,9 @@ kstrdup(const char *str)
     return cp;
 }
 
+#define ckmakmsg(buf,len,s1,s2,s3,s4) ckmakxmsg(buf, len, s1, s2, s3, s4, \
+            NULL, NULL,NULL, NULL, NULL, NULL, NULL, NULL)
+
 /*
  * Quick macro to check if a function pointer is null and, if it is, log
  * the event and return an error.
@@ -781,102 +1054,112 @@ kstrdup(const char *str)
     debug(F110, "ERROR: Required function pointer is null", STR(fp), 0); \
     return -1;}
 
-int ssh_dll_init(ssh_init_parameters_t *params) {
+/** Called by Kermit 95 when the DLL is loaded. This should make
+ * the DLL ready for use by storing copies of all the needed
+ * callback functions supplied by Kermit 95, and supplying to
+ * Kermit 95 via the install_dllfunc all of the SSH functions
+ * this DLL provides.
+ * @param params SSH initialisation parameters from Kermit 95
+ */
+int CKSSHDLLENTRY ssh_dll_init(ssh_init_parameters_t *params) {
     /* Store pointers to helper functions provided by K95 */
-    p_get_current_terminal_dimensions = params->p_get_current_terminal_dimensions;
-    CHECK_FP(p_get_current_terminal_dimensions)
-    p_get_current_terminal_type = params->p_get_current_terminal_type;
-    CHECK_FP(p_get_current_terminal_type)
-    p_ssh_get_uid = params->p_ssh_get_uid;
-    CHECK_FP(p_ssh_get_uid)
-    p_ssh_get_pw = params->p_ssh_get_pw;
-    CHECK_FP(p_ssh_get_pw)
-    p_ssh_get_nodelay_enabled = params->p_ssh_get_nodelay_enabled;
-    CHECK_FP(p_ssh_get_nodelay_enabled)
-    p_ssh_open_socket = params->p_ssh_open_socket;
-    CHECK_FP(p_ssh_open_socket)
-    p_dodebug = params->p_dodebug;
-    CHECK_FP(p_dodebug)
-    p_vscrnprintf = params->p_vscrnprintf;
-    CHECK_FP(p_vscrnprintf)
-    p_uq_txt = params->p_uq_txt;
-    CHECK_FP(p_uq_txt)
-    p_uq_mtxt = params->p_uq_mtxt;
-    CHECK_FP(p_uq_mtxt)
-    p_uq_ok = params->p_uq_ok;
-    CHECK_FP(p_uq_ok)
-    p_uq_file = params->p_uq_file;
-    CHECK_FP(p_uq_file)
-    p_zmkdir = params->p_zmkdir;
-    CHECK_FP(p_zmkdir)
-    p_ckmakxmsg = params->p_ckmakxmsg;
-    CHECK_FP(p_ckmakxmsg)
-    p_whoami = params->p_whoami;
-    CHECK_FP(p_whoami)
-    p_GetAppData = params->p_GetAppData;
-    CHECK_FP(p_GetAppData)
-    p_GetHomePath = params->p_GetHomePath;
-    CHECK_FP(p_GetHomePath)
-    p_GetHomeDrive = params->p_GetHomeDrive;
-    CHECK_FP(p_GetHomeDrive)
-    p_ckstrncpy = params->p_ckstrncpy;
-    CHECK_FP(p_ckstrncpy)
-    p_debug_logging = params->p_debug_logging;
-    CHECK_FP(p_debug_logging)
-    p_get_display = params->p_get_display;
-    CHECK_FP(p_get_display)
-    p_parse_displayname = params->p_parse_displayname;
-    CHECK_FP(p_get_display)
+    callbackp_get_current_terminal_dimensions = params->callbackp_get_current_terminal_dimensions;
+    CHECK_FP(callbackp_get_current_terminal_dimensions)
+    callbackp_get_current_terminal_type = params->callbackp_get_current_terminal_type;
+    CHECK_FP(callbackp_get_current_terminal_type)
+    callbackp_ssh_get_uid = params->callbackp_ssh_get_uid;
+    CHECK_FP(callbackp_ssh_get_uid)
+    callbackp_ssh_get_pw = params->callbackp_ssh_get_pw;
+    CHECK_FP(callbackp_ssh_get_pw)
+    callbackp_ssh_get_nodelay_enabled = params->callbackp_ssh_get_nodelay_enabled;
+    CHECK_FP(callbackp_ssh_get_nodelay_enabled)
+    callbackp_ssh_open_socket = params->callbackp_ssh_open_socket;
+    CHECK_FP(callbackp_ssh_open_socket)
+    callbackp_dodebug = params->callbackp_dodebug;
+    CHECK_FP(callbackp_dodebug)
+    callbackp_vscrnprintf = params->callbackp_vscrnprintf;
+    CHECK_FP(callbackp_vscrnprintf)
+    callbackp_uq_txt = params->callbackp_uq_txt;
+    CHECK_FP(callbackp_uq_txt)
+    callbackp_uq_mtxt = params->callbackp_uq_mtxt;
+    CHECK_FP(callbackp_uq_mtxt)
+    callbackp_uq_ok = params->callbackp_uq_ok;
+    CHECK_FP(callbackp_uq_ok)
+    callbackp_uq_file = params->callbackp_uq_file;
+    CHECK_FP(callbackp_uq_file)
+    callbackp_zmkdir = params->callbackp_zmkdir;
+    CHECK_FP(callbackp_zmkdir)
+    callbackp_ckmakxmsg = params->callbackp_ckmakxmsg;
+    CHECK_FP(callbackp_ckmakxmsg)
+    callbackp_whoami = params->callbackp_whoami;
+    CHECK_FP(callbackp_whoami)
+    callbackp_GetAppData = params->callbackp_GetAppData;
+    CHECK_FP(callbackp_GetAppData)
+    callbackp_GetHomePath = params->callbackp_GetHomePath;
+    CHECK_FP(callbackp_GetHomePath)
+    callbackp_GetHomeDrive = params->callbackp_GetHomeDrive;
+    CHECK_FP(callbackp_GetHomeDrive)
+    callbackp_ckstrncpy = params->callbackp_ckstrncpy;
+    CHECK_FP(callbackp_ckstrncpy)
+    callbackp_debug_logging = params->callbackp_debug_logging;
+    CHECK_FP(callbackp_debug_logging)
+    callbackp_get_display = params->callbackp_get_display;
+    CHECK_FP(callbackp_get_display)
+    callbackp_parse_displayname = params->callbackp_parse_displayname;
+    CHECK_FP(callbackp_parse_displayname)
 
-    /* And then supply pointers to all our functions to K95 */
-    params->p_install_funcs("ssh_set_iparam", ssh_set_iparam);
-    params->p_install_funcs("ssh_get_iparam", ssh_get_iparam);
-    params->p_install_funcs("ssh_set_sparam", ssh_set_sparam);
-    params->p_install_funcs("ssh_get_sparam", ssh_get_sparam);
-    params->p_install_funcs("ssh_set_identity_files", ssh_set_identity_files);
-    params->p_install_funcs("ssh_get_socket", ssh_get_socket);
-    params->p_install_funcs("ssh_open", ssh_open);
-    params->p_install_funcs("ssh_clos", ssh_clos);
-    params->p_install_funcs("ssh_tchk", ssh_tchk);
-    params->p_install_funcs("ssh_flui", ssh_flui);
-    params->p_install_funcs("ssh_break", ssh_break);
-    params->p_install_funcs("ssh_inc", ssh_inc);
-    params->p_install_funcs("ssh_xin", ssh_xin);
-    params->p_install_funcs("ssh_toc", ssh_toc);
-    params->p_install_funcs("ssh_tol", ssh_tol);
-    params->p_install_funcs("ssh_snaws", ssh_snaws);
-    params->p_install_funcs("ssh_proto_ver", ssh_proto_ver);
-    params->p_install_funcs("ssh_impl_ver", ssh_impl_ver);
-    params->p_install_funcs("sshkey_create", sshkey_create);
-    params->p_install_funcs("sshkey_display_fingerprint", sshkey_display_fingerprint);
-    params->p_install_funcs("sshkey_display_public", sshkey_display_public);
-    params->p_install_funcs("sshkey_display_public_as_ssh2", sshkey_display_public_as_ssh2);
-    params->p_install_funcs("sshkey_change_passphrase", sshkey_change_passphrase);
-    params->p_install_funcs("ssh_fwd_remote_port", ssh_fwd_remote_port);
-    params->p_install_funcs("ssh_fwd_local_port", ssh_fwd_local_port);
-    params->p_install_funcs("ssh_fwd_clear_remote_ports", ssh_fwd_clear_remote_ports);
-    params->p_install_funcs("ssh_fwd_clear_local_ports", ssh_fwd_clear_local_ports);
-    params->p_install_funcs("ssh_fwd_remove_remote_port", ssh_fwd_remove_remote_port);
-    params->p_install_funcs("ssh_fwd_remove_local_port", ssh_fwd_remove_local_port);
-    params->p_install_funcs("ssh_fwd_get_ports", ssh_fwd_get_ports);
+    params->callbackp_install_dllfunc("ssh_set_iparam", dllfunc_ssh_set_iparam);
+    params->callbackp_install_dllfunc("ssh_get_iparam", dllfunc_ssh_get_iparam);
+    params->callbackp_install_dllfunc("ssh_set_sparam", dllfunc_ssh_set_sparam);
+    params->callbackp_install_dllfunc("ssh_get_sparam", dllfunc_ssh_get_sparam);
+    params->callbackp_install_dllfunc("ssh_set_identity_files", dllfunc_ssh_set_identity_files);
+    params->callbackp_install_dllfunc("ssh_get_socket", dllfunc_ssh_get_socket);
+    params->callbackp_install_dllfunc("ssh_open", dllfunc_ssh_open);
+    params->callbackp_install_dllfunc("ssh_clos", dllfunc_ssh_clos);
+    params->callbackp_install_dllfunc("ssh_tchk", dllfunc_ssh_tchk);
+    params->callbackp_install_dllfunc("ssh_flui", dllfunc_ssh_flui);
+    params->callbackp_install_dllfunc("ssh_break", dllfunc_ssh_break);
+    params->callbackp_install_dllfunc("ssh_inc", dllfunc_ssh_inc);
+    params->callbackp_install_dllfunc("ssh_xin", dllfunc_ssh_xin);
+    params->callbackp_install_dllfunc("ssh_toc", dllfunc_ssh_toc);
+    params->callbackp_install_dllfunc("ssh_tol", dllfunc_ssh_tol);
+    params->callbackp_install_dllfunc("ssh_snaws", dllfunc_ssh_snaws);
+    params->callbackp_install_dllfunc("ssh_proto_ver", dllfunc_ssh_proto_ver);
+    params->callbackp_install_dllfunc("ssh_impl_ver", dllfunc_ssh_impl_ver);
+
+    /* These functions are all optional */
+    params->callbackp_install_dllfunc("sshkey_create", dllfunc_sshkey_create);
+    params->callbackp_install_dllfunc("sshkey_display_fingerprint", dllfunc_sshkey_display_fingerprint);
+    params->callbackp_install_dllfunc("sshkey_display_public", dllfunc_sshkey_display_public);
+    params->callbackp_install_dllfunc("sshkey_display_public_as_ssh2", dllfunc_sshkey_display_public_as_ssh2);
+    params->callbackp_install_dllfunc("sshkey_change_passphrase", dllfunc_sshkey_change_passphrase);
+    params->callbackp_install_dllfunc("ssh_fwd_remote_port", dllfunc_ssh_fwd_remote_port);
+    params->callbackp_install_dllfunc("ssh_fwd_local_port", dllfunc_ssh_fwd_local_port);
+    params->callbackp_install_dllfunc("ssh_fwd_clear_remote_ports", dllfunc_ssh_fwd_clear_remote_ports);
+    params->callbackp_install_dllfunc("ssh_fwd_clear_local_ports", dllfunc_ssh_fwd_clear_local_ports);
+    params->callbackp_install_dllfunc("ssh_fwd_remove_remote_port", dllfunc_ssh_fwd_remove_remote_port);
+    params->callbackp_install_dllfunc("ssh_fwd_remove_local_port", dllfunc_ssh_fwd_remove_local_port);
+    params->callbackp_install_dllfunc("ssh_fwd_get_ports", dllfunc_ssh_fwd_get_ports);
 #ifdef SSHTEST
-    params->p_install_funcs("sshkey_v1_change_comment", sshkey_v1_change_comment); /* TODO */
+    params->callbackp_install_dllfunc("sshkey_v1_change_comment", dllfunc_sshkey_v1_change_comment); /* TODO */
 #endif
-    /* params->p_install_funcs("sshkey_default_file", sshkey_default_file); */ /* TODO */
-    params->p_install_funcs("ssh_v2_rekey", ssh_v2_rekey); /* TODO */
-    params->p_install_funcs("ssh_agent_delete_file", ssh_agent_delete_file); /* TODO */
-    params->p_install_funcs("ssh_agent_delete_all", ssh_agent_delete_all); /* TODO */
-    params->p_install_funcs("ssh_agent_add_file", ssh_agent_add_file); /* TODO */
-    params->p_install_funcs("ssh_agent_list_identities", ssh_agent_list_identities); /* TODO */
 #ifdef COMMENT
-    /* Not supported: */
-    params->p_install_funcs("ssh_unload", ssh_unload);
+    params->callbackp_install_dllfunc("sshkey_default_file", dllfunc_sshkey_default_file); */ /* TODO */
 #endif /* COMMENT */
-    params->p_install_funcs("ssh_dll_ver", ssh_dll_ver);
-    params->p_install_funcs("ssh_get_keytab", ssh_get_keytab);
-    params->p_install_funcs("ssh_feature_supported", ssh_feature_supported);
-    params->p_install_funcs("ssh_get_set_help", ssh_get_set_help);
-    params->p_install_funcs("ssh_get_help", ssh_get_help);
+    params->callbackp_install_dllfunc("ssh_v2_rekey", dllfunc_ssh_v2_rekey); /* TODO */
+    params->callbackp_install_dllfunc("ssh_agent_delete_file", dllfunc_ssh_agent_delete_file); /* TODO */
+    params->callbackp_install_dllfunc("ssh_agent_delete_all", dllfunc_ssh_agent_delete_all); /* TODO */
+    params->callbackp_install_dllfunc("ssh_agent_add_file", dllfunc_ssh_agent_add_file); /* TODO */
+    params->callbackp_install_dllfunc("ssh_agent_list_identities", dllfunc_ssh_agent_list_identities); /* TODO */
+#ifdef COMMENT
+    /* Not supported */
+    params->callbackp_install_dllfunc("ssh_unload", dllfunc_ssh_unload);
+#endif /* COMMENT */
+    params->callbackp_install_dllfunc("ssh_dll_ver", dllfunc_ssh_dll_ver);
+    params->callbackp_install_dllfunc("ssh_get_keytab", dllfunc_ssh_get_keytab);
+    params->callbackp_install_dllfunc("ssh_feature_supported", dllfunc_ssh_feature_supported);
+    params->callbackp_install_dllfunc("ssh_get_set_help", dllfunc_ssh_get_set_help);
+    params->callbackp_install_dllfunc("ssh_get_help", dllfunc_ssh_get_help);
 
     /* And lastly do any other initialisation work that is independent of
      * whether we're a DLL or not */
@@ -884,11 +1167,7 @@ int ssh_dll_init(ssh_init_parameters_t *params) {
 
     return 0;
 }
-#else
-/* These live in ckossh.c */
-unsigned char* get_display();
-int parse_displayname(char *displayname, int *familyp, char **hostp,
-                      int *dpynump, int *scrnump, char **restp);
+
 #endif /* SSH_DLL */
 
 int ssh_set_iparam(int param, int value) {
@@ -1133,7 +1412,7 @@ int ssh_set_identity_files(const char** identity_files) {
  *
  * Here we can set defaults.
  */
-void ssh_initialise() {
+void ssh_initialise(void) {
 
 }
 
@@ -1213,7 +1492,7 @@ static void debug_params(const char* function) {
  * @returns Socket for the current SSH connection, or -1 if not implemented or
  *      no active connection
  */
-int ssh_get_socket() {
+int ssh_get_socket(void) {
 
     /* TODO: Get the libssh socket */
 
@@ -1224,7 +1503,7 @@ int ssh_get_socket() {
  *
  * @return Error status or 0 if everything is ok.
  */
-static int get_ssh_error() {
+static int get_ssh_error(void) {
     int error = SSH_ERR_UNSPECIFIED;
 
     /* If there is no ssh_client instance then the client is absolutely not
@@ -1269,7 +1548,7 @@ static int get_ssh_error() {
  *
  * @returns A new string containing the SSH directory.
  */
-char* ssh_directory() {
+char* ssh_directory(void) {
 
     char* dir;
     if (ssh_dir != NULL) {      /* SSH Directory */
@@ -1288,7 +1567,7 @@ char* ssh_directory() {
  *
  * @return An error code (0 = success)
  */
-int ssh_open() {
+int ssh_open(void) {
     ssh_parameters_t* parameters;
     char* user = NULL;
     int pty_height, pty_width;
@@ -1533,7 +1812,7 @@ int ssh_open() {
  *
  * @return  0 on success, < 0 on failure.
  */
-int ssh_clos() {
+int ssh_clos(void) {
     BOOL success;
     DWORD result;
     debug(F100, "ssh_clos()", "", 0);
@@ -1601,7 +1880,7 @@ int ssh_clos() {
  * @return >= 0 indicates number of bytes waiting to be read
  *          < 0 indicates a fatal error and the connection should be closed.
  */
-int ssh_tchk() {
+int ssh_tchk(void) {
     int rc = 0;
 
     if (ssh_client == NULL) {
@@ -1657,7 +1936,7 @@ int ssh_tchk() {
  *
  * @return 0 on success, < 0 on error
  */
-int ssh_flui() {
+int ssh_flui(void) {
     if (ssh_client == NULL) {
         return SSH_ERR_NO_INSTANCE;
     }
@@ -1676,7 +1955,7 @@ int ssh_flui() {
  *
  * @return
  */
-int ssh_break() {
+int ssh_break(void) {
     if (ssh_client == NULL)
         return SSH_ERR_NO_INSTANCE;
 
@@ -1951,7 +2230,7 @@ const char * ssh_errorstr(int error) {
  *
  * @return 0 on success, < 0 on error.
  */
-int ssh_ttvt() {
+int ssh_ttvt(void) {
     /* Just report success here. Returning any kind of error just results
      * in a weird message to the user like
      * "Sorry, Can't condition communication line" which is pretty meaningless
@@ -1965,7 +2244,7 @@ int ssh_ttvt() {
  *
  * @return 0 on success, < 0 otherwise.
  */
-int ssh_ttpkt() {
+int ssh_ttpkt(void) {
     /* Nothing much to do here. Just return an error if we have one. */
     return get_ssh_error();
 }
@@ -1975,18 +2254,18 @@ int ssh_ttpkt() {
  *
  * @return 0 on success, < 0 on failure.
  */
-int ssh_ttres() {
+int ssh_ttres(void) {
     /* Nothing much to do here. Just return an error if we have one. */
     return get_ssh_error();
 }
-#endif
+#endif /* COMMENT */
 
 
 /** Negotiate About Window Size. Let the remote host know the window dimensions
  * and terminal type if these have changed.
  *
  */
-int ssh_snaws() {
+int ssh_snaws(void) {
     int rows, cols;
     debug(F100, "ssh_snaws()", "", 0);
 
@@ -2229,14 +2508,10 @@ int ssh_fwd_remove_local_port(int port, BOOL apply) {
  *
  * @returns List of forwarded ports, or NULL on error or empty list
  */
-const ssh_port_forward_t* ssh_fwd_get_ports() {
+const ssh_port_forward_t* ssh_fwd_get_ports(void) {
 
     return port_forwards;
 }
-
-/* These live in ckoreg.c */
-char* GetHomePath();
-char* GetHomeDrive();
 
 /** Creates an SSH key pair
  *
@@ -2490,7 +2765,7 @@ int sshkey_create(char * filename, int bits, char * pp, int type, char * cmd_com
  *
  * @return Default SSH key filename. Must be freed by caller.
  */
-char* default_key_filename() {
+char* default_key_filename(void) {
     char *default_filename, *dir;
     dir = ssh_directory();
     default_filename = malloc(MAX_PATH * sizeof(char));
@@ -2833,9 +3108,9 @@ int sshkey_v1_change_comment(char * filename, char * comment, char * pp) {
 char * sshkey_default_file(int a) {
     return NULL; /* TODO */
 }
-#endif
+#endif /* COMMENT */
 
-void ssh_v2_rekey() {
+void ssh_v2_rekey(void) {
     /* TODO */
 }
 
@@ -2843,7 +3118,7 @@ void ssh_v2_rekey() {
  *
  * @return "SSH-2.0"
  */
-const char * ssh_proto_ver() {
+const char * ssh_proto_ver(void) {
     static char buf[16];
     snprintf(buf, sizeof buf, "SSH-2.0");
     return buf;
@@ -2851,13 +3126,13 @@ const char * ssh_proto_ver() {
 
 /** Return the current SSH backend/implementation version.
  */
-const char * ssh_impl_ver() {
+const char * ssh_impl_ver(void) {
     static char buf[64];
     snprintf(buf, sizeof(buf), "libssh %s", ssh_version(0));
     return buf;
 }
 
-const char * ssh_dll_ver() {
+const char * ssh_dll_ver(void) {
     return cksshv;
 }
 
@@ -2865,7 +3140,7 @@ int ssh_agent_delete_file(const char *filename) {
     return SSH_ERR_NOT_IMPLEMENTED; /* TODO */
 }
 
-int ssh_agent_delete_all() {
+int ssh_agent_delete_all(void) {
     return SSH_ERR_NOT_IMPLEMENTED; /* TODO */
 }
 
@@ -2966,7 +3241,7 @@ int ssh_feature_supported(int feature_id) {
  *
  * @return Help text for HELP SET SSH.
  */
-const char** ssh_get_set_help() {
+const char** ssh_get_set_help(void) {
     static const char *hmxyssh[] = {
 #ifdef SSH_AGENT_SUPPORT
 "SET SSH AGENT-FORWARDING { ON, OFF }",
@@ -3172,7 +3447,7 @@ const char** ssh_get_set_help() {
  *
  * @return Help text for HELP SSH.
  */
-const char** ssh_get_help() {
+const char** ssh_get_help(void) {
     static const char * hmxxssh[] = {
 "Syntax: SSH { ADD, AGENT, CLEAR, KEY, [ OPEN ], V2 } operands...",
 "  Performs an SSH-related action, depending on the keyword that follows:",

--- a/kermit/k95/ckonssh.c
+++ b/kermit/k95/ckonssh.c
@@ -254,60 +254,58 @@ static char                             /* The following are to be malloc'd */
 * xxx_dummy = NULL;
 
 #ifdef SSH_DLL
-static void (*p_get_current_terminal_dimensions)(int* rows, int* cols) = NULL;
-const char* (*p_get_current_terminal_type)() = NULL;
-const char* (*p_ssh_get_uid)();
-const char* (*p_ssh_get_pw)();
-int (*p_ssh_get_nodelay_enabled)();
-SOCKET (*p_ssh_open_socket)(char* host, char* port) = NULL;
-static int (*p_dodebug)(int,char *,char *,CK_OFF_T)=NULL;
-static int (*p_vscrnprintf)(const char *, ...)=NULL;
-static int (*p_uq_txt)(char *,char *,int,char **,char *,int,char *,int) = NULL;
-static int (*p_uq_mtxt) (char *,char **,int,struct txtbox[]) = NULL;
-int (*p_uq_ok)(char *,char *,int,char **,int) = NULL;
-int (*p_uq_file)(char *,char *,int,char **,char *,char *,int) = NULL;
-int (*p_zmkdir)(char *) = NULL;
-int (*p_ckmakxmsg)(char * buf, int len, char *s1, char *s2, char *s3,
-        char *s4, char *s5, char *s6, char *s7, char *s8, char *s9,
-        char *s10, char *s11, char *s12) = NULL;
-char* (*p_whoami)() = NULL;
-char* (*p_GetAppData)(int common) = NULL;
-char* (*p_GetHomePath)() = NULL;
-char* (*p_GetHomeDrive)() = NULL;
-int (*p_ckstrncpy)(char * dest, const char * src, int len) = NULL;
-int (*p_debug_logging)() = NULL;
-unsigned char* (*p_get_display)() = NULL;
-int (*p_parse_displayname)(char *displayname, int *familyp, char **hostp,
-                        int *dpynump, int *scrnump, char **restp) = NULL;
+
+static get_current_terminal_dimensions_callback *callbackp_get_current_terminal_dimensions = NULL;
+static get_current_terminal_type_callback   *callbackp_get_current_terminal_type = NULL;
+static ssh_get_uid_callback                 *callbackp_ssh_get_uid = NULL;
+static ssh_get_pw_callback                  *callbackp_ssh_get_pw = NULL;
+static ssh_get_nodelay_enabled_callback     *callbackp_ssh_get_nodelay_enabled = NULL;
+static ssh_open_socket_callback             *callbackp_ssh_open_socket = NULL;
+static dodebug_callback                     *callbackp_dodebug = NULL;
+static vscrnprintf_callback                 *callbackp_vscrnprintf = NULL;
+static uq_txt_callback                      *callbackp_uq_txt = NULL;
+static uq_mtxt_callback                     *callbackp_uq_mtxt = NULL;
+static uq_ok_callback                       *callbackp_uq_ok = NULL;
+static uq_file_callback                     *callbackp_uq_file = NULL;
+static zmkdir_callback                      *callbackp_zmkdir = NULL;
+static ckmakxmsg_callback                   *callbackp_ckmakxmsg = NULL;
+static whoami_callback                      *callbackp_whoami = NULL;
+static GetAppData_callback                  *callbackp_GetAppData = NULL;
+static GetHomePath_callback                 *callbackp_GetHomePath = NULL;
+static GetHomeDrive_callback                *callbackp_GetHomeDrive = NULL;
+static ckstrncpy_callback                   *callbackp_ckstrncpy = NULL;
+static debug_logging_callback               *callbackp_debug_logging = NULL;
+static get_display_callback                 *callbackp_get_display = NULL;
+static parse_displayname_callback           *callbackp_parse_displayname = NULL;
 
 void get_current_terminal_dimensions(int* rows, int* cols) {
-    p_get_current_terminal_dimensions(rows, cols);
+    callbackp_get_current_terminal_dimensions(rows, cols);
 }
 
-const char* get_current_terminal_type() {
-    return p_get_current_terminal_type();
+const char* get_current_terminal_type(void) {
+    return callbackp_get_current_terminal_type();
 }
 
-const char* ssh_get_uid() {
-    return p_ssh_get_uid();
+const char* ssh_get_uid(void) {
+    return callbackp_ssh_get_uid();
 }
 
-const char* ssh_get_pw() {
-    return p_ssh_get_pw();
+const char* ssh_get_pw(void) {
+    return callbackp_ssh_get_pw();
 }
 
-int ssh_get_nodelay_enabled() {
-    return p_ssh_get_nodelay_enabled();
+int ssh_get_nodelay_enabled(void) {
+    return callbackp_ssh_get_nodelay_enabled();
 }
 
 SOCKET ssh_open_socket(char* host, char* port) {
-    return p_ssh_open_socket(host, port);
+    return callbackp_ssh_open_socket(host, port);
 }
 
 int dodebug(int flag, char * s1, char * s2, CK_OFF_T n)
 {
-    if ( p_dodebug )
-        return(p_dodebug(flag,s1,s2,n));
+    if ( callbackp_dodebug )
+        return(callbackp_dodebug(flag,s1,s2,n));
     else
         return(-1);
 }
@@ -326,154 +324,472 @@ int Vscrnprintf(const char * format, ...) {
 #endif /* NT */
     va_end(ap);
 
-    if ( p_vscrnprintf )
-        return(p_vscrnprintf(myprtfstr));
+    if ( callbackp_vscrnprintf )
+        return(callbackp_vscrnprintf(myprtfstr));
     else
         return(-1);
 }
 
 int uq_txt(char * preface, char * prompt, int echo, char ** help, char * buf,
        int buflen, char *dflt, int timer) {
-    return p_uq_txt(preface, prompt, echo, help, buf, buflen, dflt, timer);
+    return callbackp_uq_txt(preface, prompt, echo, help, buf, buflen, dflt, timer);
 }
 
 int uq_mtxt(char * preface,char **help, int n, struct txtbox field[]) {
-    return p_uq_mtxt(preface, help, n, field);
+    return callbackp_uq_mtxt(preface, help, n, field);
 }
 
 int uq_ok(char * preface, char * prompt, int mask,char ** help, int dflt) {
-    return p_uq_ok(preface, prompt, mask, help, dflt);
+    return callbackp_uq_ok(preface, prompt, mask, help, dflt);
 }
 
 int uq_file(char * preface, char * fprompt, int fc, char ** help,
 	char * dflt, char * result, int rlength) {
-    return p_uq_file(preface, fprompt, fc, help, dflt, result, rlength);
+    return callbackp_uq_file(preface, fprompt, fc, help, dflt, result, rlength);
 }
 
 int zmkdir(char *path) {
-    return p_zmkdir(path);
+    return callbackp_zmkdir(path);
 }
 
 int ckmakxmsg(char * buf, int len, char *s1, char *s2, char *s3,
         char *s4, char *s5, char *s6, char *s7, char *s8, char *s9,
         char *s10, char *s11, char *s12) {
-    return p_ckmakxmsg(buf, len, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11,
+    return callbackp_ckmakxmsg(buf, len, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11,
                        s12);
 }
 
-char* whoami() {
-    return p_whoami();
+char* whoami(void) {
+    return callbackp_whoami();
 }
 
 char* GetAppData(int common) {
-    return p_GetAppData(common);
+    return callbackp_GetAppData(common);
 }
 
-char* GetHomePath() {
-    return p_GetHomePath();
+char* GetHomePath(void) {
+    return callbackp_GetHomePath();
 }
 
-char* GetHomeDrive() {
-    return p_GetHomeDrive();
+char* GetHomeDrive(void) {
+    return callbackp_GetHomeDrive();
 }
 
 int ckstrncpy(char * dest, const char * src, int len) {
-    return p_ckstrncpy(dest, src, len);
+    return callbackp_ckstrncpy(dest, src, len);
 }
 
-int debug_logging() {
-    return p_debug_logging();
+int debug_logging(void) {
+    return callbackp_debug_logging();
 }
 
-unsigned char* get_display() {
-    return p_get_display();
+unsigned char* get_display(void) {
+    return callbackp_get_display();
 }
 
 int parse_displayname(char *displayname, int *familyp, char **hostp,
                         int *dpynump, int *scrnump, char **restp) {
-    return p_parse_displayname(displayname, familyp, hostp,
+    return callbackp_parse_displayname(displayname, familyp, hostp,
                                dpynump, scrnump, restp);
 }
 
+#ifdef SSH_DLL_CALLCONV
+
+/* define prototypes for DLL functions */
+static ssh_set_iparam_dllfunc               dllfunc_ssh_set_iparam;
+static ssh_get_iparam_dllfunc               dllfunc_ssh_get_iparam;
+static ssh_set_sparam_dllfunc               dllfunc_ssh_set_sparam;
+static ssh_get_sparam_dllfunc               dllfunc_ssh_get_sparam;
+static ssh_set_identity_files_dllfunc       dllfunc_ssh_set_identity_files;
+static ssh_get_socket_dllfunc               dllfunc_ssh_get_socket;
+static ssh_open_dllfunc                     dllfunc_ssh_open;
+static ssh_clos_dllfunc                     dllfunc_ssh_clos;
+static ssh_tchk_dllfunc                     dllfunc_ssh_tchk;
+static ssh_flui_dllfunc                     dllfunc_ssh_flui;
+static ssh_break_dllfunc                    dllfunc_ssh_break;
+static ssh_inc_dllfunc                      dllfunc_ssh_inc;
+static ssh_xin_dllfunc                      dllfunc_ssh_xin;
+static ssh_toc_dllfunc                      dllfunc_ssh_toc;
+static ssh_tol_dllfunc                      dllfunc_ssh_tol;
+static ssh_snaws_dllfunc                    dllfunc_ssh_snaws;
+static ssh_proto_ver_dllfunc                dllfunc_ssh_proto_ver;
+static ssh_impl_ver_dllfunc                 dllfunc_ssh_impl_ver;
+static sshkey_create_dllfunc                dllfunc_sshkey_create;
+static sshkey_display_fingerprint_dllfunc   dllfunc_sshkey_display_fingerprint;
+static sshkey_display_public_dllfunc        dllfunc_sshkey_display_public;
+static sshkey_display_public_as_ssh2_dllfunc dllfunc_sshkey_display_public_as_ssh2;
+static sshkey_change_passphrase_dllfunc     dllfunc_sshkey_change_passphrase;
+static ssh_fwd_remote_port_dllfunc          dllfunc_ssh_fwd_remote_port;
+static ssh_fwd_local_port_dllfunc           dllfunc_ssh_fwd_local_port;
+static ssh_fwd_clear_remote_ports_dllfunc   dllfunc_ssh_fwd_clear_remote_ports;
+static ssh_fwd_clear_local_ports_dllfunc    dllfunc_ssh_fwd_clear_local_ports;
+static ssh_fwd_remove_remote_port_dllfunc   dllfunc_ssh_fwd_remove_remote_port;
+static ssh_fwd_remove_local_port_dllfunc    dllfunc_ssh_fwd_remove_local_port;
+static ssh_fwd_get_ports_dllfunc            dllfunc_ssh_fwd_get_ports;
+static sshkey_v1_change_comment_dllfunc     dllfunc_sshkey_v1_change_comment;
+static sshkey_default_file_dllfunc          dllfunc_sshkey_default_file;
+static ssh_v2_rekey_dllfunc                 dllfunc_ssh_v2_rekey;
+static ssh_agent_delete_file_dllfunc        dllfunc_ssh_agent_delete_file;
+static ssh_agent_delete_all_dllfunc         dllfunc_ssh_agent_delete_all;
+static ssh_agent_add_file_dllfunc           dllfunc_ssh_agent_add_file;
+static ssh_agent_list_identities_dllfunc    dllfunc_ssh_agent_list_identities;
+static ssh_unload_dllfunc                   dllfunc_ssh_unload;
+static ssh_dll_ver_dllfunc                  dllfunc_ssh_dll_ver;
+static ssh_get_keytab_dllfunc               dllfunc_ssh_get_keytab;
+static ssh_feature_supported_dllfunc        dllfunc_ssh_feature_supported;
+static ssh_get_set_help_dllfunc             dllfunc_ssh_get_set_help;
+static ssh_get_help_dllfunc                 dllfunc_ssh_get_help;
+
+
+/* calling convention layer for DLL functions on DLL side */
+static int CKSSHAPI dllfunc_ssh_set_iparam(int param, int value) {
+    return ssh_set_iparam(param, value);
+}
+
+static int CKSSHAPI dllfunc_ssh_get_iparam(int param) {
+    return ssh_get_iparam(param);
+}
+
+static int CKSSHAPI dllfunc_ssh_set_sparam(int param, const char* value) {
+    return ssh_set_sparam(param, value);
+}
+
+static const char* CKSSHAPI dllfunc_ssh_get_sparam(int param) {
+    return ssh_get_sparam(param);
+}
+
+static int CKSSHAPI dllfunc_ssh_set_identity_files(const char** identity_files) {
+    return ssh_set_identity_files(identity_files);
+}
+
+static int CKSSHAPI dllfunc_ssh_get_socket(void) {
+    return ssh_get_socket();
+}
+
+static int CKSSHAPI dllfunc_ssh_open(void) {
+    return ssh_open();
+}
+
+static int CKSSHAPI dllfunc_ssh_clos(void) {
+    return ssh_clos();
+}
+
+static int CKSSHAPI dllfunc_ssh_tchk(void) {
+    return ssh_tchk();
+}
+
+static int CKSSHAPI dllfunc_ssh_flui(void) {
+    return ssh_flui();
+}
+
+static int CKSSHAPI dllfunc_ssh_break(void) {
+    return ssh_break();
+}
+
+static int CKSSHAPI dllfunc_ssh_inc(int timeout) {
+    return ssh_inc(timeout);
+}
+
+static int CKSSHAPI dllfunc_ssh_xin(int count, char * buffer) {
+    return ssh_xin(count, buffer);
+}
+
+static int CKSSHAPI dllfunc_ssh_toc(int c) {
+    return ssh_toc(c);
+}
+
+static int CKSSHAPI dllfunc_ssh_tol(char * buffer, int count) {
+    return ssh_tol(buffer, count);
+}
+
+static int CKSSHAPI dllfunc_ssh_snaws(void) {
+    return ssh_snaws();
+}
+
+static const char * CKSSHAPI dllfunc_ssh_proto_ver(void) {
+    return ssh_proto_ver();
+}
+
+static const char * CKSSHAPI dllfunc_ssh_impl_ver(void) {
+    return ssh_impl_ver();
+}
+
+#ifdef COMMENT
+static int CKSSHAPI dllfunc_sshkey_create(char * filename, int bits, char * pp,
+                             int type, char * cmd_comment) {
+    return sshkey_create(filename, bits, pp, type, cmd_comment);
+}
+
+static int CKSSHAPI dllfunc_sshkey_display_fingerprint(char * filename, int babble) {
+    return sshkey_display_fingerprint(filename, babble);
+}
+
+static int CKSSHAPI dllfunc_sshkey_display_public(char * filename, char *identity_passphrase) {
+    return sshkey_display_public(filename, identity_passphrase);
+}
+
+static int CKSSHAPI dllfunc_sshkey_display_public_as_ssh2(char * filename,char *identity_passphrase) {
+    return sshkey_display_public_as_ssh2(filename, identity_passphrase);
+}
+
+static int CKSSHAPI dllfunc_sshkey_change_passphrase(char * filename, char * oldpp, char * newpp) {
+    return sshkey_change_passphrase(filename, oldpp, newpp);
+}
+
+static int CKSSHAPI dllfunc_ssh_fwd_remote_port(char* address, int port, char * host, int host_port, BOOL apply) {
+    return ssh_fwd_remote_port(address, port, host, host_port, apply);
+}
+
+static int CKSSHAPI dllfunc_ssh_fwd_local_port(char* address, int port,char * host, int host_port, BOOL apply) {
+    return ssh_fwd_local_port(address, port, host, host_port, apply);
+}
+
+static int CKSSHAPI dllfunc_ssh_fwd_clear_remote_ports(BOOL apply) {
+    return ssh_fwd_clear_remote_ports(apply);
+}
+
+static int CKSSHAPI dllfunc_ssh_fwd_clear_local_ports(BOOL apply) {
+    return ssh_fwd_clear_local_ports(apply);
+}
+
+static int CKSSHAPI dllfunc_ssh_fwd_remove_remote_port(int port, BOOL apply) {
+    return ssh_fwd_remove_remote_port(port, apply);
+}
+
+static int CKSSHAPI dllfunc_ssh_fwd_remove_local_port(int port, BOOL apply) {
+    return ssh_fwd_remove_local_port(port, apply);
+}
+
+static const ssh_port_forward_t* CKSSHAPI dllfunc_ssh_fwd_get_ports(void) {
+    return ssh_fwd_get_ports();
+}
+
+#ifdef SSHTEST
+static int CKSSHAPI dllfunc_sshkey_v1_change_comment(char * filename, char * comment, char * pp) {
+    return sshkey_v1_change_comment(filename, comment, pp);
+}
+#endif /* SSHTEST */
+
+#ifdef COMMENT
+static char * CKSSHAPI dllfunc_sshkey_default_file(int a) {
+    return sshkey_default_file(a);
+}
+#endif /* COMMENT */
+
+static void CKSSHAPI dllfunc_ssh_v2_rekey(void) {
+    ssh_v2_rekey();
+}
+
+static int CKSSHAPI dllfunc_ssh_agent_delete_file(const char *filename) {
+    return ssh_agent_delete_file(filename);
+}
+
+static int CKSSHAPI dllfunc_ssh_agent_delete_all(void) {
+    return ssh_agent_delete_all();
+}
+
+static int CKSSHAPI dllfunc_ssh_agent_add_file(const char *filename) {
+    return ssh_agent_add_file(filename);
+}
+
+static int CKSSHAPI dllfunc_ssh_agent_list_identities(int do_fp) {
+    return ssh_agent_list_identities(do_fp);
+}
+
+static void CKSSHAPI dllfunc_ssh_unload(void) {
+    ssh_unload();
+}
+#endif /* COMMENT */
+
+static const char * CKSSHAPI dllfunc_ssh_dll_ver(void) {
+    return ssh_dll_ver();
+}
+
+static ktab_ret CKSSHAPI dllfunc_ssh_get_keytab(int keytab_id) {
+    return ssh_get_keytab(keytab_id);
+}
+
+static int CKSSHAPI dllfunc_ssh_feature_supported(int feature_id) {
+    return ssh_feature_supported(feature_id);
+}
+
+static const char ** CKSSHAPI dllfunc_ssh_get_set_help(void) {
+    return ssh_get_set_help();
+}
+
+static const char ** CKSSHAPI dllfunc_ssh_get_help(void) {
+    return ssh_get_help();
+}
+
+#else /* SSH_DLL_CALLCONV */
+
+/* directly use DLL functions without calling convention layer */
+#define dllfunc_ssh_set_iparam              ssh_set_iparam
+#define dllfunc_ssh_get_iparam              ssh_get_iparam
+#define dllfunc_ssh_set_sparam              ssh_set_sparam
+#define dllfunc_ssh_get_sparam              ssh_get_sparam
+#define dllfunc_ssh_set_identity_files      ssh_set_identity_files
+#define dllfunc_ssh_get_socket              ssh_get_socket
+#define dllfunc_ssh_open                    ssh_open
+#define dllfunc_ssh_clos                    ssh_clos
+#define dllfunc_ssh_tchk                    ssh_tchk
+#define dllfunc_ssh_flui                    ssh_flui
+#define dllfunc_ssh_break                   ssh_break
+#define dllfunc_ssh_inc                     ssh_inc
+#define dllfunc_ssh_xin                     ssh_xin
+#define dllfunc_ssh_toc                     ssh_toc
+#define dllfunc_ssh_tol                     ssh_tol
+#define dllfunc_ssh_snaws                   ssh_snaws
+#define dllfunc_ssh_proto_ver               ssh_proto_ver
+#define dllfunc_ssh_impl_ver                ssh_impl_ver
+#ifdef COMMENT
+#define dllfunc_sshkey_create               sshkey_create
+#define dllfunc_sshkey_display_fingerprint  sshkey_display_fingerprint
+#define dllfunc_sshkey_display_public       sshkey_display_public
+#define dllfunc_sshkey_display_public_as_ssh2 sshkey_display_public_as_ssh2
+#define dllfunc_sshkey_change_passphrase    sshkey_change_passphrase
+#define dllfunc_ssh_fwd_remote_port         ssh_fwd_remote_port
+#define dllfunc_ssh_fwd_local_port          ssh_fwd_local_port
+#define dllfunc_ssh_fwd_clear_remote_ports  ssh_fwd_clear_remote_ports
+#define dllfunc_ssh_fwd_clear_local_ports   ssh_fwd_clear_local_ports
+#define dllfunc_ssh_fwd_remove_remote_port  ssh_fwd_remove_remote_port
+#define dllfunc_ssh_fwd_remove_local_port   ssh_fwd_remove_local_port
+#define dllfunc_ssh_fwd_get_ports           ssh_fwd_get_ports
+#ifdef SSHTEST
+#define dllfunc_sshkey_v1_change_comment    sshkey_v1_change_comment
+#endif /* SSHTEST */
+#ifdef COMMENT
+#define dllfunc_sshkey_default_file         sshkey_default_file
+#endif /* COMMENT */
+#define dllfunc_ssh_v2_rekey                ssh_v2_rekey
+#define dllfunc_ssh_agent_delete_file       ssh_agent_delete_file
+#define dllfunc_ssh_agent_delete_all        ssh_agent_delete_all
+#define dllfunc_ssh_agent_add_file          ssh_agent_add_file
+#define dllfunc_ssh_agent_list_identities   ssh_agent_list_identities
+#define dllfunc_ssh_unload                  ssh_unload
+#endif /* COMMENT */
+#define dllfunc_ssh_dll_ver                 ssh_dll_ver
+#define dllfunc_ssh_get_keytab              ssh_get_keytab
+#define dllfunc_ssh_feature_supported       ssh_feature_supported
+#define dllfunc_ssh_get_set_help            ssh_get_set_help
+#define dllfunc_ssh_get_help                ssh_get_help
+
+#endif /* SSH_DLL_CALLCONV */
+
+/*
+ * Quick macro to check if a function pointer is null and, if it is, log
+ * the event and return an error.
+ */
+#define CHECK_FP(fp)
+
 /** Called by Kermit 95 when the DLL is loaded. This should make
  * the DLL ready for use by storing copies of all the needed
- * utility functions supplied by Kermit 95, and supplying to
- * Kermit 95 via the p_install_funcs all of the SSH functions
+ * callback functions supplied by Kermit 95, and supplying to
+ * Kermit 95 via the install_dllfunc all of the SSH functions
  * this DLL provides.
  * @param params SSH initialisation parameters from Kermit 95
  */
-int CKSSHAPI ssh_dll_init(ssh_init_parameters_t *params) {
-    p_get_current_terminal_dimensions = params->p_get_current_terminal_dimensions;
-    p_get_current_terminal_type = params->p_get_current_terminal_type;
-    p_ssh_get_uid = params->p_ssh_get_uid;
-    p_ssh_get_pw = params->p_ssh_get_pw;
-    p_ssh_get_nodelay_enabled = params->p_ssh_get_nodelay_enabled;
-    p_ssh_open_socket = params->p_ssh_open_socket;
-    p_dodebug = params->p_dodebug;
-    p_vscrnprintf = params->p_vscrnprintf;
-    p_uq_txt = params->p_uq_txt;
-    p_uq_mtxt = params->p_uq_mtxt;
-    p_uq_ok = params->p_uq_ok;
-    p_uq_file = params->p_uq_file;
-    p_zmkdir = params->p_zmkdir;
-    p_ckmakxmsg = params->p_ckmakxmsg;
-    p_whoami = params->p_whoami;
-    p_GetAppData = params->p_GetAppData;
-    p_GetHomePath = params->p_GetHomePath;
-    p_GetHomeDrive = params->p_GetHomeDrive;
-    p_ckstrncpy = params->p_ckstrncpy;
-    p_debug_logging = params->p_debug_logging;
-    p_get_display = params->p_get_display;
-    p_parse_displayname = params->p_parse_displayname;
+int CKSSHDLLENTRY ssh_dll_init(ssh_init_parameters_t *params) {
+    /* Store pointers to helper functions provided by K95 */
+    callbackp_get_current_terminal_dimensions = params->callbackp_get_current_terminal_dimensions;
+    CHECK_FP(callbackp_get_current_terminal_dimensions)
+    callbackp_get_current_terminal_type = params->callbackp_get_current_terminal_type;
+    CHECK_FP(callbackp_get_current_terminal_type)
+    callbackp_ssh_get_uid = params->callbackp_ssh_get_uid;
+    CHECK_FP(callbackp_ssh_get_uid)
+    callbackp_ssh_get_pw = params->callbackp_ssh_get_pw;
+    CHECK_FP(callbackp_ssh_get_pw)
+    callbackp_ssh_get_nodelay_enabled = params->callbackp_ssh_get_nodelay_enabled;
+    CHECK_FP(callbackp_ssh_get_nodelay_enabled)
+    callbackp_ssh_open_socket = params->callbackp_ssh_open_socket;
+    CHECK_FP(callbackp_ssh_open_socket)
+    callbackp_dodebug = params->callbackp_dodebug;
+    CHECK_FP(callbackp_dodebug)
+    callbackp_vscrnprintf = params->callbackp_vscrnprintf;
+    CHECK_FP(callbackp_vscrnprintf)
+    callbackp_uq_txt = params->callbackp_uq_txt;
+    CHECK_FP(callbackp_uq_txt)
+    callbackp_uq_mtxt = params->callbackp_uq_mtxt;
+    CHECK_FP(callbackp_uq_mtxt)
+    callbackp_uq_ok = params->callbackp_uq_ok;
+    CHECK_FP(callbackp_uq_ok)
+    callbackp_uq_file = params->callbackp_uq_file;
+    CHECK_FP(callbackp_uq_file)
+    callbackp_zmkdir = params->callbackp_zmkdir;
+    CHECK_FP(callbackp_zmkdir)
+    callbackp_ckmakxmsg = params->callbackp_ckmakxmsg;
+    CHECK_FP(callbackp_ckmakxmsg)
+    callbackp_whoami = params->callbackp_whoami;
+    CHECK_FP(callbackp_whoami)
+    callbackp_GetAppData = params->callbackp_GetAppData;
+    CHECK_FP(callbackp_GetAppData)
+    callbackp_GetHomePath = params->callbackp_GetHomePath;
+    CHECK_FP(callbackp_GetHomePath)
+    callbackp_GetHomeDrive = params->callbackp_GetHomeDrive;
+    CHECK_FP(callbackp_GetHomeDrive)
+    callbackp_ckstrncpy = params->callbackp_ckstrncpy;
+    CHECK_FP(callbackp_ckstrncpy)
+    callbackp_debug_logging = params->callbackp_debug_logging;
+    CHECK_FP(callbackp_debug_logging)
+    callbackp_get_display = params->callbackp_get_display;
+    CHECK_FP(callbackp_get_display)
+    callbackp_parse_displayname = params->callbackp_parse_displayname;
+    CHECK_FP(callbackp_parse_displayname)
 
-    params->p_install_funcs("ssh_set_iparam", ssh_set_iparam);
-    params->p_install_funcs("ssh_get_iparam", ssh_get_iparam);
-    params->p_install_funcs("ssh_set_sparam", ssh_set_sparam);
-    params->p_install_funcs("ssh_get_sparam", ssh_get_sparam);
-    params->p_install_funcs("ssh_set_identity_files", ssh_set_identity_files);
-    params->p_install_funcs("ssh_get_socket", ssh_get_socket);
-    params->p_install_funcs("ssh_open", ssh_open);
-    params->p_install_funcs("ssh_clos", ssh_clos);
-    params->p_install_funcs("ssh_tchk", ssh_tchk);
-    params->p_install_funcs("ssh_flui", ssh_flui);
-    params->p_install_funcs("ssh_break", ssh_break);
-    params->p_install_funcs("ssh_inc", ssh_inc);
-    params->p_install_funcs("ssh_xin", ssh_xin);
-    params->p_install_funcs("ssh_toc", ssh_toc);
-    params->p_install_funcs("ssh_tol", ssh_tol);
-    params->p_install_funcs("ssh_snaws", ssh_snaws);
-    params->p_install_funcs("ssh_proto_ver", ssh_proto_ver);
-    params->p_install_funcs("ssh_impl_ver", ssh_impl_ver);
-#ifdef COMMENT
+    params->callbackp_install_dllfunc("ssh_set_iparam", dllfunc_ssh_set_iparam);
+    params->callbackp_install_dllfunc("ssh_get_iparam", dllfunc_ssh_get_iparam);
+    params->callbackp_install_dllfunc("ssh_set_sparam", dllfunc_ssh_set_sparam);
+    params->callbackp_install_dllfunc("ssh_get_sparam", dllfunc_ssh_get_sparam);
+    params->callbackp_install_dllfunc("ssh_set_identity_files", dllfunc_ssh_set_identity_files);
+    params->callbackp_install_dllfunc("ssh_get_socket", dllfunc_ssh_get_socket);
+    params->callbackp_install_dllfunc("ssh_open", dllfunc_ssh_open);
+    params->callbackp_install_dllfunc("ssh_clos", dllfunc_ssh_clos);
+    params->callbackp_install_dllfunc("ssh_tchk", dllfunc_ssh_tchk);
+    params->callbackp_install_dllfunc("ssh_flui", dllfunc_ssh_flui);
+    params->callbackp_install_dllfunc("ssh_break", dllfunc_ssh_break);
+    params->callbackp_install_dllfunc("ssh_inc", dllfunc_ssh_inc);
+    params->callbackp_install_dllfunc("ssh_xin", dllfunc_ssh_xin);
+    params->callbackp_install_dllfunc("ssh_toc", dllfunc_ssh_toc);
+    params->callbackp_install_dllfunc("ssh_tol", dllfunc_ssh_tol);
+    params->callbackp_install_dllfunc("ssh_snaws", dllfunc_ssh_snaws);
+    params->callbackp_install_dllfunc("ssh_proto_ver", dllfunc_ssh_proto_ver);
+    params->callbackp_install_dllfunc("ssh_impl_ver", dllfunc_ssh_impl_ver);
+
     /* These functions are all optional */
-    params->p_install_funcs("sshkey_create", sshkey_create);
-    params->p_install_funcs("sshkey_display_fingerprint", sshkey_display_fingerprint);
-    params->p_install_funcs("sshkey_display_public", sshkey_display_public);
-    params->p_install_funcs("sshkey_display_public_as_ssh2", sshkey_display_public_as_ssh2);
-    params->p_install_funcs("sshkey_change_passphrase", sshkey_change_passphrase);
-    params->p_install_funcs("ssh_fwd_remote_port", ssh_fwd_remote_port);
-    params->p_install_funcs("ssh_fwd_local_port", ssh_fwd_local_port);
-    params->p_install_funcs("ssh_fwd_clear_remote_ports", ssh_fwd_clear_remote_ports);
-    params->p_install_funcs("ssh_fwd_clear_local_ports", ssh_fwd_clear_local_ports);
-    params->p_install_funcs("ssh_fwd_remove_remote_port", ssh_fwd_remove_remote_port);
-    params->p_install_funcs("ssh_fwd_remove_local_port", ssh_fwd_remove_local_port);
-    params->p_install_funcs("ssh_fwd_get_ports", ssh_fwd_get_ports);
+#ifdef COMMENT
+    params->callbackp_install_dllfunc("sshkey_create", dllfunc_sshkey_create);
+    params->callbackp_install_dllfunc("sshkey_display_fingerprint", dllfunc_sshkey_display_fingerprint);
+    params->callbackp_install_dllfunc("sshkey_display_public", dllfunc_sshkey_display_public);
+    params->callbackp_install_dllfunc("sshkey_display_public_as_ssh2", dllfunc_sshkey_display_public_as_ssh2);
+    params->callbackp_install_dllfunc("sshkey_change_passphrase", dllfunc_sshkey_change_passphrase);
+    params->callbackp_install_dllfunc("ssh_fwd_remote_port", dllfunc_ssh_fwd_remote_port);
+    params->callbackp_install_dllfunc("ssh_fwd_local_port", dllfunc_ssh_fwd_local_port);
+    params->callbackp_install_dllfunc("ssh_fwd_clear_remote_ports", dllfunc_ssh_fwd_clear_remote_ports);
+    params->callbackp_install_dllfunc("ssh_fwd_clear_local_ports", dllfunc_ssh_fwd_clear_local_ports);
+    params->callbackp_install_dllfunc("ssh_fwd_remove_remote_port", dllfunc_ssh_fwd_remove_remote_port);
+    params->callbackp_install_dllfunc("ssh_fwd_remove_local_port", dllfunc_ssh_fwd_remove_local_port);
+    params->callbackp_install_dllfunc("ssh_fwd_get_ports", dllfunc_ssh_fwd_get_ports);
 #ifdef SSHTEST
-    params->p_install_funcs("sshkey_v1_change_comment", sshkey_v1_change_comment);
-#endif
-    /* params->p_install_funcs("sshkey_default_file", sshkey_default_file); */
-    params->p_install_funcs("ssh_v2_rekey", ssh_v2_rekey);
-    params->p_install_funcs("ssh_agent_delete_file", ssh_agent_delete_file);
-    params->p_install_funcs("ssh_agent_delete_all", ssh_agent_delete_all);
-    params->p_install_funcs("ssh_agent_add_file", ssh_agent_add_file);
-    params->p_install_funcs("ssh_agent_list_identities", ssh_agent_list_identities);
-    params->p_install_funcs("ssh_unload", ssh_unload);
+    params->callbackp_install_dllfunc("sshkey_v1_change_comment", dllfunc_sshkey_v1_change_comment); /* TODO */
+#endif /* SSHTEST */
+#ifdef COMMENT
+    params->callbackp_install_dllfunc("sshkey_default_file", dllfunc_sshkey_default_file); */ /* TODO */
 #endif /* COMMENT */
-    params->p_install_funcs("ssh_dll_ver", ssh_dll_ver);
-    params->p_install_funcs("ssh_get_keytab", ssh_get_keytab);
-    params->p_install_funcs("ssh_feature_supported", ssh_feature_supported);
-    params->p_install_funcs("ssh_get_set_help", ssh_get_set_help);
-    params->p_install_funcs("ssh_get_help", ssh_get_help);
+    params->callbackp_install_dllfunc("ssh_v2_rekey", dllfunc_ssh_v2_rekey); /* TODO */
+    params->callbackp_install_dllfunc("ssh_agent_delete_file", dllfunc_ssh_agent_delete_file); /* TODO */
+    params->callbackp_install_dllfunc("ssh_agent_delete_all", dllfunc_ssh_agent_delete_all); /* TODO */
+    params->callbackp_install_dllfunc("ssh_agent_add_file", dllfunc_ssh_agent_add_file); /* TODO */
+    params->callbackp_install_dllfunc("ssh_agent_list_identities", dllfunc_ssh_agent_list_identities); /* TODO */
+#ifdef COMMENT
+    /* Not supported: */
+    params->callbackp_install_dllfunc("ssh_unload", dllfunc_ssh_unload);
+#endif /* COMMENT */
+#endif /* COMMENT */
+    params->callbackp_install_dllfunc("ssh_dll_ver", dllfunc_ssh_dll_ver);
+    params->callbackp_install_dllfunc("ssh_get_keytab", dllfunc_ssh_get_keytab);
+    params->callbackp_install_dllfunc("ssh_feature_supported", dllfunc_ssh_feature_supported);
+    params->callbackp_install_dllfunc("ssh_get_set_help", dllfunc_ssh_get_set_help);
+    params->callbackp_install_dllfunc("ssh_get_help", dllfunc_ssh_get_help);
 
     return 0;
 }
@@ -549,11 +865,7 @@ kstrdup(const char *str)
         memcpy(cp, str, len);
     return cp;
 }
-#else
-/* These live in ckossh.c */
-unsigned char* get_display();
-int parse_displayname(char *displayname, int *familyp, char **hostp,
-                      int *dpynump, int *scrnump, char **restp);
+
 #endif /* SSH_DLL */
 
 /** Sets an integer parameter
@@ -815,7 +1127,7 @@ int ssh_set_identity_files(const char** identity_files) {
  * @returns Socket for the current SSH connection, or -1 if not implemented or
  *      no active connection
  */
-int ssh_get_socket() {
+int ssh_get_socket(void) {
 
     /* If there is an active SSH session, this function should return its
      * socket. It's used by the various "set tcp" commands to set socket
@@ -833,7 +1145,7 @@ int ssh_get_socket() {
  * called on application startup to give the SSH subsystem an
  * opportunity to set sensible defaults, etc.
  */
-void ssh_initialise() {
+void ssh_initialise(void) {
 
 }
 
@@ -860,7 +1172,7 @@ static int message_length = 0, message_position = 0;
  *
  * @return An error code (0 = success)
  */
-int ssh_open(){
+int ssh_open(void){
     /* Reset the message to the start */
     message_length = strlen(message);
     message_position = 0;
@@ -887,7 +1199,7 @@ int ssh_open(){
  *
  * @return  0 on success, < 0 on failure.
  */
-int ssh_clos() {
+int ssh_clos(void) {
     return 0;
 }
 
@@ -898,7 +1210,7 @@ int ssh_clos() {
  * @return >= 0 indicates number of bytes waiting to be read
  *          < 0 indicates a fatal error and the connection should be closed.
  */
-int ssh_tchk() {
+int ssh_tchk(void) {
     /* Respond with how many characters are left in the message */
     return message_length - message_position;
 }
@@ -907,7 +1219,7 @@ int ssh_tchk() {
  *
  * @return 0 on success, < 0 on error
  */
-int ssh_flui() {
+int ssh_flui(void) {
     return 0;
 }
 
@@ -916,7 +1228,7 @@ int ssh_flui() {
  *
  * @return
  */
-int ssh_break() {
+int ssh_break(void) {
     return 0;
 }
 
@@ -999,7 +1311,7 @@ int ssh_tol(char * buffer, int count) {
  * and terminal type if these have changed.
  *
  */
-int ssh_snaws() {
+int ssh_snaws(void) {
     return 0;
 }
 
@@ -1081,7 +1393,7 @@ int ssh_fwd_remove_local_port(int port, BOOL apply);
  *
  * @returns List of forwarded ports, or NULL on error or empty list
  */
-const ssh_port_forward_t* ssh_fwd_get_ports() {
+const ssh_port_forward_t* ssh_fwd_get_ports(void) {
     return NULL;
 }
 
@@ -1142,11 +1454,11 @@ int sshkey_v1_change_comment(char * filename, char * comment, char * pp) {
 char * sshkey_default_file(int a) {
     return NULL; /* TODO */
 }
-#endif
+#endif /* COMMENT */
 
 /** Manually re-key the SSH connection
  */
-void ssh_v2_rekey() {
+void ssh_v2_rekey(void) {
 
 }
 
@@ -1154,7 +1466,7 @@ void ssh_v2_rekey() {
  *
  * @return Current protocol version (eg, "SSH-2.0")
  */
-const char * ssh_proto_ver() {
+const char * ssh_proto_ver(void) {
     return NULL;
 }
 
@@ -1163,7 +1475,7 @@ const char * ssh_proto_ver() {
  *
  * @return SSH implementation version
  */
-const char * ssh_impl_ver() {
+const char * ssh_impl_ver(void) {
     return "Null SSH";
 }
 
@@ -1171,7 +1483,7 @@ int ssh_agent_delete_file(const char *filename) {
     return 0;
 }
 
-int ssh_agent_delete_all() {
+int ssh_agent_delete_all(void) {
     return 0;
 }
 
@@ -1192,7 +1504,7 @@ int ssh_agent_list_identities(int do_fp) {
  *
  * @return
  */
-void ssh_unload() {
+void ssh_unload(void) {
 
 }
 
@@ -1201,7 +1513,7 @@ void ssh_unload() {
  *
  * @return
  */
-const char * ssh_dll_ver() {
+const char * ssh_dll_ver(void) {
     return "NULL SSH Subsystem (does nothing)";
 }
 
@@ -1287,7 +1599,7 @@ int ssh_feature_supported(int feature_id) {
  *
  * @return Help text for HELP SET SSH.
  */
-const char** ssh_get_set_help() {
+const char** ssh_get_set_help(void) {
 
     /*
      * TODO: Remove help text for any commands reported as not supported by
@@ -1515,7 +1827,7 @@ const char** ssh_get_set_help() {
  *
  * @return Help text for HELP SSH.
  */
-const char** ssh_get_help() {
+const char** ssh_get_help(void) {
 
     /*
      * TODO: Remove help text for any commands reported as not supported by

--- a/kermit/k95/ckossh.c
+++ b/kermit/k95/ckossh.c
@@ -73,7 +73,7 @@ extern int tcp_nodelay;                 /* Enable/disable Nagle's algorithm */
  *
  * @return Currently set username
  */
-const char* ssh_get_uid() {
+const char* ssh_get_uid(void) {
     return uidbuf;
 }
 
@@ -81,7 +81,7 @@ const char* ssh_get_uid() {
  *
  * @return Currently set password or NULL
  */
-const char* ssh_get_pw() {
+const char* ssh_get_pw(void) {
     return pwflg ? pwbuf : NULL;
 }
 
@@ -89,7 +89,7 @@ const char* ssh_get_pw() {
  *
  * @return True if nodelay is enabled, False otherwise
  */
-int ssh_get_nodelay_enabled() {
+int ssh_get_nodelay_enabled(void) {
 #ifdef TCP_NODELAY
     return tcp_nodelay;
 #else
@@ -120,7 +120,7 @@ void get_current_terminal_dimensions(int* rows, int* cols) {
  *
  * @return terminal type
  */
-const char* get_current_terminal_type() {
+const char* get_current_terminal_type(void) {
     static char term_type[64];
     extern int tt_type, max_tt;
     extern struct tt_info_rec tt_info[];
@@ -157,11 +157,11 @@ const char* get_current_terminal_type() {
  * @return True if debug logging is enabled, false otherwise.
  */
 inline
-int debug_logging() {
+int debug_logging(void) {
     return deblog;
 }
 
-unsigned char* get_display() {
+unsigned char* get_display(void) {
     return tn_get_display();
 }
 
@@ -197,102 +197,57 @@ SOCKET ssh_open_socket(char* host, char* port) {
 
 #include <stdlib.h>
 
-/* Typedefs for all the function pointers we *could* receive from an SSH
- * subsystem DLL */
-typedef int (CKSSHAPI * p_ssh_dll_init_t)(ssh_init_parameters_t *);
-typedef int (CKSSHAPI * p_ssh_set_iparam_t)(int, int);
-typedef int (CKSSHAPI * p_ssh_get_iparam_t)(int);
-typedef int (CKSSHAPI * p_ssh_set_sparam_t)(int, const char*);
-typedef const char* (CKSSHAPI * p_ssh_get_sparam_t)(int);
-typedef int (CKSSHAPI * p_ssh_set_identity_files_t)(const char**);
-typedef int (CKSSHAPI * p_ssh_get_socket_t)();
-typedef int (CKSSHAPI * p_ssh_open_t)();
-typedef int (CKSSHAPI * p_ssh_clos_t)();
-typedef int (CKSSHAPI * p_ssh_tchk_t)();
-typedef int (CKSSHAPI * p_ssh_flui_t)();
-typedef int (CKSSHAPI * p_ssh_break_t)();
-typedef int (CKSSHAPI * p_ssh_inc_t)(int);
-typedef int (CKSSHAPI * p_ssh_xin_t)(int, char*);
-typedef int (CKSSHAPI * p_ssh_toc_t)(int);
-typedef int (CKSSHAPI * p_ssh_tol_t)(char*,int);
-typedef int (CKSSHAPI * p_ssh_snaws_t)();
-typedef const char* (CKSSHAPI * p_ssh_proto_ver_t)();
-typedef const char* (CKSSHAPI * p_ssh_impl_ver_t)();
-typedef int (CKSSHAPI * p_sshkey_create_t)(char *, int, char *, int, char *);
-typedef int (CKSSHAPI * p_sshkey_display_fingerprint_t)(char *, int);
-typedef int (CKSSHAPI * p_sshkey_display_public_t)(char *, char *);
-typedef int (CKSSHAPI * p_sshkey_display_public_as_ssh2_t)(char *,char *);
-typedef int (CKSSHAPI * p_sshkey_change_passphrase_t)(char *, char *, char *);
-typedef int (CKSSHAPI * p_ssh_fwd_remote_port_t)(char*, int, char *, int, BOOL);
-typedef int (CKSSHAPI * p_ssh_fwd_local_port_t)(char*, int,char *,int, BOOL);
-typedef int (CKSSHAPI * p_ssh_fwd_clear_local_ports_t)(BOOL);
-typedef int (CKSSHAPI * p_ssh_fwd_clear_remote_ports_t)(BOOL);
-typedef int (CKSSHAPI * p_ssh_fwd_remove_remote_port_t)(int, BOOL);
-typedef int (CKSSHAPI * p_ssh_fwd_remove_local_port_t)(int, BOOL);
-typedef ssh_port_forward_t* (CKSSHAPI * p_ssh_fwd_get_ports_t)();
-#ifdef SSHTEST
-typedef int (CKSSHAPI * p_sshkey_v1_change_comment_t)(char *, char *, char *);
-#endif /* SSHTEST */
-/*typedef char * (*p_sshkey_default_file_t)(int);*/
-typedef void (CKSSHAPI * p_ssh_v2_rekey_t)();
-typedef int (CKSSHAPI * p_ssh_agent_delete_file_t)(const char *);
-typedef int (CKSSHAPI * p_ssh_agent_delete_all_t)();
-typedef int (CKSSHAPI * p_ssh_agent_add_file_t)(const char*);
-typedef int (CKSSHAPI * p_ssh_agent_list_identities_t)(int);
-typedef void (CKSSHAPI * p_ssh_unload_t)();
-typedef const char* (CKSSHAPI * p_ssh_dll_ver_t)();
-typedef ktab_ret (CKSSHAPI * p_ssh_get_keytab_t)(int keytab_id);
-typedef int (CKSSHAPI * p_ssh_feature_supported_t)(int feature_id);
-typedef const char** (CKSSHAPI *p_ssh_get_set_help_t)();
-typedef const char** (CKSSHAPI *p_ssh_get_help_t)();
+typedef int CKSSHDLLENTRY ssh_dll_init_dllentry(ssh_init_parameters_t *);
+static ssh_dll_init_dllentry *dllentryp_ssh_init = NULL;
 
 /* Function pointers received from the currently loaded SSH subsystem DLL */
-static p_ssh_dll_init_t p_ssh_init = NULL;
-static p_ssh_set_iparam_t p_ssh_set_iparam = NULL;
-static p_ssh_get_iparam_t p_ssh_get_iparam = NULL;
-static p_ssh_set_sparam_t p_ssh_set_sparam = NULL;
-static p_ssh_get_sparam_t p_ssh_get_sparam = NULL;
-static p_ssh_set_identity_files_t p_ssh_set_identity_files = NULL;
-static p_ssh_get_socket_t p_ssh_get_socket = NULL;
-static p_ssh_open_t p_ssh_open = NULL;
-static p_ssh_clos_t p_ssh_clos = NULL;
-static p_ssh_tchk_t p_ssh_tchk = NULL;
-static p_ssh_flui_t p_ssh_flui = NULL;
-static p_ssh_break_t p_ssh_break = NULL;
-static p_ssh_inc_t p_ssh_inc = NULL;
-static p_ssh_xin_t p_ssh_xin = NULL;
-static p_ssh_toc_t p_ssh_toc = NULL;
-static p_ssh_tol_t p_ssh_tol = NULL;
-static p_ssh_snaws_t p_ssh_snaws = NULL;
-static p_ssh_proto_ver_t p_ssh_proto_ver = NULL;
-static p_ssh_impl_ver_t p_ssh_impl_ver = NULL;
-static p_sshkey_create_t p_sshkey_create = NULL;
-static p_sshkey_display_fingerprint_t p_sshkey_display_fingerprint = NULL;
-static p_sshkey_display_public_t p_sshkey_display_public = NULL;
-static p_sshkey_display_public_as_ssh2_t p_sshkey_display_public_as_ssh2 = NULL;
-static p_sshkey_change_passphrase_t p_sshkey_change_passphrase = NULL;
-static p_ssh_fwd_remote_port_t p_ssh_fwd_remote_port = NULL;
-static p_ssh_fwd_local_port_t p_ssh_fwd_local_port = NULL;
-static p_ssh_fwd_clear_remote_ports_t p_ssh_fwd_clear_remote_ports = NULL;
-static p_ssh_fwd_clear_local_ports_t p_ssh_fwd_clear_local_ports = NULL;
-static p_ssh_fwd_remove_remote_port_t p_ssh_fwd_remove_remote_port = NULL;
-static p_ssh_fwd_remove_local_port_t p_ssh_fwd_remove_local_port = NULL;
-static p_ssh_fwd_get_ports_t p_ssh_fwd_get_ports = NULL;
+static ssh_set_iparam_dllfunc *dllfuncp_ssh_set_iparam = NULL;
+static ssh_get_iparam_dllfunc *dllfuncp_ssh_get_iparam = NULL;
+static ssh_set_sparam_dllfunc *dllfuncp_ssh_set_sparam = NULL;
+static ssh_get_sparam_dllfunc *dllfuncp_ssh_get_sparam = NULL;
+static ssh_set_identity_files_dllfunc *dllfuncp_ssh_set_identity_files = NULL;
+static ssh_get_socket_dllfunc *dllfuncp_ssh_get_socket = NULL;
+static ssh_open_dllfunc *dllfuncp_ssh_open = NULL;
+static ssh_clos_dllfunc *dllfuncp_ssh_clos = NULL;
+static ssh_tchk_dllfunc *dllfuncp_ssh_tchk = NULL;
+static ssh_flui_dllfunc *dllfuncp_ssh_flui = NULL;
+static ssh_break_dllfunc *dllfuncp_ssh_break = NULL;
+static ssh_inc_dllfunc *dllfuncp_ssh_inc = NULL;
+static ssh_xin_dllfunc *dllfuncp_ssh_xin = NULL;
+static ssh_toc_dllfunc *dllfuncp_ssh_toc = NULL;
+static ssh_tol_dllfunc *dllfuncp_ssh_tol = NULL;
+static ssh_snaws_dllfunc *dllfuncp_ssh_snaws = NULL;
+static ssh_proto_ver_dllfunc *dllfuncp_ssh_proto_ver = NULL;
+static ssh_impl_ver_dllfunc *dllfuncp_ssh_impl_ver = NULL;
+static sshkey_create_dllfunc *dllfuncp_sshkey_create = NULL;
+static sshkey_display_fingerprint_dllfunc *dllfuncp_sshkey_display_fingerprint = NULL;
+static sshkey_display_public_dllfunc *dllfuncp_sshkey_display_public = NULL;
+static sshkey_display_public_as_ssh2_dllfunc *dllfuncp_sshkey_display_public_as_ssh2 = NULL;
+static sshkey_change_passphrase_dllfunc *dllfuncp_sshkey_change_passphrase = NULL;
+static ssh_fwd_remote_port_dllfunc *dllfuncp_ssh_fwd_remote_port = NULL;
+static ssh_fwd_local_port_dllfunc *dllfuncp_ssh_fwd_local_port = NULL;
+static ssh_fwd_clear_remote_ports_dllfunc *dllfuncp_ssh_fwd_clear_remote_ports = NULL;
+static ssh_fwd_clear_local_ports_dllfunc *dllfuncp_ssh_fwd_clear_local_ports = NULL;
+static ssh_fwd_remove_remote_port_dllfunc *dllfuncp_ssh_fwd_remove_remote_port = NULL;
+static ssh_fwd_remove_local_port_dllfunc *dllfuncp_ssh_fwd_remove_local_port = NULL;
+static ssh_fwd_get_ports_dllfunc *dllfuncp_ssh_fwd_get_ports = NULL;
 #ifdef SSHTEST
-static p_sshkey_v1_change_comment_t p_sshkey_v1_change_comment = NULL;  /* TODO */
+static sshkey_v1_change_comment_dllfunc *dllfuncp_sshkey_v1_change_comment = NULL;  /* TODO */
 #endif /* SSHTEST */
-/*static p_sshkey_default_file_t p_sshkey_default_file = NULL;*/ /* TODO */
-static p_ssh_v2_rekey_t p_ssh_v2_rekey = NULL;  /* TODO */
-static p_ssh_agent_delete_file_t p_ssh_agent_delete_file = NULL;    /* TODO */
-static p_ssh_agent_delete_all_t p_ssh_agent_delete_all = NULL;  /* TODO */
-static p_ssh_agent_add_file_t p_ssh_agent_add_file = NULL;  /* TODO */
-static p_ssh_agent_list_identities_t p_ssh_agent_list_identities = NULL;    /* TODO */
-static p_ssh_unload_t p_ssh_unload = NULL;
-static p_ssh_dll_ver_t p_ssh_dll_ver = NULL;
-static p_ssh_get_keytab_t p_ssh_get_keytab = NULL;
-static p_ssh_feature_supported_t p_ssh_feature_supported = NULL;
-static p_ssh_get_set_help_t p_ssh_get_set_help = NULL;
-static p_ssh_get_help_t p_ssh_get_help = NULL;
+#if 0
+static sshkey_default_file_dllfunc *dllfuncp_sshkey_default_file = NULL; /* TODO */
+#endif
+static ssh_v2_rekey_dllfunc *dllfuncp_ssh_v2_rekey = NULL;  /* TODO */
+static ssh_agent_delete_file_dllfunc *dllfuncp_ssh_agent_delete_file = NULL;    /* TODO */
+static ssh_agent_delete_all_dllfunc *dllfuncp_ssh_agent_delete_all = NULL;  /* TODO */
+static ssh_agent_add_file_dllfunc *dllfuncp_ssh_agent_add_file = NULL;  /* TODO */
+static ssh_agent_list_identities_dllfunc *dllfuncp_ssh_agent_list_identities = NULL;    /* TODO */
+static ssh_unload_dllfunc *dllfuncp_ssh_unload = NULL;
+static ssh_dll_ver_dllfunc *dllfuncp_ssh_dll_ver = NULL;
+static ssh_get_keytab_dllfunc *dllfuncp_ssh_get_keytab = NULL;
+static ssh_feature_supported_dllfunc *dllfuncp_ssh_feature_supported = NULL;
+static ssh_get_set_help_dllfunc *dllfuncp_ssh_get_set_help = NULL;
+static ssh_get_help_dllfunc *dllfuncp_ssh_get_help = NULL;
 
 /* If a subsystem has been successfully loaded and initialised or not */
 int ssh_subsystem_loaded = FALSE;
@@ -309,103 +264,253 @@ static HINSTANCE hSSH;
 static HMODULE hSSH;
 #endif
 
+#ifdef SSH_DLL_CALLCONV
+
+/* define prototypes for callback functions */
+static ssh_get_uid_callback callback_ssh_get_uid;
+static ssh_get_pw_callback callback_ssh_get_pw;
+static ssh_get_nodelay_enabled_callback callback_ssh_get_nodelay_enabled;
+static get_current_terminal_dimensions_callback callback_get_current_terminal_dimensions;
+static get_current_terminal_type_callback callback_get_current_terminal_type;
+static get_display_callback callback_get_display;
+static parse_displayname_callback callback_parse_displayname;
+static vscrnprintf_callback callback_vscrnprintf;
+static ckstrncpy_callback callback_ckstrncpy;
+static ssh_open_socket_callback callback_ssh_open_socket;
+static dodebug_callback callback_dodebug;
+static uq_txt_callback callback_uq_txt;
+static uq_mtxt_callback callback_uq_mtxt;
+static uq_ok_callback callback_uq_ok;
+static uq_file_callback callback_uq_file;
+static GetAppData_callback callback_GetAppData;
+static GetHomePath_callback callback_GetHomePath;
+static GetHomeDrive_callback callback_GetHomeDrive;
+static whoami_callback callback_whoami;
+static zmkdir_callback callback_zmkdir;
+static ckmakxmsg_callback callback_ckmakxmsg;
+static debug_logging_callback callback_debug_logging;
+
+static const char* CKSSHAPI callback_ssh_get_uid(void) {
+    return ssh_get_uid();
+}
+
+static const char* CKSSHAPI callback_ssh_get_pw(void) {
+    return ssh_get_pw();
+}
+
+static int CKSSHAPI callback_ssh_get_nodelay_enabled(void) {
+    return ssh_get_nodelay_enabled();
+}
+
+static void CKSSHAPI callback_get_current_terminal_dimensions(int* rows, int* cols) {
+    get_current_terminal_dimensions(rows, cols);
+}
+
+static const char* CKSSHAPI callback_get_current_terminal_type(void) {
+    return( get_current_terminal_type() );
+}
+
+static unsigned char* CKSSHAPI callback_get_display(void) {
+    return get_display();
+}
+
+static int CKSSHAPI callback_parse_displayname(char *displayname, int *familyp, char **hostp,
+                      int *dpynump, int *scrnump, char **restp) {
+    return parse_displayname(displayname, familyp, hostp,
+                                  dpynump, scrnump, restp);
+}
+
+static int CKSSHAPI callback_vscrnprintf(const char *str)
+{
+    return( Vscrnprintf(str) );
+}
+
+static int CKSSHAPI callback_ckstrncpy(char * dest, const char * src, int len)
+{
+    return( ckstrncpy(dest, src, len) );
+}
+
+static SOCKET CKSSHAPI callback_ssh_open_socket(char* host, char* port) {
+    return ssh_open_socket(host, port);
+}
+
+static int CKSSHAPI callback_dodebug(int flag, char * s1, char * s2, CK_OFF_T n)
+{
+    return( dodebug(flag, s1, s2, n) );
+}
+
+static int CKSSHAPI callback_uq_txt(char * preface, char * prompt, int echo, char ** help, char * buf,
+       int buflen, char *dflt, int timer) {
+    return uq_txt(preface, prompt, echo, help, buf, buflen, dflt, timer);
+}
+
+static int CKSSHAPI callback_uq_mtxt(char * preface,char **help, int n, struct txtbox field[]) {
+    return uq_mtxt(preface, help, n, field);
+}
+
+static int CKSSHAPI callback_uq_ok(char * preface, char * prompt, int mask,char ** help, int dflt) {
+    return uq_ok(preface, prompt, mask, help, dflt);
+}
+
+static int CKSSHAPI callback_uq_file(char * preface, char * fprompt, int fc, char ** help,
+        char * dflt, char * result, int rlength) {
+    return uq_file(preface, fprompt, fc, help, dflt, result, rlength);
+}
+
+static char* CKSSHAPI callback_GetAppData(int common) {
+    return GetAppData(common);
+}
+
+static char* CKSSHAPI callback_GetHomePath(void) {
+    return GetHomePath();
+}
+
+static char* CKSSHAPI callback_GetHomeDrive(void) {
+    return GetHomeDrive();
+}
+
+static char* CKSSHAPI callback_whoami(void) {
+    return whoami();
+}
+
+static int CKSSHAPI callback_zmkdir(char *path) {
+    return zmkdir(path);
+}
+
+static int CKSSHAPI callback_ckmakxmsg(char * buf, int len, char *s1, char *s2, char *s3,
+        char *s4, char *s5, char *s6, char *s7, char *s8, char *s9,
+        char *s10, char *s11, char *s12) {
+    return ckmakxmsg(buf, len, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12);
+}
+
+static int CKSSHAPI callback_debug_logging(void) {
+    return debug_logging();
+}
+
+#else /* SSH_DLL_CALLCONV */
+
+#define callback_ssh_get_uid                ssh_get_uid
+#define callback_ssh_get_pw                 ssh_get_pw
+#define callback_ssh_get_nodelay_enabled    ssh_get_nodelay_enabled
+#define callback_get_current_terminal_dimensions    get_current_terminal_dimensions
+#define callback_get_current_terminal_type  get_current_terminal_type
+#define callback_get_display                get_display
+#define callback_parse_displayname          parse_displayname
+#define callback_vscrnprintf                Vscrnprintf
+#define callback_ckstrncpy                  ckstrncpy
+#define callback_ssh_open_socket            ssh_open_socket
+#define callback_dodebug                    dodebug
+#define callback_uq_txt                     uq_txt
+#define callback_uq_mtxt                    uq_mtxt
+#define callback_uq_ok                      uq_ok
+#define callback_uq_file                    uq_file
+#define callback_GetAppData                 GetAppData
+#define callback_GetHomePath                GetHomePath
+#define callback_GetHomeDrive               GetHomeDrive
+#define callback_whoami                     whoami
+#define callback_zmkdir                     zmkdir
+#define callback_ckmakxmsg                  ckmakxmsg
+#define callback_debug_logging              debug_logging
+
+#endif /* SSH_DLL_CALLCONV */
+
 /** Called by the loaded SSH subsystem DLL to supply pointers to all of the
  * various fucntions it supports. Some functions are optional, others are not.
  *
  * @param function - Name of the function
  * @param p_function - Pointer to the function
  */
-void ssh_install_func(const char* function, const void* p_function) {
+static void CKSSHAPI callback_install_dllfunc(const char* function, const void* p_function) {
     debug(F110, "ssh_install_func", function, 0);
 
     if ( !strcmp(function,"ssh_set_iparam") )
-        p_ssh_set_iparam = F_CAST(p_ssh_set_iparam_t) p_function;
+        dllfuncp_ssh_set_iparam = F_CAST(ssh_set_iparam_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_get_iparam") )
-        p_ssh_get_iparam = F_CAST(p_ssh_get_iparam_t) p_function;
+        dllfuncp_ssh_get_iparam = F_CAST(ssh_get_iparam_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_set_sparam") )
-        p_ssh_set_sparam = F_CAST(p_ssh_set_sparam_t) p_function;
+        dllfuncp_ssh_set_sparam = F_CAST(ssh_set_sparam_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_get_sparam") )
-        p_ssh_get_sparam = F_CAST(p_ssh_get_sparam_t) p_function;
+        dllfuncp_ssh_get_sparam = F_CAST(ssh_get_sparam_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_set_identity_files") )
-        p_ssh_set_identity_files = F_CAST(p_ssh_set_identity_files_t) p_function;
+        dllfuncp_ssh_set_identity_files = F_CAST(ssh_set_identity_files_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_get_socket") )
-        p_ssh_get_socket = F_CAST(p_ssh_get_socket_t) p_function;
+        dllfuncp_ssh_get_socket = F_CAST(ssh_get_socket_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_open") )
-        p_ssh_open = F_CAST(p_ssh_open_t) p_function;
+        dllfuncp_ssh_open = F_CAST(ssh_open_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_clos") )
-        p_ssh_clos = F_CAST(p_ssh_clos_t) p_function;
+        dllfuncp_ssh_clos = F_CAST(ssh_clos_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_tchk") )
-        p_ssh_tchk = F_CAST(p_ssh_tchk_t) p_function;
+        dllfuncp_ssh_tchk = F_CAST(ssh_tchk_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_flui") )
-        p_ssh_flui = F_CAST(p_ssh_flui_t) p_function;
+        dllfuncp_ssh_flui = F_CAST(ssh_flui_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_break") )
-        p_ssh_break = F_CAST(p_ssh_break_t) p_function;
+        dllfuncp_ssh_break = F_CAST(ssh_break_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_inc") )
-        p_ssh_inc = F_CAST(p_ssh_inc_t) p_function;
+        dllfuncp_ssh_inc = F_CAST(ssh_inc_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_xin") )
-        p_ssh_xin = F_CAST(p_ssh_xin_t) p_function;
+        dllfuncp_ssh_xin = F_CAST(ssh_xin_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_toc") )
-        p_ssh_toc = F_CAST(p_ssh_toc_t) p_function;
+        dllfuncp_ssh_toc = F_CAST(ssh_toc_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_tol") )
-        p_ssh_tol = F_CAST(p_ssh_tol_t) p_function;
+        dllfuncp_ssh_tol = F_CAST(ssh_tol_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_snaws") )
-        p_ssh_snaws = F_CAST(p_ssh_snaws_t) p_function;
+        dllfuncp_ssh_snaws = F_CAST(ssh_snaws_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_proto_ver") )
-        p_ssh_proto_ver = F_CAST(p_ssh_proto_ver_t) p_function;
+        dllfuncp_ssh_proto_ver = F_CAST(ssh_proto_ver_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_impl_ver") )
-        p_ssh_impl_ver = F_CAST(p_ssh_impl_ver_t) p_function;
+        dllfuncp_ssh_impl_ver = F_CAST(ssh_impl_ver_dllfunc *)p_function;
     else if ( !strcmp(function,"sshkey_create") )
-        p_sshkey_create = F_CAST(p_sshkey_create_t) p_function;
+        dllfuncp_sshkey_create = F_CAST(sshkey_create_dllfunc *)p_function;
     else if ( !strcmp(function,"sshkey_display_fingerprint") )
-        p_sshkey_display_fingerprint = F_CAST(p_sshkey_display_fingerprint_t) p_function;
+        dllfuncp_sshkey_display_fingerprint = F_CAST(sshkey_display_fingerprint_dllfunc *)p_function;
     else if ( !strcmp(function,"sshkey_display_public") )
-        p_sshkey_display_public = F_CAST(p_sshkey_display_public_t) p_function;
+        dllfuncp_sshkey_display_public = F_CAST(sshkey_display_public_dllfunc *)p_function;
     else if ( !strcmp(function,"sshkey_display_public_as_ssh2") )
-        p_sshkey_display_public_as_ssh2 = F_CAST(p_sshkey_display_public_as_ssh2_t) p_function;
+        dllfuncp_sshkey_display_public_as_ssh2 = F_CAST(sshkey_display_public_as_ssh2_dllfunc *)p_function;
     else if ( !strcmp(function,"sshkey_change_passphrase") )
-        p_sshkey_change_passphrase = F_CAST(p_sshkey_change_passphrase_t) p_function;
+        dllfuncp_sshkey_change_passphrase = F_CAST(sshkey_change_passphrase_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_fwd_remote_port") )
-        p_ssh_fwd_remote_port = F_CAST(p_ssh_fwd_remote_port_t) p_function;
+        dllfuncp_ssh_fwd_remote_port = F_CAST(ssh_fwd_remote_port_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_fwd_local_port") )
-        p_ssh_fwd_local_port = F_CAST(p_ssh_fwd_local_port_t) p_function;
+        dllfuncp_ssh_fwd_local_port = F_CAST(ssh_fwd_local_port_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_fwd_clear_remote_ports") )
-        p_ssh_fwd_clear_remote_ports = F_CAST(p_ssh_fwd_clear_remote_ports_t) p_function;
+        dllfuncp_ssh_fwd_clear_remote_ports = F_CAST(ssh_fwd_clear_remote_ports_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_fwd_clear_local_ports") )
-        p_ssh_fwd_clear_local_ports = F_CAST(p_ssh_fwd_clear_local_ports_t) p_function;
+        dllfuncp_ssh_fwd_clear_local_ports = F_CAST(ssh_fwd_clear_local_ports_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_fwd_remove_remote_port") )
-        p_ssh_fwd_remove_remote_port = F_CAST(p_ssh_fwd_remove_remote_port_t) p_function;
+        dllfuncp_ssh_fwd_remove_remote_port = F_CAST(ssh_fwd_remove_remote_port_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_fwd_remove_local_port") )
-        p_ssh_fwd_remove_local_port = F_CAST(p_ssh_fwd_remove_local_port_t) p_function;
+        dllfuncp_ssh_fwd_remove_local_port = F_CAST(ssh_fwd_remove_local_port_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_fwd_get_ports") )
-        p_ssh_fwd_get_ports = F_CAST(p_ssh_fwd_get_ports_t) p_function;
+        dllfuncp_ssh_fwd_get_ports = F_CAST(ssh_fwd_get_ports_dllfunc *)p_function;
 #ifdef SSHTEST
     else if ( !strcmp(function,"sshkey_v1_change_comment") )
-        p_sshkey_v1_change_comment = F_CAST(p_sshkey_v1_change_comment_t) p_function;
+        dllfuncp_sshkey_v1_change_comment = F_CAST(sshkey_v1_change_comment_dllfunc *)p_function;
 #endif /* SSHTEST */
     /*else if ( !strcmp(function,"sshkey_default_file") )
-        p_sshkey_default_file = (p_sshkey_default_file_t) p_function;*/
+        dllfuncp_sshkey_default_file = (sshkey_default_file_dllfunc *)p_function;*/
     else if ( !strcmp(function,"ssh_v2_rekey") )
-        p_ssh_v2_rekey = F_CAST(p_ssh_v2_rekey_t) p_function;
+        dllfuncp_ssh_v2_rekey = F_CAST(ssh_v2_rekey_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_agent_delete_file") )
-        p_ssh_agent_delete_file = F_CAST(p_ssh_agent_delete_file_t) p_function;
+        dllfuncp_ssh_agent_delete_file = F_CAST(ssh_agent_delete_file_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_agent_delete_all") )
-        p_ssh_agent_delete_all = F_CAST(p_ssh_agent_delete_all_t) p_function;
+        dllfuncp_ssh_agent_delete_all = F_CAST(ssh_agent_delete_all_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_agent_add_file") )
-        p_ssh_agent_add_file = F_CAST(p_ssh_agent_add_file_t) p_function;
+        dllfuncp_ssh_agent_add_file = F_CAST(ssh_agent_add_file_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_agent_list_identities") )
-        p_ssh_agent_list_identities = F_CAST(p_ssh_agent_list_identities_t) p_function;
+        dllfuncp_ssh_agent_list_identities = F_CAST(ssh_agent_list_identities_dllfunc *)p_function;
     else if ( !strcmp(function,"ssh_unload") )
-        p_ssh_unload = F_CAST(p_ssh_unload_t) p_function;
+        dllfuncp_ssh_unload = F_CAST(ssh_unload_dllfunc *)p_function;
     else if (!strcmp(function,"ssh_dll_ver"))
-        p_ssh_dll_ver = F_CAST(p_ssh_dll_ver_t) p_function;
+        dllfuncp_ssh_dll_ver = F_CAST(ssh_dll_ver_dllfunc *)p_function;
     else if (!strcmp(function,"ssh_get_keytab"))
-        p_ssh_get_keytab = F_CAST(p_ssh_get_keytab_t) p_function;
+        dllfuncp_ssh_get_keytab = F_CAST(ssh_get_keytab_dllfunc *)p_function;
     else if (!strcmp(function,"ssh_feature_supported"))
-        p_ssh_feature_supported = F_CAST(p_ssh_feature_supported_t) p_function;
+        dllfuncp_ssh_feature_supported = F_CAST(ssh_feature_supported_dllfunc *)p_function;
     else if (!strcmp(function,"ssh_get_set_help"))
-        p_ssh_get_set_help = F_CAST(p_ssh_get_set_help_t) p_function;
+        dllfuncp_ssh_get_set_help = F_CAST(ssh_get_set_help_dllfunc *)p_function;
     else if (!strcmp(function,"ssh_get_help"))
-        p_ssh_get_help = F_CAST(p_ssh_get_help_t) p_function;
+        dllfuncp_ssh_get_help = F_CAST(ssh_get_help_dllfunc *)p_function;
 }
 
 /** Attempts to load and initialise a particular SSH subsystem DLL
@@ -431,8 +536,8 @@ int ssh_load(char* dllname) {
         debug(F111, "K95 SSH LoadLibrary failed", dllname, rc);
         return -1;
     } else {
-        p_ssh_init = (p_ssh_dll_init_t)GetProcAddress(hSSH, "ssh_dll_init");
-        if (p_ssh_init == NULL) {
+        dllentryp_ssh_init = F_CAST(ssh_dll_init_dllentry *)GetProcAddress(hSSH, "ssh_dll_init");
+        if (dllentryp_ssh_init == NULL) {
             rc = GetLastError();
             debug(F111, "K95 SSH GetProcAddress for ssh_dll_init failed", dllname, rc);
             FreeLibrary(hSSH);
@@ -456,7 +561,7 @@ int ssh_load(char* dllname) {
         return -1;
     } else {
         debug(F111, "K95 SSH LoadLibrary success",fail,rc) ;
-        if (rc = DosQueryProcAddr(hSSH,0,"ssh_dll_init",(PFN*)&p_ssh_init))
+        if (rc = DosQueryProcAddr(hSSH,0,"ssh_dll_init",(PFN*)&dllentryp_ssh_init))
         {
             debug(F111,"K95 SSH GetProcAddress for ssh_dll_init failed", dllname, rc);
             DosFreeModule(hSSH);
@@ -467,33 +572,33 @@ int ssh_load(char* dllname) {
 
     /* SSH DLL loaded successfully! Prepare init params! */
     init_params.version = 1;
-    init_params.p_install_funcs = ssh_install_func;
-    init_params.p_get_current_terminal_dimensions = get_current_terminal_dimensions;
-    init_params.p_get_current_terminal_type = get_current_terminal_type;
-    init_params.p_ssh_get_uid = ssh_get_uid;
-    init_params.p_ssh_get_pw = ssh_get_pw;
-    init_params.p_ssh_get_nodelay_enabled = ssh_get_nodelay_enabled;
-    init_params.p_ssh_open_socket = ssh_open_socket;
-    init_params.p_dodebug = dodebug;
-    init_params.p_vscrnprintf = Vscrnprintf;
-    init_params.p_uq_txt = uq_txt;
-    init_params.p_uq_mtxt = uq_mtxt;
-    init_params.p_uq_ok = uq_ok;
-    init_params.p_uq_file = uq_file;
-    init_params.p_zmkdir = zmkdir;
-    init_params.p_ckmakxmsg = ckmakxmsg;
-    init_params.p_whoami = whoami;
-    init_params.p_GetAppData = GetAppData;
-    init_params.p_GetHomePath = GetHomePath;
-    init_params.p_GetHomeDrive = GetHomeDrive;
-    init_params.p_ckstrncpy = ckstrncpy;
-    init_params.p_debug_logging = debug_logging;
-    init_params.p_get_display = tn_get_display;                  /* ckctel.c */
-    init_params.p_parse_displayname = fwdx_parse_displayname;    /* ckctel.c */
+    init_params.callbackp_install_dllfunc = callback_install_dllfunc;
+    init_params.callbackp_get_current_terminal_dimensions = callback_get_current_terminal_dimensions;
+    init_params.callbackp_get_current_terminal_type = callback_get_current_terminal_type;
+    init_params.callbackp_ssh_get_uid = callback_ssh_get_uid;
+    init_params.callbackp_ssh_get_pw = callback_ssh_get_pw;
+    init_params.callbackp_ssh_get_nodelay_enabled = callback_ssh_get_nodelay_enabled;
+    init_params.callbackp_ssh_open_socket = callback_ssh_open_socket;
+    init_params.callbackp_dodebug = callback_dodebug;
+    init_params.callbackp_vscrnprintf = callback_vscrnprintf;
+    init_params.callbackp_uq_txt = callback_uq_txt;
+    init_params.callbackp_uq_mtxt = callback_uq_mtxt;
+    init_params.callbackp_uq_ok = callback_uq_ok;
+    init_params.callbackp_uq_file = callback_uq_file;
+    init_params.callbackp_zmkdir = callback_zmkdir;
+    init_params.callbackp_ckmakxmsg = callback_ckmakxmsg;
+    init_params.callbackp_whoami = callback_whoami;
+    init_params.callbackp_GetAppData = callback_GetAppData;
+    init_params.callbackp_GetHomePath = callback_GetHomePath;
+    init_params.callbackp_GetHomeDrive = callback_GetHomeDrive;
+    init_params.callbackp_ckstrncpy = callback_ckstrncpy;
+    init_params.callbackp_debug_logging = callback_debug_logging;
+    init_params.callbackp_get_display = callback_get_display;
+    init_params.callbackp_parse_displayname = callback_parse_displayname;
 
     /* Initialise! */
     debug(F100, "Call ssh_dll_init()", NULL, 0);
-    rc = p_ssh_init(&init_params);
+    rc = dllentryp_ssh_init(&init_params);
 
     /* TODO: Check all mandatory functions are available */
 
@@ -524,55 +629,56 @@ int ssh_dll_unload(int quiet) {
     /* TODO: Kill any active SSH connection. Then perhaps make this an
      *       invisible command: "ssh unload" */
 
-    if (p_ssh_unload) {
-        p_ssh_unload();
+    if (dllfuncp_ssh_unload) {
+        dllfuncp_ssh_unload();
     }
 
     ssh_subsystem_loaded = FALSE;
 
-    p_ssh_init = NULL;
-    p_ssh_set_iparam = NULL;
-    p_ssh_get_iparam = NULL;
-    p_ssh_set_sparam = NULL;
-    p_ssh_get_sparam = NULL;
-    p_ssh_set_identity_files = NULL;
-    p_ssh_get_socket = NULL;
-    p_ssh_open = NULL;
-    p_ssh_clos = NULL;
-    p_ssh_tchk = NULL;
-    p_ssh_flui = NULL;
-    p_ssh_break = NULL;
-    p_ssh_inc = NULL;
-    p_ssh_xin = NULL;
-    p_ssh_toc = NULL;
-    p_ssh_tol = NULL;
-    p_ssh_snaws = NULL;
-    p_ssh_proto_ver = NULL;
-    p_ssh_impl_ver = NULL;
-    p_sshkey_create = NULL;
-    p_sshkey_display_fingerprint = NULL;
-    p_sshkey_display_public = NULL;
-    p_sshkey_display_public_as_ssh2 = NULL;
-    p_sshkey_change_passphrase = NULL;
-    p_ssh_fwd_remote_port = NULL;
-    p_ssh_fwd_local_port = NULL;
-    p_ssh_fwd_clear_remote_ports = NULL;
-    p_ssh_fwd_clear_local_ports = NULL;
-    p_ssh_fwd_remove_remote_port = NULL;
-    p_ssh_fwd_remove_local_port = NULL;
-    p_ssh_fwd_get_ports = NULL;
+    dllentryp_ssh_init = NULL;
+
+    dllfuncp_ssh_set_iparam = NULL;
+    dllfuncp_ssh_get_iparam = NULL;
+    dllfuncp_ssh_set_sparam = NULL;
+    dllfuncp_ssh_get_sparam = NULL;
+    dllfuncp_ssh_set_identity_files = NULL;
+    dllfuncp_ssh_get_socket = NULL;
+    dllfuncp_ssh_open = NULL;
+    dllfuncp_ssh_clos = NULL;
+    dllfuncp_ssh_tchk = NULL;
+    dllfuncp_ssh_flui = NULL;
+    dllfuncp_ssh_break = NULL;
+    dllfuncp_ssh_inc = NULL;
+    dllfuncp_ssh_xin = NULL;
+    dllfuncp_ssh_toc = NULL;
+    dllfuncp_ssh_tol = NULL;
+    dllfuncp_ssh_snaws = NULL;
+    dllfuncp_ssh_proto_ver = NULL;
+    dllfuncp_ssh_impl_ver = NULL;
+    dllfuncp_sshkey_create = NULL;
+    dllfuncp_sshkey_display_fingerprint = NULL;
+    dllfuncp_sshkey_display_public = NULL;
+    dllfuncp_sshkey_display_public_as_ssh2 = NULL;
+    dllfuncp_sshkey_change_passphrase = NULL;
+    dllfuncp_ssh_fwd_remote_port = NULL;
+    dllfuncp_ssh_fwd_local_port = NULL;
+    dllfuncp_ssh_fwd_clear_remote_ports = NULL;
+    dllfuncp_ssh_fwd_clear_local_ports = NULL;
+    dllfuncp_ssh_fwd_remove_remote_port = NULL;
+    dllfuncp_ssh_fwd_remove_local_port = NULL;
+    dllfuncp_ssh_fwd_get_ports = NULL;
 #ifdef SSHTEST
-    p_sshkey_v1_change_comment = NULL;  /* TODO */
+    dllfuncp_sshkey_v1_change_comment = NULL;  /* TODO */
 #endif /* SSHTEST */
-    /*  p_sshkey_default_file = NULL;*/ /* TODO */
-    p_ssh_v2_rekey = NULL;  /* TODO */
-    p_ssh_agent_delete_file = NULL;    /* TODO */
-    p_ssh_agent_delete_all = NULL;  /* TODO */
-    p_ssh_agent_add_file = NULL;  /* TODO */
-    p_ssh_agent_list_identities = NULL;    /* TODO */
-    p_ssh_unload = NULL;
-    p_ssh_get_set_help = NULL;
-    p_ssh_get_help = NULL;
+    /*  dllfuncp_sshkey_default_file = NULL;*/ /* TODO */
+    dllfuncp_ssh_v2_rekey = NULL;  /* TODO */
+    dllfuncp_ssh_agent_delete_file = NULL;    /* TODO */
+    dllfuncp_ssh_agent_delete_all = NULL;  /* TODO */
+    dllfuncp_ssh_agent_add_file = NULL;  /* TODO */
+    dllfuncp_ssh_agent_list_identities = NULL;    /* TODO */
+    dllfuncp_ssh_unload = NULL;
+    dllfuncp_ssh_get_set_help = NULL;
+    dllfuncp_ssh_get_help = NULL;
 
     #ifdef NT
     FreeLibrary(hSSH);
@@ -636,7 +742,7 @@ int ssh_dll_load(const char* dll_names, int quiet) {
  * has been loaded and initialised)
  * @return True if SSH commands are available
  */
-int ssh_avail() {
+int ssh_avail(void) {
     return ssh_subsystem_loaded;
 }
 
@@ -644,7 +750,7 @@ int ssh_avail() {
  *
  * @return SSH DLL filename
  */
-const char* ssh_dll_name() {
+const char* ssh_dll_name(void) {
     if (ssh_avail())
         return dll_name;
     return NULL;
@@ -654,15 +760,15 @@ const char* ssh_dll_name() {
  *
  * @return SSH DLL version
  */
-const char* ssh_dll_ver() {
-    if (p_ssh_dll_ver)
-        return p_ssh_dll_ver();
+const char* ssh_dll_ver(void) {
+    if (dllfuncp_ssh_dll_ver)
+        return dllfuncp_ssh_dll_ver();
     return NULL;
 }
 
 int ssh_set_iparam(int param, int value) {
-    if (p_ssh_set_iparam)
-        return p_ssh_set_iparam(param, value);
+    if (dllfuncp_ssh_set_iparam)
+        return dllfuncp_ssh_set_iparam(param, value);
 
     /* ERROR - this function is mandatory */
 
@@ -671,8 +777,8 @@ int ssh_set_iparam(int param, int value) {
 
 
 int ssh_get_iparam(int param) {
-    if (p_ssh_get_iparam)
-        return p_ssh_get_iparam(param);
+    if (dllfuncp_ssh_get_iparam)
+        return dllfuncp_ssh_get_iparam(param);
 
     /* These are the default values for the various settings in K95 2.1.3 */
     switch(param) {
@@ -706,8 +812,8 @@ int ssh_get_iparam(int param) {
 }
 
 int ssh_set_sparam(int param, const char* value) {
-    if (p_ssh_set_sparam)
-        return p_ssh_set_sparam(param, value);
+    if (dllfuncp_ssh_set_sparam)
+        return dllfuncp_ssh_set_sparam(param, value);
 
     /* ERROR - this function is mandatory */
 
@@ -715,8 +821,8 @@ int ssh_set_sparam(int param, const char* value) {
 }
 
 const char* ssh_get_sparam(int param) {
-    if (p_ssh_get_sparam)
-        return p_ssh_get_sparam(param);
+    if (dllfuncp_ssh_get_sparam)
+        return dllfuncp_ssh_get_sparam(param);
 
     return NULL;
 }
@@ -725,8 +831,8 @@ const char* ssh_get_sparam(int param) {
  * @param identity_files The list of identity file names, null terminated.
  */
 int ssh_set_identity_files(const char** identity_files) {
-    if (p_ssh_set_identity_files)
-        return p_ssh_set_identity_files(identity_files);
+    if (dllfuncp_ssh_set_identity_files)
+        return dllfuncp_ssh_set_identity_files(identity_files);
     return -1;
 }
 
@@ -735,9 +841,9 @@ int ssh_set_identity_files(const char** identity_files) {
  * @returns Socket for the current SSH connection, or -1 if not implemented or
  *      no active connection
  */
-int ssh_get_socket() {
-    if (p_ssh_get_socket)
-        return p_ssh_get_socket();
+int ssh_get_socket(void) {
+    if (dllfuncp_ssh_get_socket)
+        return dllfuncp_ssh_get_socket();
     return -1;
 }
 
@@ -746,9 +852,9 @@ int ssh_get_socket() {
  *
  * @return An error code (0 = success)
  */
-int ssh_open(){
-    if (p_ssh_open)
-        return p_ssh_open();
+int ssh_open(void){
+    if (dllfuncp_ssh_open)
+        return dllfuncp_ssh_open();
 
     /* ERROR - this function is mandatory. This should never happen.
      * Mark SSH as unavailable.*/
@@ -761,9 +867,9 @@ int ssh_open(){
  *
  * @return  0 on success, < 0 on failure.
  */
-int ssh_clos() {
-    if (p_ssh_clos)
-        return p_ssh_clos();
+int ssh_clos(void) {
+    if (dllfuncp_ssh_clos)
+        return dllfuncp_ssh_clos();
 
     /* ERROR - this function is mandatory. This should never happen.
      * Mark SSH as unavailable.*/
@@ -779,9 +885,9 @@ int ssh_clos() {
  * @return >= 0 indicates number of bytes waiting to be read
  *          < 0 indicates a fatal error and the connection should be closed.
  */
-int ssh_tchk() {
-    if (p_ssh_tchk)
-        return p_ssh_tchk();
+int ssh_tchk(void) {
+    if (dllfuncp_ssh_tchk)
+        return dllfuncp_ssh_tchk();
 
     /* ERROR - this function is mandatory. This should never happen.
      * Mark SSH as unavailable.*/
@@ -794,9 +900,9 @@ int ssh_tchk() {
  *
  * @return 0 on success, < 0 on error
  */
-int ssh_flui() {
-    if (p_ssh_flui)
-        return p_ssh_flui();
+int ssh_flui(void) {
+    if (dllfuncp_ssh_flui)
+        return dllfuncp_ssh_flui();
 
     /* ERROR - this function is mandatory. This should never happen.
      * Mark SSH as unavailable.*/
@@ -810,9 +916,9 @@ int ssh_flui() {
  *
  * @return
  */
-int ssh_break() {
-   if (p_ssh_break)
-        return p_ssh_break();
+int ssh_break(void) {
+   if (dllfuncp_ssh_break)
+        return dllfuncp_ssh_break();
 
     /* ERROR - this function is mandatory. This should never happen.
      * Mark SSH as unavailable.*/
@@ -828,8 +934,8 @@ int ssh_break() {
  * @return -1 for timeout, >= 0 is a valid character, < -1 is a fatal error
  */
 int ssh_inc(int timeout) {
-    if (p_ssh_inc)
-        return p_ssh_inc(timeout);
+    if (dllfuncp_ssh_inc)
+        return dllfuncp_ssh_inc(timeout);
 
     /* ERROR - this function is mandatory. This should never happen.
      * Mark SSH as unavailable.*/
@@ -849,8 +955,8 @@ int ssh_inc(int timeout) {
  * @return >= 0 indicates the number of characters read, < 0 indicates error
  */
 int ssh_xin(int count, char * buffer) {
-    if (p_ssh_xin)
-        return p_ssh_xin(count, buffer);
+    if (dllfuncp_ssh_xin)
+        return dllfuncp_ssh_xin(count, buffer);
 
     /* ERROR - this function is mandatory. This should never happen.
      * Mark SSH as unavailable.*/
@@ -866,8 +972,8 @@ int ssh_xin(int count, char * buffer) {
  * @return 0 for success, <0 for error
  */
 int ssh_toc(int c) {
-    if (p_ssh_toc)
-        return p_ssh_toc(c);
+    if (dllfuncp_ssh_toc)
+        return dllfuncp_ssh_toc(c);
 
     /* ERROR - this function is mandatory. This should never happen.
      * Mark SSH as unavailable.*/
@@ -883,8 +989,8 @@ int ssh_toc(int c) {
  * @return  >= 0 for number of characters sent, <0 for a fatal error.
  */
 int ssh_tol(char * buffer, int count) {
-    if (p_ssh_tol)
-        return p_ssh_tol(buffer, count);
+    if (dllfuncp_ssh_tol)
+        return dllfuncp_ssh_tol(buffer, count);
 
     /* ERROR - this function is mandatory. This should never happen.
      * Mark SSH as unavailable.*/
@@ -897,9 +1003,9 @@ int ssh_tol(char * buffer, int count) {
  * and terminal type if these have changed.
  *
  */
-int ssh_snaws() {
-    if (p_ssh_snaws)
-        return p_ssh_snaws();
+int ssh_snaws(void) {
+    if (dllfuncp_ssh_snaws)
+        return dllfuncp_ssh_snaws();
 
     /* ERROR - this function is mandatory. This should never happen.
      * Mark SSH as unavailable.*/
@@ -922,8 +1028,8 @@ int ssh_snaws() {
  * @returns 0 on success
  */
 int ssh_fwd_remote_port(char* address, int port, char * host, int host_port, BOOL apply) {
-    if (p_ssh_fwd_remote_port)
-        return p_ssh_fwd_remote_port(address, port, host, host_port, apply);
+    if (dllfuncp_ssh_fwd_remote_port)
+        return dllfuncp_ssh_fwd_remote_port(address, port, host, host_port, apply);
 
     /* optional feature not available */
 
@@ -944,8 +1050,8 @@ int ssh_fwd_remote_port(char* address, int port, char * host, int host_port, BOO
  * @returns 0 on success
  */
 int ssh_fwd_local_port(char* address, int port, char *host, int host_port, BOOL apply) {
-    if (p_ssh_fwd_local_port)
-        return p_ssh_fwd_local_port(address, port, host, host_port, apply);
+    if (dllfuncp_ssh_fwd_local_port)
+        return dllfuncp_ssh_fwd_local_port(address, port, host, host_port, apply);
 
     /* optional feature not available */
 
@@ -958,8 +1064,8 @@ int ssh_fwd_local_port(char* address, int port, char *host, int host_port, BOOL 
  * @returns 0 on success
  */
 int ssh_fwd_clear_remote_ports(BOOL apply) {
-    if (p_ssh_fwd_clear_remote_ports)
-        return p_ssh_fwd_clear_remote_ports(apply);
+    if (dllfuncp_ssh_fwd_clear_remote_ports)
+        return dllfuncp_ssh_fwd_clear_remote_ports(apply);
 
     /* optional feature not available */
 
@@ -972,8 +1078,8 @@ int ssh_fwd_clear_remote_ports(BOOL apply) {
  * @returns 0 on success
  */
 int ssh_fwd_clear_local_ports(BOOL apply) {
-    if (p_ssh_fwd_clear_local_ports)
-        return p_ssh_fwd_clear_local_ports(apply);
+    if (dllfuncp_ssh_fwd_clear_local_ports)
+        return dllfuncp_ssh_fwd_clear_local_ports(apply);
 
     /* optional feature not available */
 
@@ -988,8 +1094,8 @@ int ssh_fwd_clear_local_ports(BOOL apply) {
  * @return 0 on success
  */
 int ssh_fwd_remove_remote_port(int port, BOOL apply) {
-        if (p_ssh_fwd_remove_remote_port)
-        return p_ssh_fwd_remove_remote_port(port, apply);
+        if (dllfuncp_ssh_fwd_remove_remote_port)
+        return dllfuncp_ssh_fwd_remove_remote_port(port, apply);
 
     /* optional feature not available */
 
@@ -1004,8 +1110,8 @@ int ssh_fwd_remove_remote_port(int port, BOOL apply) {
  * @return 0 on success
  */
 int ssh_fwd_remove_local_port(int port, BOOL apply) {
-    if (p_ssh_fwd_remove_local_port)
-        return p_ssh_fwd_remove_local_port(port, apply);
+    if (dllfuncp_ssh_fwd_remove_local_port)
+        return dllfuncp_ssh_fwd_remove_local_port(port, apply);
 
     /* optional feature not available */
 
@@ -1017,9 +1123,9 @@ int ssh_fwd_remove_local_port(int port, BOOL apply) {
  *
  * @returns List of forwarded ports, or NULL on error or empty list
  */
-const ssh_port_forward_t* ssh_fwd_get_ports() {
-    if (p_ssh_fwd_get_ports)
-        return p_ssh_fwd_get_ports();
+const ssh_port_forward_t* ssh_fwd_get_ports(void) {
+    if (dllfuncp_ssh_fwd_get_ports)
+        return dllfuncp_ssh_fwd_get_ports();
 
     /* optional feature not available */
 
@@ -1037,8 +1143,8 @@ const ssh_port_forward_t* ssh_fwd_get_ports() {
  */
 int sshkey_create(char * filename, int bits, char *pp, int type,
                   char *cmd_comment) {
-    if (p_sshkey_create)
-        return p_sshkey_create(filename, bits, pp, type, cmd_comment);
+    if (dllfuncp_sshkey_create)
+        return dllfuncp_sshkey_create(filename, bits, pp, type, cmd_comment);
 
     /* optional feature not available */
 
@@ -1053,8 +1159,8 @@ int sshkey_create(char * filename, int bits, char *pp, int type,
  * @return 0
  */
 int sshkey_display_fingerprint(char * filename, int babble) {
-    if (p_sshkey_display_fingerprint)
-        return p_sshkey_display_fingerprint(filename, babble);
+    if (dllfuncp_sshkey_display_fingerprint)
+        return dllfuncp_sshkey_display_fingerprint(filename, babble);
 
     /* optional feature not available */
 
@@ -1067,8 +1173,8 @@ int sshkey_display_fingerprint(char * filename, int babble) {
  * @param passphrase key passphrase - will be prompted if not specified
  */
 int sshkey_display_public(char * filename, char *identity_passphrase) {
-    if (p_sshkey_display_public)
-        return p_sshkey_display_public(filename, identity_passphrase);
+    if (dllfuncp_sshkey_display_public)
+        return dllfuncp_sshkey_display_public(filename, identity_passphrase);
 
     /* optional feature not available */
 
@@ -1081,8 +1187,8 @@ int sshkey_display_public(char * filename, char *identity_passphrase) {
  * @param identity_passphrase key passphrase - will be prompted if not specified
  */
 int sshkey_display_public_as_ssh2(char * filename,char *identity_passphrase) {
-    if (p_sshkey_display_public_as_ssh2)
-        return p_sshkey_display_public_as_ssh2(filename, identity_passphrase);
+    if (dllfuncp_sshkey_display_public_as_ssh2)
+        return dllfuncp_sshkey_display_public_as_ssh2(filename, identity_passphrase);
 
     /* optional feature not available */
 
@@ -1090,8 +1196,8 @@ int sshkey_display_public_as_ssh2(char * filename,char *identity_passphrase) {
 }
 
 int sshkey_change_passphrase(char * filename, char * oldpp, char * newpp) {
-    if (p_sshkey_change_passphrase)
-        return p_sshkey_change_passphrase(filename, oldpp, newpp);
+    if (dllfuncp_sshkey_change_passphrase)
+        return dllfuncp_sshkey_change_passphrase(filename, oldpp, newpp);
 
     /* optional feature not available */
 
@@ -1100,8 +1206,8 @@ int sshkey_change_passphrase(char * filename, char * oldpp, char * newpp) {
 
 #ifdef SSHTEST
 int sshkey_v1_change_comment(char * filename, char * comment, char * pp) {
-    if (p_sshkey_v1_change_comment)
-        return p_sshkey_v1_change_comment(filename, comment, pp);
+    if (dllfuncp_sshkey_v1_change_comment)
+        return dllfuncp_sshkey_v1_change_comment(filename, comment, pp);
 
     /* optional feature not available */
 
@@ -1115,9 +1221,9 @@ char * sshkey_default_file(int a) {
 }
 #endif
 
-void ssh_v2_rekey() {
-    if (p_ssh_v2_rekey)
-        p_ssh_v2_rekey();
+void ssh_v2_rekey(void) {
+    if (dllfuncp_ssh_v2_rekey)
+        dllfuncp_ssh_v2_rekey();
 
     /* optional feature not available */
 }
@@ -1126,9 +1232,9 @@ void ssh_v2_rekey() {
  *
  * @return Current protocol version (eg, "SSH-2.0")
  */
-const char * ssh_proto_ver() {
-    if (p_ssh_proto_ver)
-        return p_ssh_proto_ver();
+const char * ssh_proto_ver(void) {
+    if (dllfuncp_ssh_proto_ver)
+        return dllfuncp_ssh_proto_ver();
 
     return NULL;
 }
@@ -1136,25 +1242,25 @@ const char * ssh_proto_ver() {
 /** Return the current SSH backend/implementation version.
  * @return SSH backend/implementation version
  */
-const char * ssh_impl_ver() {
-    if (p_ssh_impl_ver)
-        return p_ssh_impl_ver();
+const char * ssh_impl_ver(void) {
+    if (dllfuncp_ssh_impl_ver)
+        return dllfuncp_ssh_impl_ver();
 
     return NULL;
 }
 
 int ssh_agent_delete_file(const char *filename) {
-    if (p_ssh_agent_delete_file)
-        return p_ssh_agent_delete_file(filename);
+    if (dllfuncp_ssh_agent_delete_file)
+        return dllfuncp_ssh_agent_delete_file(filename);
 
     /* optional feature not available */
 
     return -1;
 }
 
-int ssh_agent_delete_all() {
-    if (p_ssh_agent_delete_all)
-        return p_ssh_agent_delete_all();
+int ssh_agent_delete_all(void) {
+    if (dllfuncp_ssh_agent_delete_all)
+        return dllfuncp_ssh_agent_delete_all();
 
     /* optional feature not available */
 
@@ -1162,8 +1268,8 @@ int ssh_agent_delete_all() {
 }
 
 int ssh_agent_add_file (const char *filename) {
-    if (p_ssh_agent_add_file)
-        return p_ssh_agent_add_file(filename);
+    if (dllfuncp_ssh_agent_add_file)
+        return dllfuncp_ssh_agent_add_file(filename);
 
     /* optional feature not available */
 
@@ -1171,8 +1277,8 @@ int ssh_agent_add_file (const char *filename) {
 }
 
 int ssh_agent_list_identities(int do_fp) {
-    if (p_ssh_agent_list_identities)
-        return p_ssh_agent_list_identities(do_fp);
+    if (dllfuncp_ssh_agent_list_identities)
+        return dllfuncp_ssh_agent_list_identities(do_fp);
 
     /* optional feature not available */
 
@@ -1185,8 +1291,8 @@ int ssh_agent_list_identities(int do_fp) {
  * @return the requested keyword table
  */
 ktab_ret ssh_get_keytab(int keytab_id) {
-    if (p_ssh_get_keytab)
-        return p_ssh_get_keytab(keytab_id);
+    if (dllfuncp_ssh_get_keytab)
+        return dllfuncp_ssh_get_keytab(keytab_id);
 
     /* ERROR - this function is mandatory. This should never happen.
      * Mark SSH as unavailable.*/
@@ -1207,19 +1313,19 @@ ktab_ret ssh_get_keytab(int keytab_id) {
  * @return TRUE if the feature is supported, or FALSE if it is not
  */
 int ssh_feature_supported(int feature_id) {
-    if (p_ssh_feature_supported)
-        return p_ssh_feature_supported(feature_id);
+    if (dllfuncp_ssh_feature_supported)
+        return dllfuncp_ssh_feature_supported(feature_id);
     return FALSE; /* No features supported! */
 }
 
-const char** ssh_get_set_help() {
+const char** ssh_get_set_help(void) {
     const char** result;
     static const char *hmxyssh[] = {
 "No help content for SET SSH was provided by the currently loaded SSH backend.",
 ""
 };
-    if (p_ssh_get_set_help)
-        result = p_ssh_get_set_help();
+    if (dllfuncp_ssh_get_set_help)
+        result = dllfuncp_ssh_get_set_help();
 
     if (result != NULL)
         return result;
@@ -1227,14 +1333,14 @@ const char** ssh_get_set_help() {
     return hmxyssh;
 }
 
-const char** ssh_get_help() {
+const char** ssh_get_help(void) {
     const char** result;
     static const char *hmxyssh[] = {
 "No help content for SSH was provided by the currently loaded SSH backend.",
 ""
 };
-    if (p_ssh_get_help)
-        result = p_ssh_get_help();
+    if (dllfuncp_ssh_get_help)
+        result = dllfuncp_ssh_get_help();
 
     if (result != NULL)
         return result;

--- a/kermit/k95/ckossh.h
+++ b/kermit/k95/ckossh.h
@@ -1,16 +1,6 @@
 #ifndef _CKOSSH_H
 #define _CKOSSH_H
 
-#ifdef NT
-#define CKSSHAPI
-#else /* NT */
-#ifdef OS2
-#define CKSSHAPI	_System
-#else /* OS2 */
-#define CKSSHAPI
-#endif /* OS2 */
-#endif /* NT */
-
 #ifndef SSH_PF_T
 #define SSH_PF_T
 /* Note: This also exists in ckolsshs.h */
@@ -105,17 +95,16 @@ _PROTOTYP(int ssh_get_iparam,(int param));
 _PROTOTYP(int ssh_set_sparam,(int param, const char* value));
 _PROTOTYP(const char* ssh_get_sparam,(int param));
 _PROTOTYP(int ssh_set_identity_files,(const char** identity_files));
-_PROTOTYP(int ssh_get_socket,());
+_PROTOTYP(int ssh_get_socket,(VOID));
 
 /* Getters for various global values within C-Kermit */
 _PROTOTYP(const char* ssh_get_uid,(VOID));
 _PROTOTYP(const char* ssh_get_pw,(VOID));
 _PROTOTYP(int ssh_get_nodelay_enabled,(VOID));
 _PROTOTYP(void get_current_terminal_dimensions,(int*,int*));
-_PROTOTYP(const char* get_current_terminal_type,());
+_PROTOTYP(const char* get_current_terminal_type,(VOID));
 
 /* SSH Interface */
-_PROTOTYP(int ssh_open,(VOID));
 _PROTOTYP(int ssh_open,(VOID));
 _PROTOTYP(int ssh_clos,(VOID));
 _PROTOTYP(int ssh_tchk,(VOID));
@@ -125,7 +114,7 @@ _PROTOTYP(int ssh_inc,(int));
 _PROTOTYP(int ssh_xin,(int,char *));
 _PROTOTYP(int ssh_toc,(int));
 _PROTOTYP(int ssh_tol,(char *,int));
-_PROTOTYP(int ssh_snaws, (void));
+_PROTOTYP(int ssh_snaws, (VOID));
 
 /* SSH Key management */
 _PROTOTYP(int sshkey_create,(char * filename, int bits, char * pp,
@@ -142,30 +131,29 @@ _PROTOTYP(int ssh_fwd_clear_remote_ports,(BOOL apply));
 _PROTOTYP(int ssh_fwd_clear_local_ports,(BOOL apply));
 _PROTOTYP(int ssh_fwd_remove_remote_port,(int port, BOOL apply));
 _PROTOTYP(int ssh_fwd_remove_local_port,(int port, BOOL apply));
-_PROTOTYP(const ssh_port_forward_t* ssh_fwd_get_ports,());
+_PROTOTYP(const ssh_port_forward_t* ssh_fwd_get_ports,(VOID));
 
 #ifdef SSHTEST
 _PROTOTYP(int sshkey_v1_change_comment,(char * filename, char * comment, char * pp));
 #endif /* SSHTEST */
 /*_PROTOTYP(char * sshkey_default_file,(int));*/
-_PROTOTYP(void ssh_v2_rekey,(void));
+_PROTOTYP(void ssh_v2_rekey,(VOID));
 
 /* SSH Agent */
 _PROTOTYP(int ssh_agent_delete_file,(const char *filename));
-_PROTOTYP(int ssh_agent_delete_all, (void));
+_PROTOTYP(int ssh_agent_delete_all, (VOID));
 _PROTOTYP(int ssh_agent_add_file, (const char *filename));
 _PROTOTYP(int ssh_agent_list_identities,(int do_fp));
 
 /* Information */
-_PROTOTYP(const char * ssh_proto_ver,(void));
-_PROTOTYP(const char * ssh_impl_ver,(void));
-_PROTOTYP(const char * ssh_dll_name,(void));
-_PROTOTYP(const char * ssh_dll_ver,(void));
-/*_PROTOTYP(int ssh_avail,(void));*/
-int ssh_avail();
+_PROTOTYP(const char * ssh_proto_ver,(VOID));
+_PROTOTYP(const char * ssh_impl_ver,(VOID));
+_PROTOTYP(const char * ssh_dll_name,(VOID));
+_PROTOTYP(const char * ssh_dll_ver,(VOID));
+_PROTOTYP(int ssh_avail,(VOID));
 _PROTOTYP(void ssh_unload,(VOID));
-_PROTOTYP(const char ** ssh_get_set_help,(void));
-_PROTOTYP(const char ** ssh_get_help,(void));
+_PROTOTYP(const char ** ssh_get_set_help,(VOID));
+_PROTOTYP(const char ** ssh_get_help,(VOID));
 
 typedef struct {
     int rc;
@@ -203,10 +191,7 @@ _PROTOTYP(ktab_ret ssh_get_keytab,(int keytab_id));
 
 _PROTOTYP(int ssh_feature_supported,(int feature_id));
 
-
-#ifndef SSH_DLL
-_PROTOTYP(void ssh_initialise,(void));
-#endif
+_PROTOTYP(void ssh_initialise,(VOID));
 
 #ifndef SOCKET
 /* On OS/2, SOCKET is just int. */
@@ -217,38 +202,88 @@ _PROTOTYP(void ssh_initialise,(void));
 #endif /* INVALID_SOCKET */
 
 #ifdef SSH_DLL
+
+/*
+ * below is setup of calling convention used between Kermit and SSH DLL
+ *
+ * 64-bit Windows use calling convention defined by ABI (default)
+ * 32-bit systems has not specified ABI therefore it can use any
+ * for all 32-bit systems it uses cdecl for better interoperatibility
+ * now you can use DLL created by any compiler togather with application
+ * compiled by another compiler
+ * only two symbols are exported from DLL
+ * ssh_dll_init and ssh_impl_ver
+ */
+#ifndef _WIN64
+#define SSH_DLL_CALLCONV    cdecl
+#endif /* _WIN64 */
+
+#ifdef SSH_DLL_CALLCONV
+#define CKSSHAPI            SSH_DLL_CALLCONV
+#define CKSSHDLLENTRY       SSH_DLL_CALLCONV
+#else
+#define CKSSHAPI
+#define CKSSHDLLENTRY
+#endif /* CKSSHAPI */
+
+/* prototypes for all callback function provided by Kermit */
+typedef void CKSSHAPI install_dllfunc_callback(const char*, const void*);
+typedef void CKSSHAPI get_current_terminal_dimensions_callback(int* rows, int* cols);
+typedef const char* CKSSHAPI get_current_terminal_type_callback(void);
+typedef const char* CKSSHAPI ssh_get_uid_callback(void);
+typedef const char* CKSSHAPI ssh_get_pw_callback(void);
+typedef int CKSSHAPI ssh_get_nodelay_enabled_callback(void);
+typedef SOCKET CKSSHAPI ssh_open_socket_callback(char* host, char* port);
+typedef int CKSSHAPI dodebug_callback(int,char *,char *,CK_OFF_T);
+typedef int CKSSHAPI vscrnprintf_callback(const char *str);
+typedef int CKSSHAPI uq_txt_callback(char *,char *,int,char **,char *,int,char *,int);
+typedef int CKSSHAPI uq_mtxt_callback(char *,char **,int,struct txtbox[]);
+typedef int CKSSHAPI uq_ok_callback(char *,char *,int,char **,int);
+typedef int CKSSHAPI uq_file_callback(char *,char *,int,char **,char *,char *,int);
+typedef int CKSSHAPI zmkdir_callback(char *);
+typedef int CKSSHAPI ckmakxmsg_callback(char * buf, int len, char *s1, char *s2, char *s3,
+            char *s4, char *s5, char *s6, char *s7, char *s8, char *s9,
+            char *s10, char *s11, char *s12);
+typedef char* CKSSHAPI whoami_callback(void);
+typedef char* CKSSHAPI GetAppData_callback(int);
+typedef char* CKSSHAPI GetHomePath_callback(void);
+typedef char* CKSSHAPI GetHomeDrive_callback(void);
+typedef int CKSSHAPI ckstrncpy_callback(char * dest, const char * src, int len);
+typedef int CKSSHAPI debug_logging_callback(void);
+typedef unsigned char* CKSSHAPI get_display_callback(void);
+typedef int CKSSHAPI parse_displayname_callback(char *displayname, int *familyp,
+            char **hostp, int *dpynump, int *scrnump, char **restp);
+
 typedef struct  {
 
     /* Version 1 */
     int version;
-    void (* CKSSHAPI p_install_funcs)(const char*, const void*);
-    void (* CKSSHAPI p_get_current_terminal_dimensions)(int* rows, int* cols);
-    const char* (* CKSSHAPI p_get_current_terminal_type)();
-    const char* (* CKSSHAPI p_ssh_get_uid)();
-    const char* (* CKSSHAPI p_ssh_get_pw)();
-    int (* CKSSHAPI p_ssh_get_nodelay_enabled)();
-    SOCKET (* CKSSHAPI p_ssh_open_socket)(char* host, char* port);
-    int (* CKSSHAPI p_dodebug)(int,char *,char *,CK_OFF_T);
-    int (* CKSSHAPI p_vscrnprintf)(const char *, ...);
-    int (* CKSSHAPI p_uq_txt)(char *,char *,int,char **,char *,int,char *,int);
-    int (* CKSSHAPI p_uq_mtxt) (char *,char **,int,struct txtbox[]);
-    int (* CKSSHAPI p_uq_ok)(char *,char *,int,char **,int);
-    int (* CKSSHAPI p_uq_file)(char *,char *,int,char **,char *,char *,int);
-	int (* CKSSHAPI p_zmkdir)(char *);
-	int (* CKSSHAPI p_ckmakxmsg)(char * buf, int len, char *s1, char *s2, char *s3,
-            char *s4, char *s5, char *s6, char *s7, char *s8, char *s9,
-            char *s10, char *s11, char *s12);
-	char* (* CKSSHAPI p_whoami)();
-    char* (* CKSSHAPI p_GetAppData)(int);
-	char* (* CKSSHAPI p_GetHomePath)();
-	char* (* CKSSHAPI p_GetHomeDrive)();
-    int (* CKSSHAPI p_ckstrncpy)(char * dest, const char * src, int len);
-    int (* CKSSHAPI p_debug_logging)();
+    install_dllfunc_callback *callbackp_install_dllfunc;
+    get_current_terminal_dimensions_callback *callbackp_get_current_terminal_dimensions;
+    get_current_terminal_type_callback *callbackp_get_current_terminal_type;
+    ssh_get_uid_callback *callbackp_ssh_get_uid;
+    ssh_get_pw_callback *callbackp_ssh_get_pw;
+    ssh_get_nodelay_enabled_callback *callbackp_ssh_get_nodelay_enabled;
+    ssh_open_socket_callback *callbackp_ssh_open_socket;
+    dodebug_callback *callbackp_dodebug;
+    vscrnprintf_callback *callbackp_vscrnprintf;
+    uq_txt_callback *callbackp_uq_txt;
+    uq_mtxt_callback *callbackp_uq_mtxt;
+    uq_ok_callback *callbackp_uq_ok;
+    uq_file_callback *callbackp_uq_file;
+    zmkdir_callback *callbackp_zmkdir;
+    ckmakxmsg_callback *callbackp_ckmakxmsg;
+    whoami_callback *callbackp_whoami;
+    GetAppData_callback *callbackp_GetAppData;
+    GetHomePath_callback *callbackp_GetHomePath;
+    GetHomeDrive_callback *callbackp_GetHomeDrive;
+    ckstrncpy_callback *callbackp_ckstrncpy;
+    debug_logging_callback *callbackp_debug_logging;
 
     /* Returns a statically allocated string containing the currently
      * configured X11 display
      */
-    unsigned char* (* CKSSHAPI p_get_display)();
+    get_display_callback *callbackp_get_display;
 
     /* Utility function for parsing the display name. Result is returned
      * via:
@@ -258,9 +293,53 @@ typedef struct  {
      *   *scrnump   - Screen number
      *   **restp    - Anything else at the end
      */
-    int (* CKSSHAPI p_parse_displayname)(char *displayname, int *familyp,
-            char **hostp, int *dpynump, int *scrnump, char **restp);
+    parse_displayname_callback *callbackp_parse_displayname;
 } ssh_init_parameters_t;
+
+/* prototypes for all functions provided by DLL */
+typedef int CKSSHAPI ssh_set_iparam_dllfunc(int, int);
+typedef int CKSSHAPI ssh_get_iparam_dllfunc(int);
+typedef int CKSSHAPI ssh_set_sparam_dllfunc(int, const char*);
+typedef const char* CKSSHAPI ssh_get_sparam_dllfunc(int);
+typedef int CKSSHAPI ssh_set_identity_files_dllfunc(const char**);
+typedef int CKSSHAPI ssh_get_socket_dllfunc(void);
+typedef int CKSSHAPI ssh_open_dllfunc(void);
+typedef int CKSSHAPI ssh_clos_dllfunc(void);
+typedef int CKSSHAPI ssh_tchk_dllfunc(void);
+typedef int CKSSHAPI ssh_flui_dllfunc(void);
+typedef int CKSSHAPI ssh_break_dllfunc(void);
+typedef int CKSSHAPI ssh_inc_dllfunc(int);
+typedef int CKSSHAPI ssh_xin_dllfunc(int, char*);
+typedef int CKSSHAPI ssh_toc_dllfunc(int);
+typedef int CKSSHAPI ssh_tol_dllfunc(char*,int);
+typedef int CKSSHAPI ssh_snaws_dllfunc(void);
+typedef const char* CKSSHAPI ssh_proto_ver_dllfunc(void);
+typedef const char* CKSSHAPI ssh_impl_ver_dllfunc(void);
+typedef int CKSSHAPI sshkey_create_dllfunc(char *, int, char *, int, char *);
+typedef int CKSSHAPI sshkey_display_fingerprint_dllfunc(char *, int);
+typedef int CKSSHAPI sshkey_display_public_dllfunc(char *, char *);
+typedef int CKSSHAPI sshkey_display_public_as_ssh2_dllfunc(char *,char *);
+typedef int CKSSHAPI sshkey_change_passphrase_dllfunc(char *, char *, char *);
+typedef int CKSSHAPI ssh_fwd_remote_port_dllfunc(char*, int, char *, int, BOOL);
+typedef int CKSSHAPI ssh_fwd_local_port_dllfunc(char*, int,char *,int, BOOL);
+typedef int CKSSHAPI ssh_fwd_clear_local_ports_dllfunc(BOOL);
+typedef int CKSSHAPI ssh_fwd_clear_remote_ports_dllfunc(BOOL);
+typedef int CKSSHAPI ssh_fwd_remove_remote_port_dllfunc(int, BOOL);
+typedef int CKSSHAPI ssh_fwd_remove_local_port_dllfunc(int, BOOL);
+typedef const ssh_port_forward_t* CKSSHAPI ssh_fwd_get_ports_dllfunc(void);
+typedef int CKSSHAPI sshkey_v1_change_comment_dllfunc(char *, char *, char *);
+typedef char * CKSSHAPI sshkey_default_file_dllfunc(int);
+typedef void CKSSHAPI ssh_v2_rekey_dllfunc(void);
+typedef int CKSSHAPI ssh_agent_delete_file_dllfunc(const char *);
+typedef int CKSSHAPI ssh_agent_delete_all_dllfunc(void);
+typedef int CKSSHAPI ssh_agent_add_file_dllfunc(const char*);
+typedef int CKSSHAPI ssh_agent_list_identities_dllfunc(int);
+typedef void CKSSHAPI ssh_unload_dllfunc(void);
+typedef const char* CKSSHAPI ssh_dll_ver_dllfunc(void);
+typedef ktab_ret CKSSHAPI ssh_get_keytab_dllfunc(int keytab_id);
+typedef int CKSSHAPI ssh_feature_supported_dllfunc(int feature_id);
+typedef const char** CKSSHAPI ssh_get_set_help_dllfunc(void);
+typedef const char** CKSSHAPI ssh_get_help_dllfunc(void);
 
 /*
  *  k95sshg.dll     libssh + gssapi (kerberos).
@@ -271,8 +350,8 @@ typedef struct  {
  */
 #define SSH_AUTO_DLLS "k95sshg.dll;k95ssh.dll;k95sshgx.dll;k95sshx.dll;k95plink.dll"
 
-_PROTOTYP(int ssh_dll_load,(const char* dll_names, int quiet));
-_PROTOTYP(int ssh_dll_unload,(int quiet));
+extern int ssh_dll_load(const char* dll_names, int quiet);
+extern int ssh_dll_unload(int quiet);
 
 #endif /* SSH_DLL */
 

--- a/kermit/k95/k95ssh.def
+++ b/kermit/k95/k95ssh.def
@@ -1,4 +1,3 @@
 LIBRARY K95SSH
 EXPORTS
   ssh_dll_init
-  ssh_impl_ver

--- a/kermit/k95/nullssh.def
+++ b/kermit/k95/nullssh.def
@@ -1,4 +1,3 @@
 LIBRARY NULLSSH
 EXPORTS
   ssh_dll_init
-  ssh_impl_ver


### PR DESCRIPTION
- only layer on Kermit side (ckossh.c) was defined but the same layer must be present on DLL side (ckolssh.c or ckonssh.c) to work properly with different compilers
- 64-bit Windows has defined ABI for DLL that default calling convention is used
- 32-bit systems has not defined ABI for DLL therefore any calling convention can be used, to simplify it cdecl calling convention is used for all 32-bit platforms, it enable to use DLL by any other compiler without dependency on compiler default calling convention
- fix prototypes to use (void) if no parameters are passed, K&R syntax () means any parameters, newer C standards don't permit mixing with K&R syntax and it is reported by some compilers as parameter passing issue
- the DLL export of the ssh_impl_ver function has been removed because no application uses it by exported symbol, it is used by internal access