### PR TITLE
Publish the manual to github pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1798,9 +1798,9 @@ jobs:
           echo "Tag: $TAG"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
-  # This version is for publishing on the internet. HTML files end in .html,
-  # and index.html is the front page of the manual
-  Build-Manual-Web:
+  # This version is for publishing on the internet elsewhere. HTML files end
+  # in .html, and index.html is the front page of the manual.
+  Build-Manual-Web-Dist:
     runs-on: windows-latest
     # We need at least one artifact from the Build-VisualCxx step but Github
     needs: Check-Build-Type
@@ -1838,6 +1838,48 @@ jobs:
           path: ${{ github.workspace }}\dist\docs\manual
           retention-days: 1
 
+  # This version is for publishing on github pages. HTML files end in .html,
+  # and index.html is the front page of the manual. If the current commit is
+  # not tagged, then every page has a note at the top saying it is preliminary
+  # documentation for an unreleased version.
+  Build-Manual-Web-Pages:
+    runs-on: windows-latest
+    # We need at least one artifact from the Build-VisualCxx step but Github
+    needs: Check-Build-Type
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fetch K95
+        uses: actions/download-artifact@v4
+        with:
+          name: k95-vs2022-x86
+          path: ${{ github.workspace }}\dist
+      - name: Prepare Documentation
+        env:
+          TAG: ${{needs.Check-Build-Type.outputs.commit-tag}}
+        run: |
+          set root=${{ github.workspace }}
+          
+          REM No tag? not release build
+          if "%TAG%" == "" goto :dev_doc
+          
+          call mkdocs.bat /W
+          
+          goto :done
+          
+          :dev_doc
+          call mkdocs.bat /W /D /B=${{ github.workspace }}\doc\preliminary.html
+          
+          :done
+
+        shell: cmd
+        working-directory: ${{ github.workspace }}\doc
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: k95-manual-for-github-pages
+          path: ${{ github.workspace }}\dist\docs\manual
+          retention-days: 1
+
   # Single deploy job since we're just deploying
   Deploy-Website:
     environment:
@@ -1845,7 +1887,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: windows-latest
     needs:
-      - Build-Manual-Web
+      - Build-Manual-Web-Pages
       - Check-Build-Type
     env:
       have_stable_artifact: yes
@@ -1914,7 +1956,7 @@ jobs:
             cd pages/current
             7z x ..\\..\\k95-manual-web.zip
             cd .. 
-            7z a -tzip artifact\stable.zip current
+            7z a -tzip artifact\\stable.zip current
           echo "have_stable_artifact=yes" >> $GITHUB_ENV
           else
             echo Could not obtain manual artifact from latest release. This build
@@ -1941,7 +1983,7 @@ jobs:
       - name: Fetch Manual as Dev Manual
         uses: actions/download-artifact@v4
         with:
-          name: k95-manual-web
+          name: k95-manual-for-github-pages
           path: ${{ github.workspace }}\pages\dev\
 
       - name: Upload artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1776,7 +1776,10 @@ jobs:
 
   # This checks to see if the commit we're building is tagged. We assume tagged
   # commits indicate a release build of some kind, meaning we should adjust
-  # the version number shown in the generated documentation.
+  # the version number shown in the generated documentation, and deploy the
+  # manual to the stable directory in the github pages artifact.
+  # *Probably* we could do this check as part of the other earlier jobs to shave
+  # 20 seconds off the overall build time.
   Check-Build-Type:
     runs-on: windows-latest
     needs: Build-VisualCxx
@@ -1869,7 +1872,7 @@ jobs:
       # make retaining the existing stable documentation, we just stash the
       # stable documentation artifact *in* the pages artifact.
       - name: Get stable docs
-        if: needs.Check-Build-Type.outputs.commit-tag != ''
+        if: needs.Check-Build-Type.outputs.commit-tag == ''
         shell: cmd
         run: |
           echo Current commit is not tagged. Fetching stable artifact from deployed site...
