### PR TITLE
Implement OSC-52

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -69,7 +69,11 @@ and terminal emulations that *do not* use the new 256-color/24-bit color modes,
    - The text cursor
    - Dim text (if the dim attribute is disabled with the new
      `SET TERMINAL ATTRIBUTE DIM OFF COLOR` command)
-
+ - Clipboard access for the remote host is now supported via OSC-52. This can be
+   enabled or disabled for read, write or both with 
+   `SET TERMINAL CLIPBOARD-ACCESS`. You can optionally choose to be notified
+   when the remote host attempts to access your clipboard. For security, the
+   default is disabled with a notification.
 
 ### Enhancements
  - The Control Sequences documentation ([preliminary version available online](https://davidrg.github.io/ckwin/dev/ctlseqs.html))

--- a/doc/ctlseqs.xml
+++ b/doc/ctlseqs.xml
@@ -14074,7 +14074,7 @@ DCS $ q 3 , } ST</pre>
                     parameter is the question-mark character (?), Kermit 95 will
                     convert the current clipboard data to the remote character
                     set, base64 encode it, and return it in the form:
-                    <tt>OSC 52 ; Pd ST</tt>
+                    <tt>OSC 52 ;; Pd ST</tt>
                 </p>
                 <p>
                     By default, aside from producing a notification in K95G on

--- a/doc/ctlseqs.xml
+++ b/doc/ctlseqs.xml
@@ -14034,16 +14034,55 @@ DCS $ q 3 , } ST</pre>
                      not-implemented="true" todo="true">
                 <ctlseq><param-single/> = 51</ctlseq>
                 <ref src="xt:h4-Operating-System-Commands:OSC-Ps;Pt-ST:Ps-=-5-1.101A"/>
-                <termsupp first="xterm" series="xt" additional=""/>
+                <p>
+                    Reserved for Emacs Shell in January 2000 for a similar
+                    purpose to OSC-7 that was never implemented. Not
+                    <em>known</em> to be in use anywhere.
+                </p>
                 <!-- Reserved, but possibly never actually used?
                     https://www.reddit.com/r/emacs/comments/7rxv6d/comment/lpigict/ -->
             </section>
             <section role="parameter" id="osc-52" mnemonic=""
-                     title="Manipulate selection data"
-                     not-implemented="true" todo="true">
-                <ctlseq><param-single/> = 52</ctlseq>
+                     title="Manipulate selection (clipboard) data">
+                <ctlseq><param-single/> = 52 ; Pc ; Pd</ctlseq>
                 <ref src="xt:h4-Operating-System-Commands:OSC-Ps;Pt-ST:Ps-=-5-2.101B"/>
                 <termsupp first="xterm" series="xt" additional="tt"/>
+                <p>
+                    The first parameter, <param-single symbol="Pc"/>, specifies
+                    which of xterms buffers are being manipulated. One or more
+                    of the following can be specified: c p q s 0 1 2 3 4 5 6 7
+                </p>
+                <p>
+                    As Windows and OS/2 only have the clipboard, Kermit 95
+                    validates the first parameter but otherwise ignores it.
+                    As the first parameter is optional, no value needs to be
+                    supplied for it.
+                </p>
+                <p>
+                    The second parameter, <param-single symbol="Pd"/>, is the
+                    new base64-encoded <em>text</em> to place in the clipboard.
+                    The text (before being base64 encoded) is assumed to be in
+                    the same character set as current remote character set.
+                    Kermit 95 will attempt to convert it to the local codepage
+                    if Unicode is disabled or Kermit 95 is running on a version
+                    of Windows that does not support Unicode (Windows 95/98/ME).
+                    Kermit 95 does not attempt to convert the character
+                    encoding.
+                </p>
+                <p>
+                    If, rather than a base64-encoded string, the second
+                    parameter is the question-mark character (?), Kermit 95 will
+                    convert the current clipboard data to the remote character
+                    set, base64 encode it, and return it in the form:
+                    <tt>OSC 52 ; Pd ST</tt>
+                </p>
+                <p>
+                    By default, aside from producing a notification in K95G on
+                    Windows 2000 or newer Kermit 95 ignores OSC-52 unless the
+                    user has chosen to enable it. Read and Write can be enabled
+                    individually via the <tt>SET TERMINAL CLIPBOARD-ACCESS</tt>
+                    command.
+                </p>
             </section>
             <section role="parameter" id="osc-60" mnemonic="XTQALLOWED"
                      title="Query allowed features"

