### PR TITLE
fix issue with vscrnprintf type

### DIFF
--- a/kermit/k95/ck_crp.c
+++ b/kermit/k95/ck_crp.c
@@ -142,7 +142,7 @@ static int (*p_ttol)(char *,int)=NULL;
 static int (*p_dodebug)(int,char *,char *,CK_OFF_T)=NULL;
 static int (*p_dohexdump)(char *,char *,int)=NULL;
 static void (*p_tn_debug)(char *)=NULL;
-static int (*p_vscrnprintf)(const char *, ...)=NULL;
+static int (*p_scrnprint)(const char *)=NULL;
 static void * p_k5_context=NULL;
 static unsigned long (*p_reqtelmutex)(unsigned long)=NULL;
 static unsigned long (*p_reltelmutex)(void)=NULL;
@@ -211,8 +211,8 @@ Vscrnprintf(const char * format, ...) {
 #endif /* NT */
     va_end(ap);
 
-    if ( p_vscrnprintf )
-        return(p_vscrnprintf(myprtfstr));
+    if ( p_scrnprint )
+        return(p_scrnprint(myprtfstr));
     else
         return(-1);
 }
@@ -5508,7 +5508,7 @@ crypt_dll_init( struct _crypt_dll_init * init )
         p_dodebug = init->p_dodebug;
         p_dohexdump = init->p_dohexdump;
         p_tn_debug = init->p_tn_debug;
-        p_vscrnprintf = init->p_vscrnprintf;
+        p_scrnprint = init->p_scrnprint;
         if ( init->version == 1 )
             return(1);
     }

--- a/kermit/k95/ckoath.c
+++ b/kermit/k95/ckoath.c
@@ -3892,6 +3892,10 @@ ck_crypt_dll_loaddll_eh(void)
 
 static int crypt_dll_loaded=0;
 
