### PR TITLE
Improve throughput for terminal sessions over SSH

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -175,6 +175,8 @@ as part of K95 at this time, the default terminal remains VT220 for now.
  - The linux console terminal emulation now uses the UTF-8 character set by
    default as most linux distributions moved to UTF-8 long ago now. 
  - Upgrade OpenSSL to 3.5.2
+ - Improved terminal throughput for SSH connections by around seven times, which
+   helps when you accidentally cat a large log file.
  
 ### New terminal control sequences
 > [!NOTE]


### PR DESCRIPTION
This change increases throughput by around 7x for terminal sessions over SSH. This primarily means K95 now handles you accidentally `cat`ting a large log file a little better. It should now be able to handle around 2MB/s where as previously it was around 275KB/s.

This is achieved by a change to `ssh_inc`, the function for reading a single character from the connection. This previously would read a single character from the ring buffer with all the mutex wrangling that comes with it.

Now `ssh_inc` has its own little buffer which *isn't* protected with mutexes. When `ssh_inc` is called, if its buffer is empty and one or more characters are waiting in the ring buffer it will pull up to 1K out of the ring buffer into its local buffer. It will then return characters from its local buffer until it is exhausted and has to go back to the ring buffer for more. As there is no locking for its local buffer, it can respond with much lower overhead. Buffer size doesn't really seem to have much effect - 1K or 1M, the speed is about the same.

If `ssh_xin` is called and there is data in the `ssh_inc` buffer, then `ssh_xin` will return data from there instead of pulling from the ring buffer to ensure all bytes are handled and handled in order. `ssh_xin` won't put data in the `ssh_inc` buffer though as `ssh_xin` reads multiple bytes from the ring buffer anyway so already had relatively low overhead. This function isn't used by terminal emulation, rather it is used for file transfers.

And lastly `ssh_tchk` will return the number of characters waiting in the `ssh_inc` local buffer if it isn't empty instead of returning the number of characters waiting in the ring buffer.

The lack of mutexes around the `ssh_inc` local buffer *should* be safe because:
- Only one thread will ever be reading from `ssh_inc` or `ssh_xin` at a time - failure to do so would result in input potentially being processed out of order leading to chaos.
- While multiple threads may call `ssh_tchk` and this could lead to it briefly returning out-of-date information about what's in the `ssh_inc` local buffer, it *shouldn't* really matter. Outside of file transfers where `ssh_inc` and its buffer shouldn't be involved, `ssh_tchk` is mostly just used to figure out if the connection is still alive, and if that information gets delayed by one call its not the end of the world.

Throughput for SSH connections *could* still be improved further in the future if desired. The next bottleneck seems to be `PostVscrnDirtySem` - setting the vscreen dirty event seems to be slow (when called hundreds of thousands of times) - context switching overhead?

Throughput on telnet sessions is also now worse than SSH. The issue is having to acquire the Local Echo and TCP/IP Mutexes on every character read. *Probably* not worth fixing.

And PTYs are also still very slow. But those really need a bunch of work to move PTY handling onto a separate thread to reduce the risk of deadlocks, and when that happens it will probably mean a similar buffering setup to SSH.

In the future I may have a go at improving performance further by moving the character input buffer out of the SSH subsystem and into the terminal emulator - probably rdcomwrtscr in ckoco3. This would enable buffering for other connection types improving telnet performance, and we could also skip some of the screen dirty calls while there is still more data waiting in the buffer which would improve throughput further for SSH. C-Kermit already does something similar on unix in ckcgetc()