@@ -2211,3 +2214,11 @@ jobs:
           path: ${{github.workspace}}/dist-mini
           if-no-files-found: error
           retention-days: 7
+
+
+# TODO: If the commit is tagged v... it would be nice to automatically
+#   create a draft release and attach those artifacts that don't
+#   need updating with things not built by GHA. At the moment, that
+#   is probably just: IA64, ARM32 and ARM64. These three architectures
+#   don't receive the dialer or anything else that needs to be built
+#   offline with Visual C++ 6.0 or older.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,12 @@ on:
     branches: [ "master" ]
   workflow_dispatch:
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 env:
   # Expected filename: https://zlib.net/zlib-1.3.1.tar.gz
   # old site: https://ftp.zx.net.nz/pub/dev/lib/zlib/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1836,7 +1836,7 @@ jobs:
           retention-days: 1
 
   # Single deploy job since we're just deploying
-  deploy-website:
+  Deploy-Website:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -1857,7 +1857,7 @@ jobs:
         env:
           TAG: ${{needs.Check-Build-Type.outputs.commit-tag}}
         run: |
-          xcopy /E doc\web pages
+          xcopy /E doc\web pages\
 
           echo "Trigger: ${{ github.ref_type }}"
           echo "Tag: %TAG%

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1850,6 +1850,9 @@ jobs:
     env:
       have_stable_artifact: yes
     # Only master can currently deploy to github-pages
+    # TODO: Eventually this will also need to be enabled for a 'stable' branch
+    #  when we have one.
+    # TODO: And we should probably check that tags start with a 'v...' too.
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/manual-publish'
     steps:
       - name: Checkout
@@ -1875,23 +1878,29 @@ jobs:
       # stable documentation artifact *in* the pages artifact.
       - name: Get stable docs
         if: needs.Check-Build-Type.outputs.commit-tag == ''
-        shell: cmd
+        shell: bash
         run: |
           echo Current commit is not tagged. Fetching stable artifact from deployed site...
           cd pages
-          curl -o artifact\stable.zip https://%GITHUB_REPOSITORY_OWNER%.github.io/ckwin/artifact/stable.zip
-          if exist artifact\stable.zip echo Have stable artifact
-          if exist artifact\stable.zip 7z x artifact\stable.zip
-          if not exist artifact\stable.zip echo Don't have stable artifact, this build will be deployed as stable
-          if not exist artifact\stable.zip echo "have_stable_artifact=no" >> %GITHUB_ENV%
-          exit /b 0
+          
+          curl -o artifact\\stable.zip https://%GITHUB_REPOSITORY_OWNER%.github.io/ckwin/artifact/stable.zip || true
+          
+          if [ -f artifact/stable.zip ]; then
+            echo Have stable artifact from currently deployed site. Using that to retain
+            echo stable documentation in this github-pages artifact.
+            7z x artifact\\stable.zip
+          else
+            echo Could not obtain stable artifact from currently deployed site. This build
+            echo will be used to provide the stable documentation.
+            echo "have_stable_artifact=no" >> $GITHUB_ENV
+          fi
 
       - name: Fetch Manual as Stable Manual
         uses: actions/download-artifact@v4
         if: needs.Check-Build-Type.outputs.commit-tag != '' || env.have_stable_artifact == 'no'
         with:
           name: k95-manual-web
-          path: ${{ github.workspace }}\pages\stable\
+          path: ${{ github.workspace }}\pages\current\
 
       - name: Use current build as stable docs
         if: needs.Check-Build-Type.outputs.commit-tag != '' || env.have_stable_artifact == 'no'
@@ -1900,7 +1909,7 @@ jobs:
           echo Current commit is tagged (or currently deployed site has no stable artifact).
           echo Stable artifact will come from this build. 
           cd pages
-          7z a -tzip artifact\stable.zip stable
+          7z a -tzip artifact\stable.zip current
 
       - name: Fetch Manual as Dev Manual
         uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1889,11 +1889,36 @@ jobs:
             echo Have stable artifact from currently deployed site. Using that to retain
             echo stable documentation in this github-pages artifact.
             7z x artifact\\stable.zip
