### PR TITLE
Hand parameters on SGR-4 (underline)

### DIFF
--- a/kermit/k95/ckoco2.c
+++ b/kermit/k95/ckoco2.c
@@ -2035,6 +2035,7 @@ VscrnWrtCell( BYTE vmode, viocell Cell, vtattrib att, USHORT Row, USHORT Col )
         (att.bold       ? VT_CHAR_ATTR_BOLD      : 0) |
         (att.dim        ? VT_CHAR_ATTR_DIM       : 0) |
         (att.underlined ? VT_CHAR_ATTR_UNDERLINE : 0) |
+        (VT_CHAR_ATTR_SET_UL_STYLE(att.ul_style))     |
         (att.blinking   ? VT_CHAR_ATTR_BLINK     : 0) |
         (att.reversed   ? VT_CHAR_ATTR_REVERSE   : 0) |
         (att.italic     ? VT_CHAR_ATTR_ITALIC    : 0) |
@@ -2504,6 +2505,7 @@ VscrnGetVtCharAttr( BYTE vmode, SHORT x, SHORT y )
     vta.bold            = attr & VT_CHAR_ATTR_BOLD ? 1 : 0 ;
     vta.dim             = attr & VT_CHAR_ATTR_DIM ? 1 : 0 ;
     vta.underlined      = attr & VT_CHAR_ATTR_UNDERLINE ? 1 : 0 ;
+    vta.ul_style        = VT_CHAR_ATTR_GET_UL_STYLE(attr);
     vta.blinking        = attr & VT_CHAR_ATTR_BLINK ? 1 : 0 ;
     vta.reversed        = attr & VT_CHAR_ATTR_REVERSE ? 1 : 0 ;
     vta.italic          = attr & VT_CHAR_ATTR_ITALIC ? 1 : 0 ;
@@ -2534,6 +2536,7 @@ VscrnSetVtCharAttr( BYTE vmode, SHORT x, SHORT y, vtattrib vta )
                 (vta.bold       ? VT_CHAR_ATTR_BOLD      : 0) |
                 (vta.dim        ? VT_CHAR_ATTR_DIM       : 0) |
                 (vta.underlined ? VT_CHAR_ATTR_UNDERLINE : 0) |
+                (VT_CHAR_ATTR_SET_UL_STYLE(vta.ul_style))     |
                 (vta.blinking   ? VT_CHAR_ATTR_BLINK     : 0) |
                 (vta.reversed   ? VT_CHAR_ATTR_REVERSE   : 0) |
                 (vta.italic     ? VT_CHAR_ATTR_ITALIC    : 0) | 

--- a/kermit/k95/ckoco3.c
+++ b/kermit/k95/ckoco3.c
@@ -420,7 +420,7 @@ cell_video_attr_t                       /* Video attribute bytes */
 
 cell_video_attr_t decatc_colors[16];
 
-vtattrib attrib={0,0,0,0,0,0,0,0,0,0},
+vtattrib attrib={0,0,0,0,0,0,0,0,0,0,0,0,0,0},
          savedattrib[VNUM]={{0,0,0,0,0,0,0,0,0,0},{0,0,0,0,0,0,0,0,0,0},
                             {0,0,0,0,0,0,0,0,0,0},{0,0,0,0,0,0,0,0,0,0}},
          cmdattrib={0,0,0,0,0,0,0,0,0,0};
@@ -13513,6 +13513,24 @@ dodcs( void )
 
                         if (attrib.italic) strcat(sgrbuf, ";3");
                         if (attrib.underlined) strcat(sgrbuf, ";4");
+#ifdef KUI_EXTENDED_UL
+                        if (attrib.ul_style != UL_STYLE_NORMAL) {
+                            switch(attrib.ul_style) {
+                            case UL_STYLE_DOUBLE:
+                                strcat(sgrbuf, ":2");
+                                break;
+                            case UL_STYLE_WAVY:
+                                strcat(sgrbuf, ":3");
+                                break;
+                            case UL_STYLE_DOTTED:
+                                strcat(sgrbuf, ":4");
+                                break;
+                            case UL_STYLE_DASHED:
+                                strcat(sgrbuf, ":5");
+                                break;
+                            }
+                        }
+#endif /* KUI_EXTENDED_UL */
                         if (attrib.blinking) strcat(sgrbuf, ";5");
                         if (attrib.reversed) strcat(sgrbuf, ";7");
                         if (attrib.invisible) strcat(sgrbuf, ";8");
@@ -20660,6 +20678,7 @@ vtcsi(void)
                             attrib.bold = FALSE;
                             attrib.invisible = FALSE;
                             attrib.underlined = FALSE;
