### PR TITLE
Upgrade to OpenSSL 3.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,10 @@ env:
   # fine, so we've switched back to zlib.net.
   ZLIB_VERSION: 1.3.1
   # Expected filename: https://github.com/openssl/openssl/releases/download/openssl-${{env.OPENSSL_VERSION}}/openssl-${{env.OPENSSL_VERSION}}.tar.gz
-  OPENSSL_VERSION: 3.0.15
+  OPENSSL_VERSION: 3.4.0
   # OpenSSL 3.0 and 3.1 aren't properly compatible with Windows on ARM, so we've
   # got to use 3.2 or newer for that.
-  OPENSSL_ARM_VERSION: 3.3.2
+  OPENSSL_ARM_VERSION: 3.4.0
   # Exoected filename: ${{env.LIBSSH_SOURCE}}libssh-${{env.LIBSSH_VERSION}}.tar.xz
   LIBSSH_SOURCE: https://www.libssh.org/files/0.10/
   LIBSSH_VERSION: 0.10.6

--- a/doc/changes.md
+++ b/doc/changes.md
@@ -89,7 +89,8 @@ by OpenSSH on modern versions of windows, add the command
 
 ### Minor Enhancements and other changes
 * All executables (*.exe, *.dll) now have proper versioninfo resources
-* Upgraded to OpenSSL 3.0.15 which fixes a number of bugs and security issues
+* Upgraded to OpenSSL 3.4 which fixes a number of bugs and security issues and
+  is supported until October 2026. 
 * K95G no longer opens COM1 by default. If you still want this behaviour, add
   `set port com1` to your k95custom.ini
 * The command `set gui toolbar off` has been renamed to


### PR DESCRIPTION
OpenSSL 3.4 is the version that has the longest support horizon at this point (at least until the next LTS release which will probably be 3.5).

Tested fine on Windows XP SP3 and ARM32 Windows 8.1. Not tested on Itanium but earlier releases worked so I'll just have to assume this does too (no access to hardware)