+          echo "have_stable_artifact=yes" >> $GITHUB_ENV
           else
             echo Could not obtain stable artifact from currently deployed site. This build
             echo will be used to provide the stable documentation.
             echo "have_stable_artifact=no" >> $GITHUB_ENV
           fi
+
+      - name: Fetch Latest Release Manual
+        uses: robinraju/release-downloader@v1
+        if: needs.Check-Build-Type.outputs.commit-tag == '' && env.have_stable_artifact == 'no'
+        with:
+          latest: true
+          fileName: 'k95-manual-web.zip'
+
+      - name: Get stable docs
+        shell: bash
+        if: needs.Check-Build-Type.outputs.commit-tag == '' && env.have_stable_artifact == 'no'
+        run: |
+          if [ -f k95-manual-web.zip ]; then
+            echo Have manual from latest release. This will be used to provide
+            echo stable documentation in this github-pages artifact.
+            mkdir pages/current
+            cd pages/current
+            7z x ..\\..\\k95-manual-web.zip
+          echo "have_stable_artifact=yes" >> $GITHUB_ENV
+          else
+            echo Could not obtain manual artifact from latest release. This build
+            echo will be used to provide the stable documentation.
+            echo "have_stable_artifact=no" >> $GITHUB_ENV
+          fi          
 
       - name: Fetch Manual as Stable Manual
         uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1835,6 +1835,85 @@ jobs:
           path: ${{ github.workspace }}\dist\docs\manual
           retention-days: 1
 
+  # Single deploy job since we're just deploying
+  deploy-website:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: windows-latest
+    needs:
+      - Build-Manual-Web
+      - Check-Build-Type
+    env:
+      have_stable_artifact: yes
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Prepare base site
+        shell: cmd
+        env:
+          TAG: ${{needs.Check-Build-Type.outputs.commit-tag}}
+        run: |
+          xcopy /E doc\web pages
+
+          echo "Trigger: ${{ github.ref_type }}"
+          echo "Tag: %TAG%
+
+      # Because github pages doesn't support partial deployment, we've got to
+      # fetch the bits of the site we don't want to change ourselves and add
+      # them into the new pages artifact. In this case, if the current commit
+      # isn't tagged, then we don't want to update the stable documentation. To
+      # make retaining the existing stable documentation, we just stash the
+      # stable documentation artifact *in* the pages artifact.
+      - name: Get stable docs
+        if: needs.Check-Build-Type.outputs.commit-tag != ''
+        shell: cmd
+        run: |
+          echo Current commit is not tagged. Fetching stable artifact from deployed site...
+          cd pages
+          curl -o artifact\stable.zip https://%GITHUB_REPOSITORY_OWNER%.github.io/ckwin/artifact/stable.zip
+          if exist artifact\stable.zip echo Have stable artifact
+          if exist artifact\stable.zip 7z x artifact\stable.zip
+          if not exist artifact\stable.zip echo Don't have stable artifact, this build will be deployed as stable
+          if not exist artifact\stable.zip echo "have_stable_artifact=no" >> %GITHUB_ENV%
+
+
+      - name: Fetch Manual as Stable Manual
+        uses: actions/download-artifact@v4
+        if: needs.Check-Build-Type.outputs.commit-tag != '' || env.have_stable_artifact == 'no'
+        with:
+          name: k95-manual-web
+          path: ${{ github.workspace }}\pages\stable\
+
+      - name: Use current build as stable docs
+        if: needs.Check-Build-Type.outputs.commit-tag != '' || env.have_stable_artifact == 'no'
+        shell: cmd
+        run: |
+          echo Current commit is tagged (or currently deployed site has no stable artifact).
+          echo Stable artifact will come from this build. 
+          cd pages
+          7z a -tzip artifact\stable.zip stable
+
+      - name: Fetch Manual as Dev Manual
+        uses: actions/download-artifact@v4
+        with:
+          name: k95-manual-web
+          path: ${{ github.workspace }}\pages\dev\
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './pages'
+
+# This doesn't currently work properly.
+# See:  https://github.com/actions/deploy-pages/issues/383
+#      - name: Deploy to GitHub Pages
+#        id: deployment
+#        uses: actions/deploy-pages@v4
+
   # This is the normal version for distribution with the application. HTML
   # files end in .htm, index.htm is the front page of the K95 documentation,
   # and k95manual.htm is the front page of the manual