+                            attrib.ul_style = UL_STYLE_NORMAL;
                             attrib.reversed = FALSE;
                             attrib.graphic = FALSE ;
                             attrib.dim = FALSE ;
@@ -20733,9 +20752,46 @@ vtcsi(void)
                                 attribute = underlineattribute;
                             }
                             else {
-                                if (attrib.underlined)
-                                    break;
-                                attrib.underlined = TRUE;
+                                if (pn_pe_start[j] == -1) {
+                                    attrib.underlined = TRUE;
+                                    attrib.ul_style = UL_STYLE_NORMAL;
+                                } else {
+                                    /* We have parameter elements! */
+                                    int pe_start = pn_pe_start[j];
+								    int pe_count = pn_pe_count[j];
+
+                                    if (pe_count >= 1) {
+                                        int ul_style = pe[pe_start];
+                                        switch(ul_style) {
+                                        case 0:
+                                            attrib.underlined = FALSE;
+                                            attrib.ul_style = UL_STYLE_NORMAL;
+                                            break;
+                                        case 1:
+                                            attrib.underlined = TRUE;
+                                            attrib.ul_style = UL_STYLE_NORMAL;
+                                            break;
+#ifdef KUI_EXTENDED_UL
+                                        case 2:
+                                            attrib.underlined = TRUE;
+                                            attrib.ul_style = UL_STYLE_DOUBLE;
+                                            break;
+                                        case 3:
+                                            attrib.underlined = TRUE;
+                                            attrib.ul_style = UL_STYLE_WAVY;
+                                            break;
+                                        case 4:
+                                            attrib.underlined = TRUE;
+                                            attrib.ul_style = UL_STYLE_DOTTED;
+                                            break;
+                                        case 5:
+                                            attrib.underlined = TRUE;
+                                            attrib.ul_style = UL_STYLE_DASHED;
+                                            break;
+#endif /* KUI_EXTENDED_UL */
+                                        }
+                                    }
+                                }
                             }
                             break;
                         case 5:
@@ -20914,7 +20970,11 @@ vtcsi(void)
 								/* Since linux 4.17. Prior to this, it was normal
 								 * intensity */
 								attrib.underlined = TRUE;
-							} else {
+                                attrib.ul_style = UL_STYLE_NORMAL;
+							} else if (ISK95(tt_type_mode) || ISXTERM(tt_type_mode)) {
+                                attrib.underlined = TRUE;
+                                attrib.ul_style = UL_STYLE_DOUBLE;
+                            } else {
 	                            if (attrib.bold)
 	                                attrib.bold = FALSE;
                             	if (attrib.dim)

--- a/kermit/k95/ckocon.h
+++ b/kermit/k95/ckocon.h
@@ -1248,9 +1248,26 @@ typedef struct _vtattrib {      /* Character (SGR) attributes, 1 bit each */
     unsigned wyseattr:1;        /* Wyse Attribute */
     unsigned italic:1;          /* Italic */
 	unsigned crossedout:1;		/* Crossed out */
+    unsigned ul_style:3;        /* Extended underline styles */
     unsigned hyperlink:1;       /* Hyperlink */
     unsigned short linkid;      /* Hyperlink Index */
 } vtattrib ;
+
+/* Underline styles for the ul_style field above, and the three
+ * VT_CHAR_ATTR_UNDERLINE_{A,B,C} bit fields in the virtual buffer field below.
+ * Someday "Normal" underline may be moved in here too, to free up the attribute
+ * bit currently occupited by VT_CHAR_ATTR_UNDERLINE. For now, the underline
+ * style is ignored if that bit is not set.
+ */
+#define UL_STYLE_NORMAL  0
+#define UL_STYLE_DOUBLE  1
+#define UL_STYLE_DASHED  2
+#define UL_STYLE_DOTTED  3
+#define UL_STYLE_WAVY    4
+#define UL_STYLE_RES_A   5        /* Unused */
+#define UL_STYLE_RES_B   6        /* Unused */
+#define UL_STYLE_RES_C   7        /* Unused */
+#define UL_STYLE_MAX     UL_STYLE_WAVY
 
 /*
  *
@@ -1267,14 +1284,18 @@ typedef struct _vtattrib {      /* Character (SGR) attributes, 1 bit each */
 #define VT_CHAR_ATTR_GRAPHIC          ((USHORT) 0x0040)
 #define VT_CHAR_ATTR_DIM              ((USHORT) 0x0080)
 #define WY_CHAR_ATTR                  ((USHORT) 0x0100)
-#define KUI_CHAR_ATTR_UPPER_HALF      ((USHORT) 0x0200)
-#define KUI_CHAR_ATTR_LOWER_HALF      ((USHORT) 0x0400)
+#define VT_CHAR_ATTR_CROSSEDOUT       ((USHORT) 0x0200)
+#define VT_CHAR_UNUSED                ((USHORT) 0x0400)  /* Available */
 #define VT_CHAR_ATTR_ITALIC           ((USHORT) 0x0800)
 #define VT_CHAR_ATTR_HYPERLINK        ((USHORT) 0x1000)
-#define VT_CHAR_ATTR_CROSSEDOUT      ((USHORT) 0x2000)
-/* These three are available for use */
-#define VT_CHAR_RESERVED_2            ((USHORT) 0x4000)  /* Doubly-underlined */
-#define VT_CHAR_RESERVED_1            ((USHORT) 0x8000)
+#define VT_CHAR_ATTR_UNDERLINE_A      ((USHORT) 0x2000)
+#define VT_CHAR_ATTR_UNDERLINE_B      ((USHORT) 0x4000)
+#define VT_CHAR_ATTR_UNDERLINE_C      ((USHORT) 0x8000)
+
+/* The three fields VT_CHAR_ATTR_UNDERLINE_{A,B,C} together are a three bit
+ * field that specifies the extended underline style. See UL_STYLE_* above. */
+#define VT_CHAR_ATTR_GET_UL_STYLE(x)  ((x & 0xE000) >> 13)
+#define VT_CHAR_ATTR_SET_UL_STYLE(x)  ((x & 0x0007) << 13)
 
 #define VT_LINE_ATTR_NORMAL           ((USHORT) 0x00)
 #define VT_LINE_ATTR_DOUBLE_WIDE      ((USHORT) 0x01)

--- a/kermit/k95/kui/kclient.cxx
+++ b/kermit/k95/kui/kclient.cxx
@@ -870,6 +870,10 @@ void KClient::writeMe()
             SetTextColor( hdc(), cell_video_attr_foreground_rgb(prevAttr));
         }
 
