### PR TITLE
Double maximum terminal lines to 256 on modern K95G

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -177,6 +177,7 @@ as part of K95 at this time, the default terminal remains VT220 for now.
  - Upgrade OpenSSL to 3.5.2
  - Improved terminal throughput for SSH connections by around seven times, which
    helps when you accidentally cat a large log file.
+ - Doubled maximum terminal lines to 256 in K95G on modern systems
  
 ### New terminal control sequences
 > [!NOTE]

--- a/kermit/k95/ckocon.h
+++ b/kermit/k95/ckocon.h
@@ -99,13 +99,15 @@
  * maximum to be changed at runtime solving this problem properly.
  */
 #define MAXSCRNCOL  512            /* Maximum screen columns */
+#define MAXSCRNROW  256            /* Maximum screen rows    */
 #else
 #define MAXSCRNCOL  256            /* Maximum screen columns */
+#define MAXSCRNROW  128            /* Maximum screen rows    */
 #endif
 #else /* KUI */
 #define MAXSCRNCOL  256            /* Maximum screen columns */
-#endif /* KUI */
 #define MAXSCRNROW  128            /* Maximum screen rows    */
+#endif /* KUI */
 #define MAXTERMSIZE (MAXSCRNCOL*MAXSCRNROW)
 #else /* NT */
 /* OS/2 WARP allows for screen widths up to 255 characters.


### PR DESCRIPTION
This is really just an interim solution to enable K95G to render properly on an unscaled 4K display. Eventually some work needs to be done to decouple memory use from the maximum dimensions by allocating various data structures dynamically, but thats not work that is likely to happen in the near future.