--- a/doc/manual/setterm.html
+++ b/doc/manual/setterm.html
@@ -167,6 +167,16 @@ you must not have <tt>PARITY</tt> set to anything other than <tt>NONE</tt>.
 <i>remote-set</i></tt>
 
 <p>
+<dt><tt>SET TERMINAL CLIPBOARD-ACCESS <i>{</i> ALLOW-BOTH, ALLOW-READ,
+    ALLOW-WRITE <i>}</i> <i>{</i> ON, OFF <i>} NOTIFY</i></tt>
+<dd>
+    Enable or disable clipboard access by the remote host using OSC-52. You can
+    turn read and write on or off individually, or you can set both at once with
+    the <tt>ALLOW-BOTH</tt> option. You can optionally choose to be notified
+    when theremote host attempts to access the clipboard with the
+    <tt>NOTIFY</tt> option. This requires Windows 2000 or newer.
+</dd>
+<p>
 <dt><tt>SET TERMINAL CODE-PAGE nnn</tt>
 <dd>This command can not be used in Windows 95.  In OS/2 and Windows NT, it
 actually loads the given code page into your session.  Make sure to also give a

--- a/kermit/k95/ckoco3.c
+++ b/kermit/k95/ckoco3.c
@@ -12532,8 +12532,8 @@ doosc( void ) {
 
                         /* Encode it... */
                         if ((rc = b8tob64(clipboardData, -1, encodedData, encodedLen)) >= 0) {
-                            /* Send it in the form: OSC 52 ; data ST */
-                            sendchars("\033]52;", 5);
+                            /* Send it in the form: OSC 52 ;; data ST */
+                            sendchars("\033]52;;", 6);
                             sendchars(encodedData, rc);
                             sendchars("\033\\", 2);
                         } else {

--- a/kermit/k95/ckoco3.c
+++ b/kermit/k95/ckoco3.c
@@ -12644,8 +12644,9 @@ doosc( void ) {
                         if (use_unicode) {
                             rc = CopyToClipboard((BYTE*)ucs2_string,
                                                  sizeof(USHORT) * cliplen);
-                        } else {
+                        } else
 #endif /* NT */
+                        {
                             /* We've now got the clipboard data as a UCS-2
                              * string, but we're on Windows 9x or OS/2 (or NT
                              * with Unicode support turned off), so we need to

--- a/kermit/k95/ckoco3.c
+++ b/kermit/k95/ckoco3.c
@@ -188,8 +188,8 @@ extern int tt_status[VNUM];           /* Terminal status line displayed */
 extern int tt_status_usr[VNUM];
 extern int tt_modechg;          /* Terminal Video-Change (80 or 132 cols) */
 extern int tt_senddata;         /* May data be sent to the host */
-extern int tt_clipboard_read = CLIPBOARD_DENY_NOTIFY,
-           tt_clipboard_write = CLIPBOARD_DENY_NOTIFY; /* OSC-52 */
+extern int tt_clipboard_read,
+           tt_clipboard_write;  /* OSC-52 */
 extern int tt_hidattr;          /* Attributes do not occupy a space */
 #ifdef PCTERM
 extern int tt_pcterm;

--- a/kermit/k95/ckoco3.c
+++ b/kermit/k95/ckoco3.c
@@ -41,6 +41,7 @@
 #include <string.h>
 #include <assert.h>
 #include <time.h>
+#include <math.h>
 
 #define DECLED
 
@@ -12522,7 +12523,7 @@ doosc( void ) {
                     }
 #endif /* NT */
 
-                    if (clipboardData) {
+                    if (clipboardData != NULL) {
                         /* Allocate memory for the maximum length the base64
                          * encoded data could be */
                         int rc;

--- a/kermit/k95/ckoco4.c
+++ b/kermit/k95/ckoco4.c
@@ -884,7 +884,7 @@ CopyVscrnToClipboard( BYTE vmode, int select_mode )
         return -1 ;
 
     return CopyToClipboard(
-        use_unicode ? Uselection : selection,
+        use_unicode ? (unsigned char*)Uselection : selection,
         use_unicode ? 2 * nselect : nselect);
 }
 

--- a/kermit/k95/ckoco4.c
+++ b/kermit/k95/ckoco4.c
@@ -550,6 +550,85 @@ CopyVscrnToKbdBuffer( BYTE vmode, int select_mode ) {
     return rc ;
 }
 
+#ifdef NT
+USHORT *
+GetUnicodeClipboardContent()
+{
+    BYTE * hClipbrdData ;
+    USHORT * pUClipbrdData = 0;
+    HGLOBAL hClipboard = NULL ;
+
+    if ( OpenClipboard( NULL ) )
+    {
+        if ( hClipboard = (BYTE *) GetClipboardData( CF_UNICODETEXT ) )
+        {
+            hClipbrdData = GlobalLock(hClipboard) ;
+            pUClipbrdData = wcsdup( (const wchar_t *) hClipbrdData ) ;
+            GlobalUnlock( hClipboard ) ;
+        }
+        CloseClipboard();
+    }
+
+    return pUClipbrdData ;
+}
+#endif /* NT */
+
+BYTE *
+GetClipboardContent()
+{
+    APIRET rc = -1 ;
+    BYTE * hClipbrdData ;
+    USHORT * pUClipbrdData = 0;
+    BYTE * pClipbrdData = 0 ;
+#ifndef NT
+    BYTE * pClipboard ;
+#endif /* NT */
+
+#ifdef NT
+    HGLOBAL hClipboard = NULL ;
+
+    if ( OpenClipboard( NULL ) )
+    {
+        if ( hClipboard = (BYTE *) GetClipboardData( CF_TEXT ) )
+        {
+            hClipbrdData = GlobalLock(hClipboard) ;
+            pClipbrdData = strdup( hClipbrdData ) ;
+            GlobalUnlock( hClipboard ) ;
+        }
+
+        CloseClipboard() ;
+    }
+    if ( pClipbrdData )
+        CharToOem( pClipbrdData, pClipbrdData );
+#else /* NT */
+    pClipbrdData = GetTextFromClipboardServer() ;
+
+    if ( !pClipbrdData ) {
+        if ( rc = WinOpenClipbrd(hab) ) {
+            hClipbrdData = (BYTE *) WinQueryClipbrdData( hab, CF_TEXT ) ;
+            if ( !DosGetSharedMem( hClipbrdData, PAG_READ ) )
+            {
+                pClipbrdData = strdup( hClipbrdData ) ;
+
+                /* We must copy the text back to the Clipboard because the   */
+                /* GetSharedMemory call screwed up the clipboard.  We're not */
+                /* supposed to do things like that.                          */
+                if ( !DosAllocSharedMem( (PPVOID) &pClipboard, 0, strlen(pClipbrdData)+1,
+                                         PAG_COMMIT | PAG_READ | PAG_WRITE |
+                                         OBJ_GIVEABLE | OBJ_GETTABLE ) )
+                {
+                    strcpy( pClipboard, pClipbrdData ) ;
+                    WinSetClipbrdData( hab, (ULONG) pClipboard, CF_TEXT, CFI_POINTER ) ;
+                    DosFreeMem( pClipboard ) ;
+                }
+            }
+            WinCloseClipbrd( hab ) ;
+        }
+    }
+#endif /* NT */
+    return pClipbrdData ;
+}
+
 APIRET
 CopyClipboardToKbdBuffer( BYTE vmode )
 {
@@ -727,9 +806,8 @@ CopyClipboardToKbdBuffer( BYTE vmode )
 }
 
 APIRET
-CopyVscrnToClipboard( BYTE vmode, int select_mode )
+CopyToClipboard( BYTE* data, ULONG length )
 {
-    ULONG  ClipBoardSz = 0 ;
     BYTE * pClipboard = 0 ;
 #ifdef NT
     HGLOBAL hClipboard = NULL ;
@@ -737,17 +815,11 @@ CopyVscrnToClipboard( BYTE vmode, int select_mode )
     APIRET rc = 0 ;
     int use_unicode = (ck_isunicode() && !isWin95());
 
-    if ( VscrnSelect(vmode, select_mode) )
-        return -1 ;
-
-    /* Determine size of Clipboard */
-    ClipBoardSz = use_unicode ? 2 * nselect : nselect ;
-
     /* Allocate Clipboard Buffer */
 #ifdef NT
-    if ( (hClipboard = GlobalAlloc( GMEM_MOVEABLE | GMEM_DDESHARE, ClipBoardSz )) == NULL )
+    if ( (hClipboard = GlobalAlloc( GMEM_MOVEABLE | GMEM_DDESHARE, length )) == NULL )
 #else /* NT */
-    if ( rc = DosAllocSharedMem( (PPVOID) &pClipboard, 0, ClipBoardSz,
+    if ( rc = DosAllocSharedMem( (PPVOID) &pClipboard, 0, length,
                    PAG_COMMIT | PAG_READ | PAG_WRITE |
                    OBJ_GIVEABLE | OBJ_GETTABLE ) )
 #endif /* NT */
@@ -769,10 +841,7 @@ CopyVscrnToClipboard( BYTE vmode, int select_mode )
 #endif /* NT */
 
     /* Copy the data to the clibboard buffer */
-    if ( use_unicode )
-        memcpy( pClipboard, Uselection, ClipBoardSz );
-    else
-        strcpy( pClipboard, selection ) ;
+    memcpy( pClipboard, data, length );
 
 #ifdef NT
     if ( !use_unicode )
@@ -804,6 +873,19 @@ CopyVscrnToClipboard( BYTE vmode, int select_mode )
       }
 #endif /* NT */
     return rc ;
+}
+
+APIRET
+CopyVscrnToClipboard( BYTE vmode, int select_mode )
+{
+    int use_unicode = (ck_isunicode() && !isWin95());
+
+    if ( VscrnSelect(vmode, select_mode) )
+        return -1 ;
+
+    return CopyToClipboard(
+        use_unicode ? Uselection : selection,
+        use_unicode ? 2 * nselect : nselect);
 }
 
 

--- a/kermit/k95/ckocon.h
+++ b/kermit/k95/ckocon.h
@@ -1656,6 +1656,12 @@ _PROTOTYP( int os2_setcmdwidth,(int));
 _PROTOTYP( int kui_setheightwidth,(int,int));
 #endif /* KUI */
 
+_PROTOTYP( APIRET CopyToClipboard, ( BYTE* data, ULONG length ));
+_PROTOTYP( BYTE * GetClipboardContent, (void));
+#ifdef NT
+_PROTOTYP( USHORT * GetUnicodeClipboardContent, (void));
+#endif /* NT */
+
 typedef struct _hyperlink {
     int index;
     int type;

--- a/kermit/k95/ckocon.h
+++ b/kermit/k95/ckocon.h
@@ -1374,6 +1374,12 @@ typedef struct videobuffer_struct {
 _PROTOTYP( void setdecssdt, (int));
 _PROTOTYP( void setdecsasd, (bool));
 
+/* Clipboard Access settings */
+#define CLIPBOARD_ALLOW 1
+#define CLIPBOARD_ALLOW_NOTIFY 2
+#define CLIPBOARD_DENY 0
+#define CLIPBOARD_DENY_NOTIFY -1
+
 enum charsetsize { cs94, cs96, cs128, csmb } ;
 struct _vtG {
     unsigned char designation, def_designation ;
@@ -1485,6 +1491,7 @@ _PROTOTYP( void JumpScroll, (void ) ) ;
 _PROTOTYP( APIRET VscrnSelect, ( BYTE, int ) ) ;
 _PROTOTYP( APIRET VscrnURL, ( BYTE, USHORT, USHORT       ) ) ;
 _PROTOTYP( APIRET CopyVscrnToKbdBuffer, ( BYTE, int ) ) ;
+_PROTOTYP( APIRET CopyToClipboard, ( BYTE* data, ULONG length ) ) ;
 _PROTOTYP( APIRET CopyVscrnToClipboard, ( BYTE, int ) ) ;
 _PROTOTYP( APIRET CopyVscrnToPrinter, ( BYTE, int ) ) ;
 _PROTOTYP( APIRET CopyClipboardToKbdBuffer, ( BYTE ) ) ;

--- a/kermit/k95/ckoker.mak
+++ b/kermit/k95/ckoker.mak
@@ -124,7 +124,7 @@ MSC_VER = 80
 TARGET_CPU = x86
 !endif
 
-WIN32_VERSION=0x0400
+WIN32_VERSION=0x0400]
 
 # So that we can set the minimum subsystem version when needed
 SUBSYSTEM_CONSOLE=console

--- a/kermit/k95/ckotio.c
+++ b/kermit/k95/ckotio.c
@@ -460,6 +460,7 @@ int dfloc = 0;
 
 int OSVer = 0;
 int nt351 = 0;
+int nt5 = 0;
 
 #ifdef NTSIG
 int TlsIndex = 0;
@@ -1710,6 +1711,7 @@ sysinit() {
                 OSVer = osverinfo.dwPlatformId ;
 
             if (osverinfo.dwMajorVersion < 4) nt351 = 1; /* We're on NT 3.51 */
+            if (osverinfo.dwMajorVersion > 4) nt5 = 1; /* We're on Win2k or newer */
 
 #ifndef CK_UTSNAME
             sprintf(ckxsystem, " %s %1d.%02d(%1d)%s%s",

--- a/kermit/k95/ckuus2.c
+++ b/kermit/k95/ckuus2.c
@@ -8078,7 +8078,28 @@ static char *hxyterm[] = {
 #endif /* NOCSETS */
 
 #ifdef OS2
-
+"SET TERMINAL CLIPBOARD-ACCESS { ALLOW-BOTH, ALLOW-READ, ALLOW-WRITE } ",
+#ifdef KUI
+#ifdef CK_SHELL_NOTIFY
+"  { ON, OFF } NOTIFY",
+#else /* CK_SHELL_NOTIFY */
+"  { ON, OFF }",
+#endif /* CK_SHELL_NOTIFY */
+#else /* KUI */
+"  { ON, OFF }",
+#endif /* KUI */
+" Enable or disable clipboard access by the remote host using OSC-52. You can",
+" turn read and write on or off individually, or you can set both at once with",
+" the ALLOW-BOTH option. ",
+#ifdef KUI
+#ifdef CK_SHELL_NOTIFY
+" ",
+" You can optionally choose to be notified when the remote host attempts to ",
+" access the clipboard with the NOTIFY option. This requires Windows 2000 or ",
+" newer",
+#endif /* CK_SHELL_NOTIFY */
+#endif /* KUI */
+" ",
 "SET TERMINAL CODE-PAGE <number>",
 "  Lets you change the PC code page.  Only works for code pages that are",
 "  successfully prepared in CONFIG.SYS.  Use SHOW TERMINAL to list the",

--- a/kermit/k95/ckuus5.c
+++ b/kermit/k95/ckuus5.c
@@ -6111,6 +6111,7 @@ shotrm() {
     extern int wy_autopage, autoscroll, sgrcolors, colorreset, user_erasemode,
       decscnm, decscnm_usr, tt_diff_upd, tt_senddata,
       wy_blockend, marginbell, marginbellcol, tt_modechg, dgunix;
+    extern int tt_clipboard_read, tt_clipboard_write;
     int lines = 0;
     extern int colorpalette;
 #ifdef KUI
@@ -6252,8 +6253,8 @@ shotrm() {
             "Color palette", s);
     if (++lines > cmd_rows - 3) { if (!askmore()) return; else lines = 0; }
 
-    printf(" %19s: %-13d  %13s: %-15d\n","Transmit-timeout",tt_ctstmo,
-           "Output-pacing",tt_pacing);
+    printf(" %19s: %-13d  %13s: %-15s\n","Transmit-timeout",tt_ctstmo,
+           "Screen mode",decscnm?"reverse":"normal");
     if (++lines > cmd_rows - 3) { if (!askmore()) return; else lines = 0; }
 
     printf(" %19s: %-13d  %13s: %s\n","Idle-timeout",tt_idlelimit,
@@ -6262,6 +6263,40 @@ shotrm() {
     if (++lines > cmd_rows - 3) { if (!askmore()) return; else lines = 0; }
     printf(" %19s: %-13s  %13s: %-15s\n","Send data",
           showoff(tt_senddata),"End of Block", wy_blockend?"crlf/etx":"us/cr");
+    if (++lines > cmd_rows - 3) { if (!askmore()) return; else lines = 0; }
+
+    /* Shell notifications only in K95G on Windows 2000 or newer */
+#ifndef KUI
+#ifdef CK_SHELL_NOTIFY
+#undef CK_SHELL_NOTIFY
+#endif /* CK_SHELL_NOTIFY */
+#endif /* KUI */
+
+#ifdef CK_SHELL_NOTIFY
+    printf(" %19s: %-13s  %13s: %-15s\n",
+            "Clipboard: Read",
+                tt_clipboard_read == CLIPBOARD_ALLOW ? "allow"
+              : tt_clipboard_read == CLIPBOARD_ALLOW_NOTIFY ? "allow, notify"
+              : tt_clipboard_read == CLIPBOARD_DENY ? "deny"
+              : tt_clipboard_read == CLIPBOARD_DENY_NOTIFY ? "deny, notify"
+              : "",
+            "Write",
+                tt_clipboard_write == CLIPBOARD_ALLOW ? "allow"
+              : tt_clipboard_write == CLIPBOARD_ALLOW_NOTIFY ? "allow, notify"
+              : tt_clipboard_write == CLIPBOARD_DENY ? "deny"
+              : tt_clipboard_write == CLIPBOARD_DENY_NOTIFY ? "deny, notify"
+              : "");
+#else /* CK_SHELL_NOTIFY */
+    printf(" %19s: %-13s  %13s: %-15s\n",
+            "Clipboard: Read",
+                tt_clipboard_read >= CLIPBOARD_ALLOW ? "allow"
+              : tt_clipboard_read <= CLIPBOARD_DENY ? "deny"
+              : "",
+            "Write",
+                tt_clipboard_write >= CLIPBOARD_ALLOW ? "allow"
+              : tt_clipboard_write <= CLIPBOARD_DENY ? "deny"
+              : "");
+#endif /* CK_SHELL_NOTIFY */
     if (++lines > cmd_rows - 3) { if (!askmore()) return; else lines = 0; }
 #ifndef NOTRIGGER
     printf(" %19s: %-13s  %13s: %d seconds\n","Auto-exit trigger",
@@ -6337,10 +6372,8 @@ shotrm() {
            "Screen-optimization",showoff(tt_diff_upd),
            "Status line",showoff(tt_status[VTERM]));
     if (++lines > cmd_rows - 3) { if (!askmore()) return; else lines = 0; }
-    printf(" %19s: %-13s  %13s: %-15s\n","Screen mode",decscnm?"reverse":"normal",
+    printf(" %19s: %-13s  %13s: %-15s\n","Debug", showoff(debses),
            "Session log", seslog? sesfil : "(none)" );
-    if (++lines > cmd_rows - 3) { if (!askmore()) return; else lines = 0; }
-    printf(" %19s: %-13s  \n", "Debug", showoff(debses));
     if (++lines > cmd_rows - 3) { if (!askmore()) return; else lines = 0; }
 
     /* Display colors (should become SHOW COLORS) */

--- a/kermit/k95/ckuus7.c
+++ b/kermit/k95/ckuus7.c
@@ -1424,7 +1424,8 @@ int tt_status_usr[VNUM] = {1,1,0,0};
 #else /* K95G */
 int tt_status[VNUM] = {0,0,0,0};        /* Terminal status line displayed */
 int tt_status_usr[VNUM] = {0,0,0,0};
-int tt_clipboard_read = 1, tt_clipboard_write = 1; /* Host clipboard access */
+int tt_clipboard_read = CLIPBOARD_DENY_NOTIFY,
+    tt_clipboard_write = CLIPBOARD_DENY_NOTIFY; /* Host clipboard access */
 #endif /* K95G */
 #endif /* KUI */
 int tt_senddata = 0;                    /* Let host read terminal data */

--- a/kermit/k95/ckuusr.h
+++ b/kermit/k95/ckuusr.h
@@ -1301,6 +1301,7 @@ struct stringint {			/* String and (wide) integer */
 #define   XYTIACT   63  /* SET TERM IDLE-ACTION  */
 #define   XYTLSP    64  /* SET TERM LINE-SPACING */
 #define   XYTLFD    65	/* SET TERM LF-DISPLAY   */
+#define   XYTCLP    66  /* SET TERM CLIPBOARD-ACCESS */
 
 #define XYATTR 34       /* Attribute packets  */
 #define XYSERV 35	/* Server parameters  */
@@ -2035,6 +2036,7 @@ struct stringint {			/* String and (wide) integer */
 #define SHOLOC    73			/* SHOW LOCALE */
 #define SHOTMPDIR 74			/* SHOW TEMP-DIRECTORY */
 #define SHOVMSTXT 75			/* SHOW VMS_TEXT */
+#define SHONOTIF  76            /* SHOW NOTIFICATION */
 
 /* REMOTE command symbols */
 

--- a/kermit/k95/feature_flags.mak
+++ b/kermit/k95/feature_flags.mak
@@ -67,6 +67,18 @@ DISABLED_FEATURE_DEFS = $(DISABLED_FEATURE_DEFS) -DNOTYPEINTERPRET
 !if "$(PLATFORM)" == "NT"
 WIN32_VERSION=0x0400
 
+!if ($(MSC_VER) >= 150)
+# Visual C++ 2008 can't target anything older than Windows 2000, so bump the
+# WINVER up to that to get some extra shell notification icon features.
+!message Targeting Windows 2000 or newer
+WIN32_VERSION=0x0500
+!endif
+
+!if ($(MSC_VER) > 120)
+# Shell Notify requires Windows 2000 and Visual C++ 2002 (7.0) or newer
+ENABLED_FEATURE_DEFS = $(ENABLED_FEATURE_DEFS) -DCK_SHELL_NOTIFY
+!endif
+
 !if "$(CMP)" == "OWCL"
 # No built-in SSH support for Open Watcom (yet), so if SSH support has been
 # requested, turn Dynamic SSH on.

--- a/kermit/k95/kui/ikui.cxx
+++ b/kermit/k95/kui/ikui.cxx
@@ -282,3 +282,11 @@ void KuiGetProperty( int propid, intptr_t param1, intptr_t param2 )
     if( kui )
         kui->getProperty( propid, param1, param2 );
 }
+
+/*------------------------------------------------------------------------
+------------------------------------------------------------------------*/
+#ifdef CK_SHELL_NOTIFY
+void KuiShowNotification(int icon, char* title, char * message) {
+    kui->getTerminal()->showNotification(icon, title, message);
+}
+#endif /* CK_SHELL_NOTIFY */

--- a/kermit/k95/kui/ikui.h
+++ b/kermit/k95/kui/ikui.h
@@ -77,3 +77,15 @@ void KuiSetTerminalRunMode(int);
 #define STATUS_HW         4
 
 int KuiFileDialog(char *, char *, char *, int, BOOL, BOOL);
+
+#ifdef CK_SHELL_NOTIFY
+#ifndef KUI_NOTIF_I_NONE
+#define KUI_NOTIF_I_NONE   0
+#define KUI_NOTIF_I_INFO   1
+#define KUI_NOTIF_I_WARN   2
+#define KUI_NOTIF_I_ERR    3
+#define KUI_NOTIF_I_USER   4
+#endif /* KUI_NOTIF_I_NONE */
+
+void KuiShowNotification(int icon, char* title, char * message);
+#endif /* CK_SHELL_NOTIFY */

--- a/kermit/k95/kui/kappwin.cxx
+++ b/kermit/k95/kui/kappwin.cxx
@@ -1,3 +1,15 @@
+#ifndef CKT_NT35
+#ifdef CK_SHELL_NOTIFY
+#ifdef __WATCOMC__
+/* The Watcom headers need this defined for shell notifications */
+#ifdef _WIN32_IE
+#undef _WIN32_IE
+#endif /* _WIN32_IE */
+#define _WIN32_IE 0x0500
+#endif /* __WATCOMC__ */
+#endif /* CK_SHELL_NOTIFY */
+#endif /* CKT_NT35 */
+
 #include "kappwin.hxx"
 #include "kmenu.hxx"
 #include "ktoolbar.hxx"

--- a/kermit/k95/kui/kappwin.hxx
+++ b/kermit/k95/kui/kappwin.hxx
@@ -55,6 +55,15 @@
 #define WMSZ_BOTTOMRIGHT    8
 #endif
 
+#define KUI_NOTIF_I_NONE   0
+#define KUI_NOTIF_I_INFO   1
+#define KUI_NOTIF_I_WARN   2
+#define KUI_NOTIF_I_ERR    3
+#define KUI_NOTIF_I_USER   4
+
+#ifdef CK_SHELL_NOTIFY
+#define WMAPP_NOTIFYCALLBACK (WM_APP + 1)
+#endif /* CK_SHELL_NOTIFY */
 
 class KSizePopup;
 class KMenu;
@@ -88,6 +97,10 @@ public:
     virtual void sizeFontSetDim( UINT fwSide, LPRECT lpr );
     void    createMenu(void);
     void    destroyMenu(void);
+#ifdef CK_SHELL_NOTIFY
+    void    showNotification(int icon, char* title, char * message);
+    void    destroyNotificationIcon();
+#endif /* CK_SHELL_NOTIFY */
 
   protected:
     int Win32ShellExecute( char * );
@@ -97,6 +110,9 @@ public:
     KMenu* menu;
     KToolBar* toolbar;
     KStatus* status;
+#ifdef CK_SHELL_NOTIFY
+    BOOL     iconCreated;
+#endif /* CK_SHELL_NOTIFY */
 
   private:
     KClient* client;

--- a/kermit/k95/kui/ktermin.cxx
+++ b/kermit/k95/kui/ktermin.cxx
@@ -5,7 +5,7 @@
 #ifdef _WIN32_IE
 #undef _WIN32_IE
 #endif /* _WIN32_IE */
-#define _WIN32_IE 0x0500
+#define _WIN32_IE 0x0501
 #endif /* __WATCOMC__ */
 #endif /* CK_SHELL_NOTIFY */
 #endif /* CKT_NT35 */

--- a/kermit/k95/kui/ktermin.cxx
+++ b/kermit/k95/kui/ktermin.cxx
@@ -1,3 +1,15 @@
+#ifndef CKT_NT35
+#ifdef CK_SHELL_NOTIFY
+#ifdef __WATCOMC__
+/* The Watcom headers need this defined for shell notifications */
+#ifdef _WIN32_IE
+#undef _WIN32_IE
+#endif /* _WIN32_IE */
+#define _WIN32_IE 0x0500
+#endif /* __WATCOMC__ */
+#endif /* CK_SHELL_NOTIFY */
+#endif /* CKT_NT35 */
+
 #include <windowsx.h>
 #include "ktermin.hxx"
 #include "kmenu.hxx"

--- a/kermit/k95/kui/ktermin.cxx
+++ b/kermit/k95/kui/ktermin.cxx
@@ -740,6 +740,9 @@ Bool KTerminal::message( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam )
     case WM_CLOSE:
         debug(F111,"KTerminal::message","WM_CLOSE",msg);
         PostMessage( hWnd, WM_REQUEST_CLOSE_KERMIT, 0, 0 );
+#ifdef CK_SHELL_NOTIFY
+        destroyNotificationIcon();
+#endif /* CK_SHELL_NOTIFY */
         done = TRUE;
         break;
 
@@ -805,6 +808,24 @@ Bool KTerminal::message( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam )
             }
         }
         break;
+
+#ifdef CK_SHELL_NOTIFY
+    case WMAPP_NOTIFYCALLBACK:
+        switch (LOWORD(lParam))
+        {
+            case WM_LBUTTONDOWN:
+            case NIN_BALLOONUSERCLICK:
+                /* User clicked the notification */
+                takeFocus();
+            case WM_RBUTTONDOWN:
+            case NIN_BALLOONTIMEOUT:
+                /* Get rid of the notification icon */
+                destroyNotificationIcon();
+                break;
+        }
+        done = TRUE;
+        break;
+#endif /* CK_SHELL_NOTIFY */
 
     case WM_SYSCOMMAND:
     case WM_COMMAND:

--- a/kermit/k95/kui/kui.rc
+++ b/kermit/k95/kui/kui.rc
@@ -680,7 +680,7 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "CompanyName", "The Kermit Project"
-            VALUE "FileDescription", "Kermit 95, Graphical executable"
+            VALUE "FileDescription", "Kermit 95"
             VALUE "FileVersion", RC_FILE_VERSION_STR
             VALUE "InternalName", "k95g"
             VALUE "LegalCopyright", "Portions (C) Copyright 1995-2013 The Trustees of Columbia University in the City of New York. Portions (C) Copyright 2013-2022 The Kermit Project contributors."


### PR DESCRIPTION
This allows both querying (reading) the clipboard, and setting (writing) it, translating to/from the remote character set as required.

The feature is off by default, and can be enabled in one or both directions via SET TERMINAL CLIPBOARD-ACCESS. In K95G, when the remote host uses OSC-52 you can optionally choose to receive a notification on Windows 2000 or up.