### PR TITLE
build: correct OS/2 stack size for Presentation Manager applications

### DIFF
--- a/kermit/k95/ckoker.mak
+++ b/kermit/k95/ckoker.mak
@@ -691,7 +691,7 @@ wcos2:
         WARP="YES" \
 !endif
         LINKFLAGS="-l=os2v2 -k512K" \
-        LINKFLAGS_WIN="-l=os2v2_pm" \
+        LINKFLAGS_WIN="-l=os2v2_pm -k512K" \
         LINKFLAGS_DLL="-l=os2v2_dll" \
 	    DEF=""  # ckoker32.def
 
@@ -716,7 +716,7 @@ wcos2d:
         WARP="YES" \
 !endif
         LINKFLAGS="-l=os2v2 -k512K" \
-        LINKFLAGS_WIN="-l=os2v2_pm" \
+        LINKFLAGS_WIN="-l=os2v2_pm -k512K" \
         LINKFLAGS_DLL="-l=os2v2_dll" \
 	    DEF=""  # ckoker32.def
 


### PR DESCRIPTION
increase stack size to be same as for console application