### PR TITLE
rename some symbols to be more consistent

### DIFF
--- a/kermit/k95/ck_crp.c
+++ b/kermit/k95/ck_crp.c
@@ -5495,11 +5495,11 @@ ck_crypt_dll_version()
 }
 
 int
-crypt_dll_init( struct _crypt_dll_init * init )
+crypt_dll_init( crypt_dll_init_data * init )
 {
 #ifdef LIBDES
     extern int des_check_key;
-    extern void libdes_dll_init(struct _crypt_dll_init *);
+    extern void libdes_dll_init(crypt_dll_init_data *);
     des_check_key = 1;
 #endif /* LIBDES */
 
@@ -5519,29 +5519,29 @@ crypt_dll_init( struct _crypt_dll_init * init )
             return(1);
     }
     if ( init->version >= 3 ) {
-        init->p_install_funcs("encrypt_parse",encrypt_parse);
-        init->p_install_funcs("encrypt_init",encrypt_init);
-        init->p_install_funcs("encrypt_session_key",encrypt_session_key);
-        init->p_install_funcs("encrypt_send_request_start",
+        init->callbackp_install_dllfunc("encrypt_parse",encrypt_parse);
+        init->callbackp_install_dllfunc("encrypt_init",encrypt_init);
+        init->callbackp_install_dllfunc("encrypt_session_key",encrypt_session_key);
+        init->callbackp_install_dllfunc("encrypt_send_request_start",
                               encrypt_send_request_start
                               );
-        init->p_install_funcs("encrypt_request_start",encrypt_request_start);
-        init->p_install_funcs("encrypt_send_request_end",
+        init->callbackp_install_dllfunc("encrypt_request_start",encrypt_request_start);
+        init->callbackp_install_dllfunc("encrypt_send_request_end",
                               encrypt_send_request_end
                               );
-        init->p_install_funcs("encrypt_request_end",encrypt_request_end);
-        init->p_install_funcs("encrypt_send_end",encrypt_send_end);
-        init->p_install_funcs("encrypt_send_support",encrypt_send_support);
-        init->p_install_funcs("encrypt_is_encrypting",encrypt_is_encrypting);
-        init->p_install_funcs("encrypt_is_decrypting",encrypt_is_decrypting);
-        init->p_install_funcs("get_crypt_table",get_crypt_table);
-        init->p_install_funcs("des_is_weak_key",ck_des_is_weak_key);
+        init->callbackp_install_dllfunc("encrypt_request_end",encrypt_request_end);
+        init->callbackp_install_dllfunc("encrypt_send_end",encrypt_send_end);
+        init->callbackp_install_dllfunc("encrypt_send_support",encrypt_send_support);
+        init->callbackp_install_dllfunc("encrypt_is_encrypting",encrypt_is_encrypting);
+        init->callbackp_install_dllfunc("encrypt_is_decrypting",encrypt_is_decrypting);
+        init->callbackp_install_dllfunc("get_crypt_table",get_crypt_table);
+        init->callbackp_install_dllfunc("des_is_weak_key",ck_des_is_weak_key);
         libdes_dll_init(init);
         if (init->version == 3)
           return(1);
     }
     if ( init->version >= 4 ) {
-        init->p_install_funcs("crypt_dll_version",ck_crypt_dll_version);
+        init->callbackp_install_dllfunc("crypt_dll_version",ck_crypt_dll_version);
         if (init->version == 4)
           return(1);
     }
@@ -5554,7 +5554,7 @@ crypt_dll_init( struct _crypt_dll_init * init )
     }
 
     if ( init->version >= 6 ) {
-        init->p_install_funcs("encrypt_dont_support",encrypt_dont_support);
+        init->callbackp_install_dllfunc("encrypt_dont_support",encrypt_dont_support);
         if ( init->version == 6 )
             return(1);
         /* when adding new versions; migrate the next two lines */

--- a/kermit/k95/ck_des.c
+++ b/kermit/k95/ck_des.c
@@ -92,15 +92,15 @@ libdes_pcbc_encrypt(des_cblock *input, des_cblock *output, long length,
 
 #ifdef CRYPT_DLL
 void
-libdes_dll_init(struct _crypt_dll_init * init)
+libdes_dll_init(crypt_dll_init_data * init)
 {
-    init->p_install_funcs("libdes_random_key",libdes_random_key);
-    init->p_install_funcs("libdes_random_seed",libdes_random_seed);
-    init->p_install_funcs("libdes_key_sched",libdes_key_sched);
-    init->p_install_funcs("libdes_ecb_encrypt",libdes_ecb_encrypt);
-    init->p_install_funcs("libdes_string_to_key",libdes_string_to_key);
-    init->p_install_funcs("libdes_fixup_key_parity",libdes_fixup_key_parity);
-    init->p_install_funcs("libdes_pcbc_encrypt",libdes_pcbc_encrypt);
+    init->callbackp_install_dllfunc("libdes_random_key",libdes_random_key);
+    init->callbackp_install_dllfunc("libdes_random_seed",libdes_random_seed);
+    init->callbackp_install_dllfunc("libdes_key_sched",libdes_key_sched);
+    init->callbackp_install_dllfunc("libdes_ecb_encrypt",libdes_ecb_encrypt);
+    init->callbackp_install_dllfunc("libdes_string_to_key",libdes_string_to_key);
+    init->callbackp_install_dllfunc("libdes_fixup_key_parity",libdes_fixup_key_parity);
+    init->callbackp_install_dllfunc("libdes_pcbc_encrypt",libdes_pcbc_encrypt);
 
 }
 #endif /* CRYPT_DLL */

--- a/kermit/k95/ckoath.c
+++ b/kermit/k95/ckoath.c
@@ -3576,7 +3576,7 @@ ck_des_pcbc_encrypt(Block input, Block output, long length,
 #endif /* CK_DES */
 
 #ifdef CRYPT_DLL
-typedef int  (*p_crypt_dll_init_t)(struct _crypt_dll_init *);
+typedef int  (*p_crypt_dll_init_t)(crypt_dll_init_data *);
 typedef int  (*p_encrypt_parse_t)(unsigned char *, int);
 typedef void (*p_encrypt_init_t)(kstream,int);
 typedef int  (*p_encrypt_session_key_t)(Session_Key *, int);
@@ -3732,7 +3732,7 @@ ck_des_is_weak_key(Block B)
 }
 
 void
-crypt_install_funcs(char * name, void * func)
+callback_install_dllfunc(char * name, void * func)
 {
     if ( !strcmp(name,"encrypt_parse") )
         p_encrypt_parse = (p_encrypt_parse_t) func;
@@ -3855,7 +3855,7 @@ int
 ck_crypt_loaddll( void )
 {
     ULONG rc = 0 ;
-    struct _crypt_dll_init init;
+    crypt_dll_init_data init;
     extern unsigned long startflags;
     int load_error = 0, len;
 #ifdef OS2ONLY
@@ -3934,7 +3934,7 @@ ck_crypt_loaddll( void )
     init.p_k5_context = NULL;
 #endif /* KRB5 */
     /* Version 3 */
-    init.p_install_funcs = crypt_install_funcs;
+    init.callbackp_install_dllfunc = callback_install_dllfunc;
     /* Version 5 */
     init.p_reqtelmutex = RequestTelnetMutex;
     init.p_reltelmutex = ReleaseTelnetMutex;

--- a/kermit/k95/ckolssh.c
+++ b/kermit/k95/ckolssh.c
@@ -1061,105 +1061,105 @@ kstrdup(const char *str)
  * this DLL provides.
  * @param params SSH initialisation parameters from Kermit 95
  */
-int CKSSHDLLENTRY ssh_dll_init(ssh_init_parameters_t *params) {
+int CKSSHDLLENTRY ssh_dll_init(ssh_dll_init_data *init) {
     /* Store pointers to helper functions provided by K95 */
-    callbackp_get_current_terminal_dimensions = params->callbackp_get_current_terminal_dimensions;
+    callbackp_get_current_terminal_dimensions = init->callbackp_get_current_terminal_dimensions;
     CHECK_FP(callbackp_get_current_terminal_dimensions)
-    callbackp_get_current_terminal_type = params->callbackp_get_current_terminal_type;
+    callbackp_get_current_terminal_type = init->callbackp_get_current_terminal_type;
     CHECK_FP(callbackp_get_current_terminal_type)
-    callbackp_ssh_get_uid = params->callbackp_ssh_get_uid;
+    callbackp_ssh_get_uid = init->callbackp_ssh_get_uid;
     CHECK_FP(callbackp_ssh_get_uid)
-    callbackp_ssh_get_pw = params->callbackp_ssh_get_pw;
+    callbackp_ssh_get_pw = init->callbackp_ssh_get_pw;
     CHECK_FP(callbackp_ssh_get_pw)
-    callbackp_ssh_get_nodelay_enabled = params->callbackp_ssh_get_nodelay_enabled;
+    callbackp_ssh_get_nodelay_enabled = init->callbackp_ssh_get_nodelay_enabled;
     CHECK_FP(callbackp_ssh_get_nodelay_enabled)
-    callbackp_ssh_open_socket = params->callbackp_ssh_open_socket;
+    callbackp_ssh_open_socket = init->callbackp_ssh_open_socket;
     CHECK_FP(callbackp_ssh_open_socket)
-    callbackp_dodebug = params->callbackp_dodebug;
+    callbackp_dodebug = init->callbackp_dodebug;
     CHECK_FP(callbackp_dodebug)
-    callbackp_scrnprint = params->callbackp_scrnprint;
+    callbackp_scrnprint = init->callbackp_scrnprint;
     CHECK_FP(callbackp_scrnprint)
-    callbackp_uq_txt = params->callbackp_uq_txt;
+    callbackp_uq_txt = init->callbackp_uq_txt;
     CHECK_FP(callbackp_uq_txt)
-    callbackp_uq_mtxt = params->callbackp_uq_mtxt;
+    callbackp_uq_mtxt = init->callbackp_uq_mtxt;
     CHECK_FP(callbackp_uq_mtxt)
-    callbackp_uq_ok = params->callbackp_uq_ok;
+    callbackp_uq_ok = init->callbackp_uq_ok;
     CHECK_FP(callbackp_uq_ok)
-    callbackp_uq_file = params->callbackp_uq_file;
+    callbackp_uq_file = init->callbackp_uq_file;
     CHECK_FP(callbackp_uq_file)
-    callbackp_zmkdir = params->callbackp_zmkdir;
+    callbackp_zmkdir = init->callbackp_zmkdir;
     CHECK_FP(callbackp_zmkdir)
-    callbackp_ckmakxmsg = params->callbackp_ckmakxmsg;
+    callbackp_ckmakxmsg = init->callbackp_ckmakxmsg;
     CHECK_FP(callbackp_ckmakxmsg)
-    callbackp_whoami = params->callbackp_whoami;
+    callbackp_whoami = init->callbackp_whoami;
     CHECK_FP(callbackp_whoami)
-    callbackp_GetAppData = params->callbackp_GetAppData;
+    callbackp_GetAppData = init->callbackp_GetAppData;
     CHECK_FP(callbackp_GetAppData)
-    callbackp_GetHomePath = params->callbackp_GetHomePath;
+    callbackp_GetHomePath = init->callbackp_GetHomePath;
     CHECK_FP(callbackp_GetHomePath)
-    callbackp_GetHomeDrive = params->callbackp_GetHomeDrive;
+    callbackp_GetHomeDrive = init->callbackp_GetHomeDrive;
     CHECK_FP(callbackp_GetHomeDrive)
-    callbackp_ckstrncpy = params->callbackp_ckstrncpy;
+    callbackp_ckstrncpy = init->callbackp_ckstrncpy;
     CHECK_FP(callbackp_ckstrncpy)
-    callbackp_debug_logging = params->callbackp_debug_logging;
+    callbackp_debug_logging = init->callbackp_debug_logging;
     CHECK_FP(callbackp_debug_logging)
-    callbackp_get_display = params->callbackp_get_display;
+    callbackp_get_display = init->callbackp_get_display;
     CHECK_FP(callbackp_get_display)
-    callbackp_parse_displayname = params->callbackp_parse_displayname;
+    callbackp_parse_displayname = init->callbackp_parse_displayname;
     CHECK_FP(callbackp_parse_displayname)
 
-    params->callbackp_install_dllfunc("ssh_set_iparam", dllfunc_ssh_set_iparam);
-    params->callbackp_install_dllfunc("ssh_get_iparam", dllfunc_ssh_get_iparam);
-    params->callbackp_install_dllfunc("ssh_set_sparam", dllfunc_ssh_set_sparam);
-    params->callbackp_install_dllfunc("ssh_get_sparam", dllfunc_ssh_get_sparam);
-    params->callbackp_install_dllfunc("ssh_set_identity_files", dllfunc_ssh_set_identity_files);
-    params->callbackp_install_dllfunc("ssh_get_socket", dllfunc_ssh_get_socket);
-    params->callbackp_install_dllfunc("ssh_open", dllfunc_ssh_open);
-    params->callbackp_install_dllfunc("ssh_clos", dllfunc_ssh_clos);
-    params->callbackp_install_dllfunc("ssh_tchk", dllfunc_ssh_tchk);
-    params->callbackp_install_dllfunc("ssh_flui", dllfunc_ssh_flui);
-    params->callbackp_install_dllfunc("ssh_break", dllfunc_ssh_break);
-    params->callbackp_install_dllfunc("ssh_inc", dllfunc_ssh_inc);
-    params->callbackp_install_dllfunc("ssh_xin", dllfunc_ssh_xin);
-    params->callbackp_install_dllfunc("ssh_toc", dllfunc_ssh_toc);
-    params->callbackp_install_dllfunc("ssh_tol", dllfunc_ssh_tol);
-    params->callbackp_install_dllfunc("ssh_snaws", dllfunc_ssh_snaws);
-    params->callbackp_install_dllfunc("ssh_proto_ver", dllfunc_ssh_proto_ver);
-    params->callbackp_install_dllfunc("ssh_impl_ver", dllfunc_ssh_impl_ver);
+    init->callbackp_install_dllfunc("ssh_set_iparam", dllfunc_ssh_set_iparam);
+    init->callbackp_install_dllfunc("ssh_get_iparam", dllfunc_ssh_get_iparam);
+    init->callbackp_install_dllfunc("ssh_set_sparam", dllfunc_ssh_set_sparam);
+    init->callbackp_install_dllfunc("ssh_get_sparam", dllfunc_ssh_get_sparam);
+    init->callbackp_install_dllfunc("ssh_set_identity_files", dllfunc_ssh_set_identity_files);
+    init->callbackp_install_dllfunc("ssh_get_socket", dllfunc_ssh_get_socket);
+    init->callbackp_install_dllfunc("ssh_open", dllfunc_ssh_open);
+    init->callbackp_install_dllfunc("ssh_clos", dllfunc_ssh_clos);
+    init->callbackp_install_dllfunc("ssh_tchk", dllfunc_ssh_tchk);
+    init->callbackp_install_dllfunc("ssh_flui", dllfunc_ssh_flui);
+    init->callbackp_install_dllfunc("ssh_break", dllfunc_ssh_break);
+    init->callbackp_install_dllfunc("ssh_inc", dllfunc_ssh_inc);
+    init->callbackp_install_dllfunc("ssh_xin", dllfunc_ssh_xin);
+    init->callbackp_install_dllfunc("ssh_toc", dllfunc_ssh_toc);
+    init->callbackp_install_dllfunc("ssh_tol", dllfunc_ssh_tol);
+    init->callbackp_install_dllfunc("ssh_snaws", dllfunc_ssh_snaws);
+    init->callbackp_install_dllfunc("ssh_proto_ver", dllfunc_ssh_proto_ver);
+    init->callbackp_install_dllfunc("ssh_impl_ver", dllfunc_ssh_impl_ver);
 
     /* These functions are all optional */
-    params->callbackp_install_dllfunc("sshkey_create", dllfunc_sshkey_create);
-    params->callbackp_install_dllfunc("sshkey_display_fingerprint", dllfunc_sshkey_display_fingerprint);
-    params->callbackp_install_dllfunc("sshkey_display_public", dllfunc_sshkey_display_public);
-    params->callbackp_install_dllfunc("sshkey_display_public_as_ssh2", dllfunc_sshkey_display_public_as_ssh2);
-    params->callbackp_install_dllfunc("sshkey_change_passphrase", dllfunc_sshkey_change_passphrase);
-    params->callbackp_install_dllfunc("ssh_fwd_remote_port", dllfunc_ssh_fwd_remote_port);
-    params->callbackp_install_dllfunc("ssh_fwd_local_port", dllfunc_ssh_fwd_local_port);
-    params->callbackp_install_dllfunc("ssh_fwd_clear_remote_ports", dllfunc_ssh_fwd_clear_remote_ports);
-    params->callbackp_install_dllfunc("ssh_fwd_clear_local_ports", dllfunc_ssh_fwd_clear_local_ports);
-    params->callbackp_install_dllfunc("ssh_fwd_remove_remote_port", dllfunc_ssh_fwd_remove_remote_port);
-    params->callbackp_install_dllfunc("ssh_fwd_remove_local_port", dllfunc_ssh_fwd_remove_local_port);
-    params->callbackp_install_dllfunc("ssh_fwd_get_ports", dllfunc_ssh_fwd_get_ports);
+    init->callbackp_install_dllfunc("sshkey_create", dllfunc_sshkey_create);
+    init->callbackp_install_dllfunc("sshkey_display_fingerprint", dllfunc_sshkey_display_fingerprint);
+    init->callbackp_install_dllfunc("sshkey_display_public", dllfunc_sshkey_display_public);
+    init->callbackp_install_dllfunc("sshkey_display_public_as_ssh2", dllfunc_sshkey_display_public_as_ssh2);
+    init->callbackp_install_dllfunc("sshkey_change_passphrase", dllfunc_sshkey_change_passphrase);
+    init->callbackp_install_dllfunc("ssh_fwd_remote_port", dllfunc_ssh_fwd_remote_port);
+    init->callbackp_install_dllfunc("ssh_fwd_local_port", dllfunc_ssh_fwd_local_port);
+    init->callbackp_install_dllfunc("ssh_fwd_clear_remote_ports", dllfunc_ssh_fwd_clear_remote_ports);
+    init->callbackp_install_dllfunc("ssh_fwd_clear_local_ports", dllfunc_ssh_fwd_clear_local_ports);
+    init->callbackp_install_dllfunc("ssh_fwd_remove_remote_port", dllfunc_ssh_fwd_remove_remote_port);
+    init->callbackp_install_dllfunc("ssh_fwd_remove_local_port", dllfunc_ssh_fwd_remove_local_port);
+    init->callbackp_install_dllfunc("ssh_fwd_get_ports", dllfunc_ssh_fwd_get_ports);
 #ifdef SSHTEST
-    params->callbackp_install_dllfunc("sshkey_v1_change_comment", dllfunc_sshkey_v1_change_comment); /* TODO */
+    init->callbackp_install_dllfunc("sshkey_v1_change_comment", dllfunc_sshkey_v1_change_comment); /* TODO */
 #endif
 #ifdef COMMENT
-    params->callbackp_install_dllfunc("sshkey_default_file", dllfunc_sshkey_default_file); */ /* TODO */
+    init->callbackp_install_dllfunc("sshkey_default_file", dllfunc_sshkey_default_file); */ /* TODO */
 #endif /* COMMENT */
-    params->callbackp_install_dllfunc("ssh_v2_rekey", dllfunc_ssh_v2_rekey); /* TODO */
-    params->callbackp_install_dllfunc("ssh_agent_delete_file", dllfunc_ssh_agent_delete_file); /* TODO */
-    params->callbackp_install_dllfunc("ssh_agent_delete_all", dllfunc_ssh_agent_delete_all); /* TODO */
-    params->callbackp_install_dllfunc("ssh_agent_add_file", dllfunc_ssh_agent_add_file); /* TODO */
-    params->callbackp_install_dllfunc("ssh_agent_list_identities", dllfunc_ssh_agent_list_identities); /* TODO */
+    init->callbackp_install_dllfunc("ssh_v2_rekey", dllfunc_ssh_v2_rekey); /* TODO */
+    init->callbackp_install_dllfunc("ssh_agent_delete_file", dllfunc_ssh_agent_delete_file); /* TODO */
+    init->callbackp_install_dllfunc("ssh_agent_delete_all", dllfunc_ssh_agent_delete_all); /* TODO */
+    init->callbackp_install_dllfunc("ssh_agent_add_file", dllfunc_ssh_agent_add_file); /* TODO */
+    init->callbackp_install_dllfunc("ssh_agent_list_identities", dllfunc_ssh_agent_list_identities); /* TODO */
 #ifdef COMMENT
     /* Not supported */
-    params->callbackp_install_dllfunc("ssh_unload", dllfunc_ssh_unload);
+    init->callbackp_install_dllfunc("ssh_unload", dllfunc_ssh_unload);
 #endif /* COMMENT */
-    params->callbackp_install_dllfunc("ssh_dll_ver", dllfunc_ssh_dll_ver);
-    params->callbackp_install_dllfunc("ssh_get_keytab", dllfunc_ssh_get_keytab);
-    params->callbackp_install_dllfunc("ssh_feature_supported", dllfunc_ssh_feature_supported);
-    params->callbackp_install_dllfunc("ssh_get_set_help", dllfunc_ssh_get_set_help);
-    params->callbackp_install_dllfunc("ssh_get_help", dllfunc_ssh_get_help);
+    init->callbackp_install_dllfunc("ssh_dll_ver", dllfunc_ssh_dll_ver);
+    init->callbackp_install_dllfunc("ssh_get_keytab", dllfunc_ssh_get_keytab);
+    init->callbackp_install_dllfunc("ssh_feature_supported", dllfunc_ssh_feature_supported);
+    init->callbackp_install_dllfunc("ssh_get_set_help", dllfunc_ssh_get_set_help);
+    init->callbackp_install_dllfunc("ssh_get_help", dllfunc_ssh_get_help);
 
     /* And lastly do any other initialisation work that is independent of
      * whether we're a DLL or not */

--- a/kermit/k95/ckonssh.c
+++ b/kermit/k95/ckonssh.c
@@ -689,107 +689,107 @@ static const char ** CKSSHAPI dllfunc_ssh_get_help(void) {
  * this DLL provides.
  * @param params SSH initialisation parameters from Kermit 95
  */
-int CKSSHDLLENTRY ssh_dll_init(ssh_init_parameters_t *params) {
+int CKSSHDLLENTRY ssh_dll_init(ssh_dll_init_data *init) {
     /* Store pointers to helper functions provided by K95 */
-    callbackp_get_current_terminal_dimensions = params->callbackp_get_current_terminal_dimensions;
+    callbackp_get_current_terminal_dimensions = init->callbackp_get_current_terminal_dimensions;
     CHECK_FP(callbackp_get_current_terminal_dimensions)
-    callbackp_get_current_terminal_type = params->callbackp_get_current_terminal_type;
+    callbackp_get_current_terminal_type = init->callbackp_get_current_terminal_type;
     CHECK_FP(callbackp_get_current_terminal_type)
-    callbackp_ssh_get_uid = params->callbackp_ssh_get_uid;
+    callbackp_ssh_get_uid = init->callbackp_ssh_get_uid;
     CHECK_FP(callbackp_ssh_get_uid)
-    callbackp_ssh_get_pw = params->callbackp_ssh_get_pw;
+    callbackp_ssh_get_pw = init->callbackp_ssh_get_pw;
     CHECK_FP(callbackp_ssh_get_pw)
-    callbackp_ssh_get_nodelay_enabled = params->callbackp_ssh_get_nodelay_enabled;
+    callbackp_ssh_get_nodelay_enabled = init->callbackp_ssh_get_nodelay_enabled;
     CHECK_FP(callbackp_ssh_get_nodelay_enabled)
-    callbackp_ssh_open_socket = params->callbackp_ssh_open_socket;
+    callbackp_ssh_open_socket = init->callbackp_ssh_open_socket;
     CHECK_FP(callbackp_ssh_open_socket)
-    callbackp_dodebug = params->callbackp_dodebug;
+    callbackp_dodebug = init->callbackp_dodebug;
     CHECK_FP(callbackp_dodebug)
-    callbackp_scrnprint = params->callbackp_scrnprint;
+    callbackp_scrnprint = init->callbackp_scrnprint;
     CHECK_FP(callbackp_scrnprint)
-    callbackp_uq_txt = params->callbackp_uq_txt;
+    callbackp_uq_txt = init->callbackp_uq_txt;
     CHECK_FP(callbackp_uq_txt)
-    callbackp_uq_mtxt = params->callbackp_uq_mtxt;
+    callbackp_uq_mtxt = init->callbackp_uq_mtxt;
     CHECK_FP(callbackp_uq_mtxt)
-    callbackp_uq_ok = params->callbackp_uq_ok;
+    callbackp_uq_ok = init->callbackp_uq_ok;
     CHECK_FP(callbackp_uq_ok)
-    callbackp_uq_file = params->callbackp_uq_file;
+    callbackp_uq_file = init->callbackp_uq_file;
     CHECK_FP(callbackp_uq_file)
-    callbackp_zmkdir = params->callbackp_zmkdir;
+    callbackp_zmkdir = init->callbackp_zmkdir;
     CHECK_FP(callbackp_zmkdir)
-    callbackp_ckmakxmsg = params->callbackp_ckmakxmsg;
+    callbackp_ckmakxmsg = init->callbackp_ckmakxmsg;
     CHECK_FP(callbackp_ckmakxmsg)
-    callbackp_whoami = params->callbackp_whoami;
+    callbackp_whoami = init->callbackp_whoami;
     CHECK_FP(callbackp_whoami)
-    callbackp_GetAppData = params->callbackp_GetAppData;
+    callbackp_GetAppData = init->callbackp_GetAppData;
     CHECK_FP(callbackp_GetAppData)
-    callbackp_GetHomePath = params->callbackp_GetHomePath;
+    callbackp_GetHomePath = init->callbackp_GetHomePath;
     CHECK_FP(callbackp_GetHomePath)
-    callbackp_GetHomeDrive = params->callbackp_GetHomeDrive;
+    callbackp_GetHomeDrive = init->callbackp_GetHomeDrive;
     CHECK_FP(callbackp_GetHomeDrive)
-    callbackp_ckstrncpy = params->callbackp_ckstrncpy;
+    callbackp_ckstrncpy = init->callbackp_ckstrncpy;
     CHECK_FP(callbackp_ckstrncpy)
-    callbackp_debug_logging = params->callbackp_debug_logging;
+    callbackp_debug_logging = init->callbackp_debug_logging;
     CHECK_FP(callbackp_debug_logging)
-    callbackp_get_display = params->callbackp_get_display;
+    callbackp_get_display = init->callbackp_get_display;
     CHECK_FP(callbackp_get_display)
-    callbackp_parse_displayname = params->callbackp_parse_displayname;
+    callbackp_parse_displayname = init->callbackp_parse_displayname;
     CHECK_FP(callbackp_parse_displayname)
 
-    params->callbackp_install_dllfunc("ssh_set_iparam", dllfunc_ssh_set_iparam);
-    params->callbackp_install_dllfunc("ssh_get_iparam", dllfunc_ssh_get_iparam);
-    params->callbackp_install_dllfunc("ssh_set_sparam", dllfunc_ssh_set_sparam);
-    params->callbackp_install_dllfunc("ssh_get_sparam", dllfunc_ssh_get_sparam);
-    params->callbackp_install_dllfunc("ssh_set_identity_files", dllfunc_ssh_set_identity_files);
-    params->callbackp_install_dllfunc("ssh_get_socket", dllfunc_ssh_get_socket);
-    params->callbackp_install_dllfunc("ssh_open", dllfunc_ssh_open);
-    params->callbackp_install_dllfunc("ssh_clos", dllfunc_ssh_clos);
-    params->callbackp_install_dllfunc("ssh_tchk", dllfunc_ssh_tchk);
-    params->callbackp_install_dllfunc("ssh_flui", dllfunc_ssh_flui);
-    params->callbackp_install_dllfunc("ssh_break", dllfunc_ssh_break);
-    params->callbackp_install_dllfunc("ssh_inc", dllfunc_ssh_inc);
-    params->callbackp_install_dllfunc("ssh_xin", dllfunc_ssh_xin);
-    params->callbackp_install_dllfunc("ssh_toc", dllfunc_ssh_toc);
-    params->callbackp_install_dllfunc("ssh_tol", dllfunc_ssh_tol);
-    params->callbackp_install_dllfunc("ssh_snaws", dllfunc_ssh_snaws);
-    params->callbackp_install_dllfunc("ssh_proto_ver", dllfunc_ssh_proto_ver);
-    params->callbackp_install_dllfunc("ssh_impl_ver", dllfunc_ssh_impl_ver);
+    init->callbackp_install_dllfunc("ssh_set_iparam", dllfunc_ssh_set_iparam);
+    init->callbackp_install_dllfunc("ssh_get_iparam", dllfunc_ssh_get_iparam);
+    init->callbackp_install_dllfunc("ssh_set_sparam", dllfunc_ssh_set_sparam);
+    init->callbackp_install_dllfunc("ssh_get_sparam", dllfunc_ssh_get_sparam);
+    init->callbackp_install_dllfunc("ssh_set_identity_files", dllfunc_ssh_set_identity_files);
+    init->callbackp_install_dllfunc("ssh_get_socket", dllfunc_ssh_get_socket);
+    init->callbackp_install_dllfunc("ssh_open", dllfunc_ssh_open);
+    init->callbackp_install_dllfunc("ssh_clos", dllfunc_ssh_clos);
+    init->callbackp_install_dllfunc("ssh_tchk", dllfunc_ssh_tchk);
+    init->callbackp_install_dllfunc("ssh_flui", dllfunc_ssh_flui);
+    init->callbackp_install_dllfunc("ssh_break", dllfunc_ssh_break);
+    init->callbackp_install_dllfunc("ssh_inc", dllfunc_ssh_inc);
+    init->callbackp_install_dllfunc("ssh_xin", dllfunc_ssh_xin);
+    init->callbackp_install_dllfunc("ssh_toc", dllfunc_ssh_toc);
+    init->callbackp_install_dllfunc("ssh_tol", dllfunc_ssh_tol);
+    init->callbackp_install_dllfunc("ssh_snaws", dllfunc_ssh_snaws);
+    init->callbackp_install_dllfunc("ssh_proto_ver", dllfunc_ssh_proto_ver);
+    init->callbackp_install_dllfunc("ssh_impl_ver", dllfunc_ssh_impl_ver);
 
     /* These functions are all optional */
 #ifdef COMMENT
-    params->callbackp_install_dllfunc("sshkey_create", dllfunc_sshkey_create);
-    params->callbackp_install_dllfunc("sshkey_display_fingerprint", dllfunc_sshkey_display_fingerprint);
-    params->callbackp_install_dllfunc("sshkey_display_public", dllfunc_sshkey_display_public);
-    params->callbackp_install_dllfunc("sshkey_display_public_as_ssh2", dllfunc_sshkey_display_public_as_ssh2);
-    params->callbackp_install_dllfunc("sshkey_change_passphrase", dllfunc_sshkey_change_passphrase);
-    params->callbackp_install_dllfunc("ssh_fwd_remote_port", dllfunc_ssh_fwd_remote_port);
-    params->callbackp_install_dllfunc("ssh_fwd_local_port", dllfunc_ssh_fwd_local_port);
-    params->callbackp_install_dllfunc("ssh_fwd_clear_remote_ports", dllfunc_ssh_fwd_clear_remote_ports);
-    params->callbackp_install_dllfunc("ssh_fwd_clear_local_ports", dllfunc_ssh_fwd_clear_local_ports);
-    params->callbackp_install_dllfunc("ssh_fwd_remove_remote_port", dllfunc_ssh_fwd_remove_remote_port);
-    params->callbackp_install_dllfunc("ssh_fwd_remove_local_port", dllfunc_ssh_fwd_remove_local_port);
-    params->callbackp_install_dllfunc("ssh_fwd_get_ports", dllfunc_ssh_fwd_get_ports);
+    init->callbackp_install_dllfunc("sshkey_create", dllfunc_sshkey_create);
+    init->callbackp_install_dllfunc("sshkey_display_fingerprint", dllfunc_sshkey_display_fingerprint);
+    init->callbackp_install_dllfunc("sshkey_display_public", dllfunc_sshkey_display_public);
+    init->callbackp_install_dllfunc("sshkey_display_public_as_ssh2", dllfunc_sshkey_display_public_as_ssh2);
+    init->callbackp_install_dllfunc("sshkey_change_passphrase", dllfunc_sshkey_change_passphrase);
+    init->callbackp_install_dllfunc("ssh_fwd_remote_port", dllfunc_ssh_fwd_remote_port);
+    init->callbackp_install_dllfunc("ssh_fwd_local_port", dllfunc_ssh_fwd_local_port);
+    init->callbackp_install_dllfunc("ssh_fwd_clear_remote_ports", dllfunc_ssh_fwd_clear_remote_ports);
+    init->callbackp_install_dllfunc("ssh_fwd_clear_local_ports", dllfunc_ssh_fwd_clear_local_ports);
+    init->callbackp_install_dllfunc("ssh_fwd_remove_remote_port", dllfunc_ssh_fwd_remove_remote_port);
+    init->callbackp_install_dllfunc("ssh_fwd_remove_local_port", dllfunc_ssh_fwd_remove_local_port);
+    init->callbackp_install_dllfunc("ssh_fwd_get_ports", dllfunc_ssh_fwd_get_ports);
 #ifdef SSHTEST
-    params->callbackp_install_dllfunc("sshkey_v1_change_comment", dllfunc_sshkey_v1_change_comment); /* TODO */
+    init->callbackp_install_dllfunc("sshkey_v1_change_comment", dllfunc_sshkey_v1_change_comment); /* TODO */
 #endif /* SSHTEST */
 #ifdef COMMENT
-    params->callbackp_install_dllfunc("sshkey_default_file", dllfunc_sshkey_default_file); */ /* TODO */
+    init->callbackp_install_dllfunc("sshkey_default_file", dllfunc_sshkey_default_file); */ /* TODO */
 #endif /* COMMENT */
-    params->callbackp_install_dllfunc("ssh_v2_rekey", dllfunc_ssh_v2_rekey); /* TODO */
-    params->callbackp_install_dllfunc("ssh_agent_delete_file", dllfunc_ssh_agent_delete_file); /* TODO */
-    params->callbackp_install_dllfunc("ssh_agent_delete_all", dllfunc_ssh_agent_delete_all); /* TODO */
-    params->callbackp_install_dllfunc("ssh_agent_add_file", dllfunc_ssh_agent_add_file); /* TODO */
-    params->callbackp_install_dllfunc("ssh_agent_list_identities", dllfunc_ssh_agent_list_identities); /* TODO */
+    init->callbackp_install_dllfunc("ssh_v2_rekey", dllfunc_ssh_v2_rekey); /* TODO */
+    init->callbackp_install_dllfunc("ssh_agent_delete_file", dllfunc_ssh_agent_delete_file); /* TODO */
+    init->callbackp_install_dllfunc("ssh_agent_delete_all", dllfunc_ssh_agent_delete_all); /* TODO */
+    init->callbackp_install_dllfunc("ssh_agent_add_file", dllfunc_ssh_agent_add_file); /* TODO */
+    init->callbackp_install_dllfunc("ssh_agent_list_identities", dllfunc_ssh_agent_list_identities); /* TODO */
 #ifdef COMMENT
     /* Not supported: */
-    params->callbackp_install_dllfunc("ssh_unload", dllfunc_ssh_unload);
+    init->callbackp_install_dllfunc("ssh_unload", dllfunc_ssh_unload);
 #endif /* COMMENT */
 #endif /* COMMENT */
-    params->callbackp_install_dllfunc("ssh_dll_ver", dllfunc_ssh_dll_ver);
-    params->callbackp_install_dllfunc("ssh_get_keytab", dllfunc_ssh_get_keytab);
-    params->callbackp_install_dllfunc("ssh_feature_supported", dllfunc_ssh_feature_supported);
-    params->callbackp_install_dllfunc("ssh_get_set_help", dllfunc_ssh_get_set_help);
-    params->callbackp_install_dllfunc("ssh_get_help", dllfunc_ssh_get_help);
+    init->callbackp_install_dllfunc("ssh_dll_ver", dllfunc_ssh_dll_ver);
+    init->callbackp_install_dllfunc("ssh_get_keytab", dllfunc_ssh_get_keytab);
+    init->callbackp_install_dllfunc("ssh_feature_supported", dllfunc_ssh_feature_supported);
+    init->callbackp_install_dllfunc("ssh_get_set_help", dllfunc_ssh_get_set_help);
+    init->callbackp_install_dllfunc("ssh_get_help", dllfunc_ssh_get_help);
 
     return 0;
 }

--- a/kermit/k95/ckossh.c
+++ b/kermit/k95/ckossh.c
@@ -197,7 +197,7 @@ SOCKET ssh_open_socket(char* host, char* port) {
 
 #include <stdlib.h>
 
-typedef int CKSSHDLLENTRY ssh_dll_init_dllentry(ssh_init_parameters_t *);
+typedef int CKSSHDLLENTRY ssh_dll_init_dllentry(ssh_dll_init_data *);
 static ssh_dll_init_dllentry *dllentryp_ssh_init = NULL;
 
 /* Function pointers received from the currently loaded SSH subsystem DLL */
@@ -523,7 +523,7 @@ static void CKSSHAPI callback_install_dllfunc(const char* function, const void* 
  */
 int ssh_load(char* dllname) {
     ULONG rc = 0;
-    ssh_init_parameters_t init_params;
+    ssh_dll_init_data init;
 
 #ifdef OS2ONLY
     CHAR *exe_path;
@@ -576,34 +576,34 @@ int ssh_load(char* dllname) {
 #endif
 
     /* SSH DLL loaded successfully! Prepare init params! */
-    init_params.version = 1;
-    init_params.callbackp_install_dllfunc = callback_install_dllfunc;
-    init_params.callbackp_get_current_terminal_dimensions = callback_get_current_terminal_dimensions;
-    init_params.callbackp_get_current_terminal_type = callback_get_current_terminal_type;
-    init_params.callbackp_ssh_get_uid = callback_ssh_get_uid;
-    init_params.callbackp_ssh_get_pw = callback_ssh_get_pw;
-    init_params.callbackp_ssh_get_nodelay_enabled = callback_ssh_get_nodelay_enabled;
-    init_params.callbackp_ssh_open_socket = callback_ssh_open_socket;
-    init_params.callbackp_dodebug = callback_dodebug;
-    init_params.callbackp_scrnprint = callback_scrnprint;
-    init_params.callbackp_uq_txt = callback_uq_txt;
-    init_params.callbackp_uq_mtxt = callback_uq_mtxt;
-    init_params.callbackp_uq_ok = callback_uq_ok;
-    init_params.callbackp_uq_file = callback_uq_file;
-    init_params.callbackp_zmkdir = callback_zmkdir;
-    init_params.callbackp_ckmakxmsg = callback_ckmakxmsg;
-    init_params.callbackp_whoami = callback_whoami;
-    init_params.callbackp_GetAppData = callback_GetAppData;
-    init_params.callbackp_GetHomePath = callback_GetHomePath;
-    init_params.callbackp_GetHomeDrive = callback_GetHomeDrive;
-    init_params.callbackp_ckstrncpy = callback_ckstrncpy;
-    init_params.callbackp_debug_logging = callback_debug_logging;
-    init_params.callbackp_get_display = callback_get_display;
-    init_params.callbackp_parse_displayname = callback_parse_displayname;
+    init.version = 1;
+    init.callbackp_install_dllfunc = callback_install_dllfunc;
+    init.callbackp_get_current_terminal_dimensions = callback_get_current_terminal_dimensions;
+    init.callbackp_get_current_terminal_type = callback_get_current_terminal_type;
+    init.callbackp_ssh_get_uid = callback_ssh_get_uid;
+    init.callbackp_ssh_get_pw = callback_ssh_get_pw;
+    init.callbackp_ssh_get_nodelay_enabled = callback_ssh_get_nodelay_enabled;
+    init.callbackp_ssh_open_socket = callback_ssh_open_socket;
+    init.callbackp_dodebug = callback_dodebug;
+    init.callbackp_scrnprint = callback_scrnprint;
+    init.callbackp_uq_txt = callback_uq_txt;
+    init.callbackp_uq_mtxt = callback_uq_mtxt;
+    init.callbackp_uq_ok = callback_uq_ok;
+    init.callbackp_uq_file = callback_uq_file;
+    init.callbackp_zmkdir = callback_zmkdir;
+    init.callbackp_ckmakxmsg = callback_ckmakxmsg;
+    init.callbackp_whoami = callback_whoami;
+    init.callbackp_GetAppData = callback_GetAppData;
+    init.callbackp_GetHomePath = callback_GetHomePath;
+    init.callbackp_GetHomeDrive = callback_GetHomeDrive;
+    init.callbackp_ckstrncpy = callback_ckstrncpy;
+    init.callbackp_debug_logging = callback_debug_logging;
+    init.callbackp_get_display = callback_get_display;
+    init.callbackp_parse_displayname = callback_parse_displayname;
 
     /* Initialise! */
     debug(F100, "Call ssh_dll_init()", NULL, 0);
-    rc = dllentryp_ssh_init(&init_params);
+    rc = dllentryp_ssh_init(&init);
 
     /* TODO: Check all mandatory functions are available */
 

--- a/kermit/k95/ckossh.h
+++ b/kermit/k95/ckossh.h
@@ -211,8 +211,6 @@ _PROTOTYP(void ssh_initialise,(VOID));
  * for all 32-bit systems it uses cdecl for better interoperatibility
  * now you can use DLL created by any compiler togather with application
  * compiled by another compiler
- * only two symbols are exported from DLL
- * ssh_dll_init and ssh_impl_ver
  */
 #ifndef _WIN64
 #define SSH_DLL_CALLCONV    cdecl
@@ -294,7 +292,7 @@ typedef struct  {
      *   **restp    - Anything else at the end
      */
     parse_displayname_callback *callbackp_parse_displayname;
-} ssh_init_parameters_t;
+} ssh_dll_init_data;
 
 /* prototypes for all functions provided by DLL */
 typedef int CKSSHAPI ssh_set_iparam_dllfunc(int, int);

--- a/kermit/k95/ckuat2.h
+++ b/kermit/k95/ckuat2.h
@@ -280,7 +280,7 @@ int decrypt_ks_hack(unsigned char *, int);
 #endif /* ENCRYPTION */
 
 #ifdef CRYPT_DLL
-struct _crypt_dll_init {
+typedef struct {
     int version;
 
     /* Version 1 variables */
@@ -294,12 +294,12 @@ struct _crypt_dll_init {
     void * p_k5_context;
 
     /* Version 3 variables */
-    void (*p_install_funcs)(char *,void *);
+    void (*callbackp_install_dllfunc)(char *,void *);
 
     /* Version 5 variables */
     unsigned long (*p_reqtelmutex)(unsigned long);
     unsigned long (*p_reltelmutex)(void);
-};
+} crypt_dll_init_data;
 #endif /* CRYPT_DLL */
 
 /* per Kerberos v5 protocol spec */


### PR DESCRIPTION
rename symbols for SSH and CRYPT DLL initialization code to be consistent over both projects