@@ -1915,6 +1994,8 @@ jobs:
           name: k95-manual-dist-vintage
           path: ${{ github.workspace }}\dist\docs\manual
           retention-days: 1
+
+
 
   ##############################################################################
   # Generate final "releasable" artifacts                                      #

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1849,6 +1849,8 @@ jobs:
       - Check-Build-Type
     env:
       have_stable_artifact: yes
+    # Only master can currently deploy to github-pages
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/manual-publish'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -1882,7 +1884,7 @@ jobs:
           if exist artifact\stable.zip 7z x artifact\stable.zip
           if not exist artifact\stable.zip echo Don't have stable artifact, this build will be deployed as stable
           if not exist artifact\stable.zip echo "have_stable_artifact=no" >> %GITHUB_ENV%
-
+          exit /b 0
 
       - name: Fetch Manual as Stable Manual
         uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: Full Build
 on:
   push:
     branches: [ "master" ]
+    tags:
+      - '*'
   pull_request:
     branches: [ "master" ]
   workflow_dispatch:
@@ -1772,12 +1774,33 @@ jobs:
   # we can't do it until after the Build-VisualCxx job has completed as all
   # the x86 builds have REXX support included
 
+  # This checks to see if the commit we're building is tagged. We assume tagged
+  # commits indicate a release build of some kind, meaning we should adjust
+  # the version number shown in the generated documentation.
+  Check-Build-Type:
+    runs-on: windows-latest
+    needs: Build-VisualCxx
+    outputs:
+      commit-tag: ${{ steps.check-for-tag.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check if commit is tagged
+        id: check-for-tag
+        shell: bash
+        run: |
+          SHA=`git rev-parse HEAD`
+          echo "SHA: $SHA"
+          TAG=`git describe --tags --exact-match $SHA` || true
+          echo "Tag: $TAG"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
   # This version is for publishing on the internet. HTML files end in .html,
   # and index.html is the front page of the manual
   Build-Manual-Web:
     runs-on: windows-latest
     # We need at least one artifact from the Build-VisualCxx step but Github
-    needs: Build-VisualCxx
+    needs: Check-Build-Type
     steps:
       - uses: actions/checkout@v4
       - name: Fetch K95
@@ -1786,9 +1809,23 @@ jobs:
           name: k95-vs2022-x86
           path: ${{ github.workspace }}\dist
       - name: Prepare Documentation
+        env:
+          TAG: ${{needs.Check-Build-Type.outputs.commit-tag}}
         run: |
           set root=${{ github.workspace }}
+          
+          REM No tag? not release build
+          if "%TAG%" == "" goto :dev_doc
+          
+          call mkdocs.bat /W
+          
+          goto :done
+          
+          :dev_doc
           call mkdocs.bat /W /D
+          
+          :done
+
         shell: cmd
         working-directory: ${{ github.workspace }}\doc
       - name: Upload artifact
@@ -1804,7 +1841,7 @@ jobs:
   Build-Manual-Dist:
     runs-on: windows-latest
     # We need at least one artifact from the Build-VisualCxx step but Github
-    needs: Build-VisualCxx
+    needs: Check-Build-Type
     steps:
       - uses: actions/checkout@v4
       - name: Fetch K95
@@ -1813,9 +1850,22 @@ jobs:
           name: k95-vs2022-x86
           path: ${{ github.workspace }}\dist
       - name: Prepare Documentation
+        env:
+          TAG: ${{needs.Check-Build-Type.outputs.commit-tag}}
         run: |
           set root=${{ github.workspace }}
+          
+          REM No tag? not release build
+          if "%TAG%" == "" goto :dev_doc
+
+          call mkdocs.bat
+
+          goto :done
+
+          :dev_doc
           call mkdocs.bat /D
+
+          :done
         shell: cmd
         working-directory: ${{ github.workspace }}\doc
       - name: Upload artifact
@@ -1832,7 +1882,7 @@ jobs:
   Build-Manual-Dist-Vintage:
     runs-on: windows-latest
     # We need at least one artifact from the Build-VisualCxx step but Github
-    needs: Build-VisualCxx
+    needs: Check-Build-Type
     steps:
       - uses: actions/checkout@v4
       - name: Fetch K95
@@ -1841,9 +1891,22 @@ jobs:
           name: k95-vs2022-x86
           path: ${{ github.workspace }}\dist
       - name: Prepare Documentation
+        env:
+          TAG: ${{needs.Check-Build-Type.outputs.commit-tag}}
         run: |
           set root=${{ github.workspace }}
+                    
+          REM No tag? not release build
+          if "%TAG%" == "" goto :dev_doc
+
+          call mkdocs.bat /I
+
+          goto :done
+
+          :dev_doc
           call mkdocs.bat /D /I
+
+          :done
         shell: cmd
         working-directory: ${{ github.workspace }}\doc
       - name: Upload artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1885,7 +1885,9 @@ jobs:
           path: ${{ github.workspace }}\dist\docs\manual
           retention-days: 1
 
-  # Single deploy job since we're just deploying
+  # Deploy the Github Pages website if:
+  #   The branch is master
+  #   Or the tag starts with 'v'
   Deploy-Website:
     environment:
       name: github-pages
@@ -1942,6 +1944,10 @@ jobs:
             echo "have_stable_artifact=no" >> $GITHUB_ENV
           fi
 
+      # If we couldn't fetch the current stable manual from the live github
+      # pages site, then try and fetch the manual artifact from the latest
+      # release instead.
+      # (this is probably something we could just do always
       - name: Fetch Latest Release Manual
         uses: robinraju/release-downloader@v1
         if: needs.Check-Build-Type.outputs.commit-tag == '' && env.have_stable_artifact == 'no'
@@ -1949,7 +1955,7 @@ jobs:
           latest: true
           fileName: 'k95-manual-web.zip'
 
-      - name: Process latest release manual
+      - name: Process Latest Release Manual
         shell: bash
         if: needs.Check-Build-Type.outputs.commit-tag == '' && env.have_stable_artifact == 'no'
         run: |
@@ -1995,11 +2001,12 @@ jobs:
         with:
           path: './pages'
 
-# This doesn't currently work properly.
+# TODO: This doesn't currently work properly.
+# If the commit is built before the tag, the deploy won't happen.
 # See:  https://github.com/actions/deploy-pages/issues/383
-#      - name: Deploy to GitHub Pages
-#        id: deployment
-#        uses: actions/deploy-pages@v4
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
 
   # This is the normal version for distribution with the application. HTML
   # files end in .htm, index.htm is the front page of the K95 documentation,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1883,7 +1883,7 @@ jobs:
           echo Current commit is not tagged. Fetching stable artifact from deployed site...
           cd pages
           
-          curl -o artifact\\stable.zip https://%GITHUB_REPOSITORY_OWNER%.github.io/ckwin/artifact/stable.zip || true
+          curl -o artifact\\stable.zip https://davidrg.github.io/ckwin/artifact/stable.zip || true
           
           if [ -f artifact/stable.zip ]; then
             echo Have stable artifact from currently deployed site. Using that to retain
@@ -1903,7 +1903,7 @@ jobs:
           latest: true
           fileName: 'k95-manual-web.zip'
 
-      - name: Get stable docs
+      - name: Process latest release manual
         shell: bash
         if: needs.Check-Build-Type.outputs.commit-tag == '' && env.have_stable_artifact == 'no'
         run: |
@@ -1913,6 +1913,8 @@ jobs:
             mkdir pages/current
             cd pages/current
             7z x ..\\..\\k95-manual-web.zip
+            cd .. 
+            7z a -tzip artifact\stable.zip current
           echo "have_stable_artifact=yes" >> $GITHUB_ENV
           else
             echo Could not obtain manual artifact from latest release. This build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1796,7 +1796,12 @@ jobs:
           echo "SHA: $SHA"
           TAG=`git describe --tags --exact-match $SHA` || true
           echo "Tag: $TAG"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          if [[ $TAG == v* ]] ; then 
+              echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          else 
+              echo "Not a release tag"
+              echo "tag=" >> "$GITHUB_OUTPUT"
+          fi
 
   # This version is for publishing on the internet elsewhere. HTML files end
   # in .html, and index.html is the front page of the manual.
@@ -1891,11 +1896,10 @@ jobs:
       - Check-Build-Type
     env:
       have_stable_artifact: yes
-    # Only master can currently deploy to github-pages
+    # Only master or tags starting with v can currently deploy to github-pages
     # TODO: Eventually this will also need to be enabled for a 'stable' branch
     #  when we have one.
-    # TODO: And we should probably check that tags start with a 'v...' too.
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/manual-publish'
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/manual-publish'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -83,15 +83,17 @@ supported and can be configured via the `set mouse reporting` command.
 Documentation
 -------------
 
-The Kermit 95 manual has mostly been revised for K95 v3.0 and is now included
-as of beta 7. To view it, choose _Manual_ from the _Help_ menu, or type the
-`manual` command at the K-95 prompt. There is also a 
-[Kermit 95 How-To](https://www.kermitproject.org/ckwhowto.html) which may be 
+The Kermit 95 manual has mostly been revised for K95 v3.0 and is now
+[available on the web](https://davidrg.github.io/ckwin/current/) in addition to
+being included as part of the standard K95 distribution as of beta 7. To open it
+from Kermit 95, choose _Manual_ from the _Help_ menu, or type the `manual` 
+command at the K-95 prompt. There is also a [Kermit 95 How-To](https://www.kermitproject.org/ckwhowto.html) which may be 
 useful for new users.
 
 The full documentation for the built-in SSH client is now included in the
-_SSH Client Reference_ section of the users guide, but for a quick summary
-you can consult the [SSH Readme](doc/ssh-readme.md). 
+[_SSH Client Reference_](https://davidrg.github.io/ckwin/current/sshclien.html) 
+section of the users guide, but for a quick summary you can consult the 
+[SSH Readme](doc/ssh-readme.md). 
 
 If you previously used Kermit 95 v2.1 or earlier and would like to know what's 
 changed, see the [Kermit 95 Change Log](doc/changes.md) as well as the C-Kermit 9.0

--- a/doc/web/index.html
+++ b/doc/web/index.html
@@ -24,7 +24,7 @@
     <li>IBM OS/2 2.x, Warp 3, Warp 4</li>
 </ul>
 
-<p>For support, you can ask a question <a href="https://github.com/davidrg/ckwin/discussions">on Github Discussions</a></p>
+<p>For support, you can ask a question <a href="https://github.com/davidrg/ckwin/discussions">on Github Discussions</a>.</p>
 
 <p>
     For more information:

--- a/doc/web/index.html
+++ b/doc/web/index.html
@@ -24,6 +24,8 @@
     <li>IBM OS/2 2.x, Warp 3, Warp 4</li>
 </ul>
 
+<p>For support, you can ask a question <a href="https://github.com/davidrg/ckwin/discussions">on Github Discussions</a></p>
+
 <p>
     For more information:
 </p>
@@ -31,6 +33,14 @@
     <li><a href="https://github.com/davidrg/ckwin/?tab=readme-ov-file#readme">The New Open Source Kermit 95</a></li>
     <li><a href="https://kermitproject.org/ckw10beta.html">The Latest Kermit 95 beta information on kermitproject.org</a></li>
     <li><a href="https://kermitproject.org/k95.html">Information about Kermit 95 2.1.3</a> (from 2003, not open source)</li>
+</ul>
+<p>And these pages from <a href="https://github.com/davidrg/ckwin/wiki">the Wiki</a> may be useful:</p>
+<ul>
+    <li><a href="https://github.com/davidrg/ckwin/wiki/Feature-Comparison">Kermit 95 vs Tera Term and PuTTY</a></li>
+    <li><a href="https://github.com/davidrg/ckwin/wiki/Feature-Comparison:-Windows-HyperTerminal">Kermit 95 vs Windows HyperTerm (9x/NT through XP)</a></li>
+    <li><a href="https://github.com/davidrg/ckwin/wiki/Hyperlinks">Hyperlink support in K95</a></li>
+    <li><a href="https://github.com/davidrg/ckwin/wiki/Terminal-Emulation">Supported Terminal Emulations</a></li>
+    <li><a href="https://github.com/davidrg/ckwin/wiki/Simple-Console-Server">Simple RFC2217 Console Server</a></li>
 </ul>
 <hr>
 </body>

--- a/doc/web/index.html
+++ b/doc/web/index.html
@@ -9,7 +9,7 @@
     to being packaged with Kermit 95:
 </p>
 <ul>
-    <li><a href="stable/">Kermit 95 v3.0 - latest stable release</a> (3.0.0 beta 7 currently)</li>
+    <li><a href="current/">Kermit 95 v3.0 - latest stable release</a> (3.0.0 beta 7 currently)</li>
     <li><a href="dev/">Kermit 95 latest development build</a> - may discuss features and details that are not available yet</li>
     <li><a href="https://kermitproject.org/k95manual/">Kermit 95 v2.1.3</a> - the last commercial release from 2003</li>
 </ul>

--- a/doc/web/index.html
+++ b/doc/web/index.html
@@ -1,0 +1,37 @@
+<html>
+<head>
+    <title>Kermit 95 Documentation</title>
+</head>
+<body>
+<h1>Kermit 95 Documentation</h1>
+<hr>
+<p>Three versions of the Kermit 95 manual are currently available online in addition
+    to being packaged with Kermit 95:
+</p>
+<ul>
+    <li><a href="stable/">Kermit 95 v3.0 - latest stable release</a> (3.0.0 beta 7 currently)</li>
+    <li><a href="dev/">Kermit 95 latest development build</a> - may discuss features and details that are not available yet</li>
+    <li><a href="https://kermitproject.org/k95manual/">Kermit 95 v2.1.3</a> - the last commercial release from 2003</li>
+</ul>
+
+<p>To download Kermit 95, the latest stable release is:
+    <a href="https://github.com/davidrg/ckwin/releases/tag/3.0.0beta7">
+        Kermit 95 3.0 beta 7</a>. Open Source, no registration required. Works on:
+</p>
+<ul>
+    <li>all 32-bit and 64-bit desktop versions of Windows on any CPU architecture,
+        and most server versions (excludes Windows NT 3.10)
+    <li>IBM OS/2 2.x, Warp 3, Warp 4</li>
+</ul>
+
+<p>
+    For more information:
+</p>
+<ul>
+    <li><a href="https://github.com/davidrg/ckwin/?tab=readme-ov-file#readme">The New Open Source Kermit 95</a></li>
+    <li><a href="https://kermitproject.org/ckw10beta.html">The Latest Kermit 95 beta information on kermitproject.org</a></li>
+    <li><a href="https://kermitproject.org/k95.html">Information about Kermit 95 2.1.3</a> (from 2003, not open source)</li>
+</ul>
+<hr>
+</body>
+</html>


### PR DESCRIPTION
This _should_ maintain two versions of the manual on github pages:

* The manual for the latest "stable" release (which is really beta 7 right now). This is either downloaded from the previous version of the github pages site and added in to the new version, or its pulled from an asset attached to the latest release on github
* The manual for the current development code in the git master branch

There is also a little index page with some information and other pointers.