### PR TITLE
build: add default object file extension to suppress message

### DIFF
--- a/kermit/k95/ckoker.mak
+++ b/kermit/k95/ckoker.mak
@@ -347,6 +347,8 @@ SSH_LIB = ssh.lib
 REXX_LIB = rexx.lib
 !endif
 
+O=.obj
+
 #---------- Compiler targets:
 #
 # To build: "[dn]make <target>"


### PR DESCRIPTION
"Command list does not belong to any target"