### PR TITLE
arm-build: temporary fix 32-bit ARM build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,20 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    # temporary setup Windows SDK version for 32-bit ARM to 10.0.22621.0 because
+    # latest SDK version 10.0.26100.0 doesn't contains 32-bit ARM files
     - name: Enable Developer Command Prompt
+      if: matrix.arch == 'x64_arm'
+      # You may pin to the exact commit or the version.
+      # uses: ilammy/msvc-dev-cmd@d8610e2b41c6d0f0c3b4c46dad8df0fd826c68e1
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: ${{ matrix.arch }}
+        toolset: ${{ matrix.toolset }}
+        sdk: '10.0.22621.0'
+        #spectre: # set true to use VC libraries with sepctre mitigations
+    - name: Enable Developer Command Prompt
+      if: matrix.arch != 'x64_arm'
       # You may pin to the exact commit or the version.
       # uses: ilammy/msvc-dev-cmd@d8610e2b41c6d0f0c3b4c46dad8df0fd826c68e1
       uses: ilammy/msvc-dev-cmd@v1


### PR DESCRIPTION
in latest Windows SDK 10.0.26100.0 is not included 32-bit ARM files 
latest SDK which contains 32-bit ARM files is 10.0.22621.0