+#ifdef KUI_EXTENDED_UL
+        char underlineType = -1;
+#endif /* KUI_EXTENDED_UL */
+
         if( prevEffect != kws->effect )
         {
             prevEffect = kws->effect;
@@ -892,6 +896,15 @@ void KClient::writeMe()
 
                 normal = !underline && !blink;
             }
+
+#ifdef KUI_EXTENDED_UL
+            if (underline && VT_CHAR_ATTR_GET_UL_STYLE(prevEffect) != UL_STYLE_NORMAL) {
+                /* Its not a regular underline, so we'll take care of drawing it
+                 * rather than using an underlined font. */
+                underline = FALSE;
+                underlineType = VT_CHAR_ATTR_GET_UL_STYLE(prevEffect);
+            }
+#endif /* KUI_EXTENDED_UL */
 
             if( normal )
                 getFont()->resetFont( hdc() );
@@ -963,6 +976,19 @@ void KClient::writeMe()
 			(wchar_t*) &(textBuffer[ kws->offset ]),
 			kws->length,
 			(int*)&interSpace );
+
+#ifdef KUI_EXTENDED_UL
+            if (underlineType != -1) {
+                // TODO: We're drawing the underline ourselves.
+
+                switch(underlineType) {
+                case UL_STYLE_DOUBLE:
+                case UL_STYLE_DASHED:
+                case UL_STYLE_DOTTED:
+                case UL_STYLE_WAVY:
+                }
+            }
+#endif /* KUI_EXTENDED_UL */
         }
         else {
             ExtTextOut( hdc(), rect.left, rect.top, 

--- a/kermit/k95/kui/kclient.hxx
+++ b/kermit/k95/kui/kclient.hxx
@@ -93,7 +93,6 @@ private:    // this section is for performance
 
     cell_video_attr_t prevAttr;
     ushort prevEffect;
-
     int wc;
     int vscrollpos;
     int hscrollpos;


### PR DESCRIPTION
Some recent terminal emulators have supported additional parameters on SGR-4 to set different underline styles as well as to turn off unline (eg, `\x1b[4:0m`).

While there are no immediate plans to support additional underline styles, these parameters should at least be handled, and the two that _could_ easily be supported (no underline, and regular underline) ought to do the right thing in case some application decides to blindly use them.

This PR adds parsing for parameters on SGR-4, and if `KUI_EXTENDED_UL` is defined those parameters will be stored and forwarded all the way to the KUI renderer where there is a TODO in place of an implementation.