+static int scrnprint(const char *str) {
+    return Vscrnprintf(str);
+}
+
 int
 ck_crypt_loaddll( void )
 {
@@ -3967,7 +3971,7 @@ ck_crypt_loaddll( void )
     init.p_dohexdump = NULL;
 #endif /* NODEBUG */
     init.p_tn_debug = tn_debug;
-    init.p_vscrnprintf = Vscrnprintf;
+    init.p_scrnprint = scrnprint;
     /* Version 2 */
 #ifdef KRB5
     init.p_k5_context = &k5_context;

--- a/kermit/k95/ckolssh.c
+++ b/kermit/k95/ckolssh.c
@@ -561,7 +561,7 @@ static ssh_get_pw_callback                  *callbackp_ssh_get_pw = NULL;
 static ssh_get_nodelay_enabled_callback     *callbackp_ssh_get_nodelay_enabled = NULL;
 static ssh_open_socket_callback             *callbackp_ssh_open_socket = NULL;
 static dodebug_callback                     *callbackp_dodebug = NULL;
-static vscrnprintf_callback                 *callbackp_vscrnprintf = NULL;
+static scrnprint_callback                   *callbackp_scrnprint = NULL;
 static uq_txt_callback                      *callbackp_uq_txt = NULL;
 static uq_mtxt_callback                     *callbackp_uq_mtxt = NULL;
 static uq_ok_callback                       *callbackp_uq_ok = NULL;
@@ -623,8 +623,8 @@ int Vscrnprintf(const char * format, ...) {
 #endif /* NT */
     va_end(ap);
 
-    if ( callbackp_vscrnprintf )
-        return(callbackp_vscrnprintf(myprtfstr));
+    if ( callbackp_scrnprint )
+        return(callbackp_scrnprint(myprtfstr));
     else
         return(-1);
 }
@@ -1077,8 +1077,8 @@ int CKSSHDLLENTRY ssh_dll_init(ssh_init_parameters_t *params) {
     CHECK_FP(callbackp_ssh_open_socket)
     callbackp_dodebug = params->callbackp_dodebug;
     CHECK_FP(callbackp_dodebug)
-    callbackp_vscrnprintf = params->callbackp_vscrnprintf;
-    CHECK_FP(callbackp_vscrnprintf)
+    callbackp_scrnprint = params->callbackp_scrnprint;
+    CHECK_FP(callbackp_scrnprint)
     callbackp_uq_txt = params->callbackp_uq_txt;
     CHECK_FP(callbackp_uq_txt)
     callbackp_uq_mtxt = params->callbackp_uq_mtxt;

--- a/kermit/k95/ckonssh.c
+++ b/kermit/k95/ckonssh.c
@@ -262,7 +262,7 @@ static ssh_get_pw_callback                  *callbackp_ssh_get_pw = NULL;
 static ssh_get_nodelay_enabled_callback     *callbackp_ssh_get_nodelay_enabled = NULL;
 static ssh_open_socket_callback             *callbackp_ssh_open_socket = NULL;
 static dodebug_callback                     *callbackp_dodebug = NULL;
-static vscrnprintf_callback                 *callbackp_vscrnprintf = NULL;
+static scrnprint_callback                   *callbackp_scrnprint = NULL;
 static uq_txt_callback                      *callbackp_uq_txt = NULL;
 static uq_mtxt_callback                     *callbackp_uq_mtxt = NULL;
 static uq_ok_callback                       *callbackp_uq_ok = NULL;
@@ -324,8 +324,8 @@ int Vscrnprintf(const char * format, ...) {
 #endif /* NT */
     va_end(ap);
 
-    if ( callbackp_vscrnprintf )
-        return(callbackp_vscrnprintf(myprtfstr));
+    if ( callbackp_scrnprint )
+        return(callbackp_scrnprint(myprtfstr));
     else
         return(-1);
 }
@@ -705,8 +705,8 @@ int CKSSHDLLENTRY ssh_dll_init(ssh_init_parameters_t *params) {
     CHECK_FP(callbackp_ssh_open_socket)
     callbackp_dodebug = params->callbackp_dodebug;
     CHECK_FP(callbackp_dodebug)
-    callbackp_vscrnprintf = params->callbackp_vscrnprintf;
-    CHECK_FP(callbackp_vscrnprintf)
+    callbackp_scrnprint = params->callbackp_scrnprint;
+    CHECK_FP(callbackp_scrnprint)
     callbackp_uq_txt = params->callbackp_uq_txt;
     CHECK_FP(callbackp_uq_txt)
     callbackp_uq_mtxt = params->callbackp_uq_mtxt;

--- a/kermit/k95/ckossh.c
+++ b/kermit/k95/ckossh.c
@@ -264,6 +264,11 @@ static HINSTANCE hSSH;
 static HMODULE hSSH;
 #endif
 
+static int scrnprint(const char *str)
+{
+    return( Vscrnprintf(str) );
+}
+
 #ifdef SSH_DLL_CALLCONV
 
 /* define prototypes for callback functions */
@@ -274,7 +279,7 @@ static get_current_terminal_dimensions_callback callback_get_current_terminal_di
 static get_current_terminal_type_callback callback_get_current_terminal_type;
 static get_display_callback callback_get_display;
 static parse_displayname_callback callback_parse_displayname;
-static vscrnprintf_callback callback_vscrnprintf;
+static scrnprint_callback callback_scrnprint;
 static ckstrncpy_callback callback_ckstrncpy;
 static ssh_open_socket_callback callback_ssh_open_socket;
 static dodebug_callback callback_dodebug;
@@ -320,9 +325,9 @@ static int CKSSHAPI callback_parse_displayname(char *displayname, int *familyp, 
                                   dpynump, scrnump, restp);
 }
 
-static int CKSSHAPI callback_vscrnprintf(const char *str)
+static int CKSSHAPI callback_scrnprint(const char *str)
 {
-    return( Vscrnprintf(str) );
+    return( scrnprint(str) );
 }
 
 static int CKSSHAPI callback_ckstrncpy(char * dest, const char * src, int len)
@@ -396,7 +401,7 @@ static int CKSSHAPI callback_debug_logging(void) {
 #define callback_get_current_terminal_type  get_current_terminal_type
 #define callback_get_display                get_display
 #define callback_parse_displayname          parse_displayname
-#define callback_vscrnprintf                Vscrnprintf
+#define callback_scrnprint                  scrnprint
 #define callback_ckstrncpy                  ckstrncpy
 #define callback_ssh_open_socket            ssh_open_socket
 #define callback_dodebug                    dodebug
@@ -580,7 +585,7 @@ int ssh_load(char* dllname) {
     init_params.callbackp_ssh_get_nodelay_enabled = callback_ssh_get_nodelay_enabled;
     init_params.callbackp_ssh_open_socket = callback_ssh_open_socket;
     init_params.callbackp_dodebug = callback_dodebug;
-    init_params.callbackp_vscrnprintf = callback_vscrnprintf;
+    init_params.callbackp_scrnprint = callback_scrnprint;
     init_params.callbackp_uq_txt = callback_uq_txt;
     init_params.callbackp_uq_mtxt = callback_uq_mtxt;
     init_params.callbackp_uq_ok = callback_uq_ok;

--- a/kermit/k95/ckossh.h
+++ b/kermit/k95/ckossh.h
@@ -235,7 +235,7 @@ typedef const char* CKSSHAPI ssh_get_pw_callback(void);
 typedef int CKSSHAPI ssh_get_nodelay_enabled_callback(void);
 typedef SOCKET CKSSHAPI ssh_open_socket_callback(char* host, char* port);
 typedef int CKSSHAPI dodebug_callback(int,char *,char *,CK_OFF_T);
-typedef int CKSSHAPI vscrnprintf_callback(const char *str);
+typedef int CKSSHAPI scrnprint_callback(const char *str);
 typedef int CKSSHAPI uq_txt_callback(char *,char *,int,char **,char *,int,char *,int);
 typedef int CKSSHAPI uq_mtxt_callback(char *,char **,int,struct txtbox[]);
 typedef int CKSSHAPI uq_ok_callback(char *,char *,int,char **,int);
@@ -266,7 +266,7 @@ typedef struct  {
     ssh_get_nodelay_enabled_callback *callbackp_ssh_get_nodelay_enabled;
     ssh_open_socket_callback *callbackp_ssh_open_socket;
     dodebug_callback *callbackp_dodebug;
-    vscrnprintf_callback *callbackp_vscrnprintf;
+    scrnprint_callback *callbackp_scrnprint;
     uq_txt_callback *callbackp_uq_txt;
     uq_mtxt_callback *callbackp_uq_mtxt;
     uq_ok_callback *callbackp_uq_ok;

--- a/kermit/k95/ckuat2.h
+++ b/kermit/k95/ckuat2.h
@@ -288,7 +288,7 @@ struct _crypt_dll_init {
     int (*p_dodebug)(int,char *,char *,CK_OFF_T);
     int (*p_dohexdump)(char *,char *,int);
     void (*p_tn_debug)(char *);
-    int (*p_vscrnprintf)(const char *, ...);
+    int (*p_scrnprint)(const char *);
 
     /* Version 2 variables */
     void * p_k5_context;


### PR DESCRIPTION
renaming vscrnprintf to scrnprint to make the difference from Vscrnprintf transparent
using a single argument and removing the variadic type of the function (to improve portability between compilers and calling conventions)