### PR TITLE
DECRQCRA.... as a function!

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -194,6 +194,12 @@ as part of K95 at this time, the default terminal remains VT220 for now.
  - Improved terminal throughput for SSH connections by around seven times, which
    helps when you accidentally cat a large log file.
  - Doubled maximum terminal lines to 256 in K95G on modern systems
+ - Added a new function, `\fterminalchecksum`, which produces a checksum of the
+   terminal screen using the same algorithm as DECRQCRA. Parameters allow you
+   to specify a region of a particular page to calculate a checksum off. If
+   parameters are left off it calculates the checksum of the entire page on
+   screen. Unlike DECRQCRA, it is not bound by page margins.
+   
  
 ### New terminal control sequences
 > [!NOTE]

--- a/doc/ctlseqs.xml
+++ b/doc/ctlseqs.xml
@@ -15716,13 +15716,24 @@ DCS $ q 3 , } ST</pre>
                 and <tt><param-single symbol="Pt"/> ;
                 <param-single symbol="Pl"/> ; <param-single symbol="Pb"/> ;
                 <param-single symbol="Pr"/></tt> is the rectangle to calculate
-                the checksum for. Only available if send-data is enabled
-                (<tt>set terminal send-data on</tt>).
+                the checksum for. Coordinates are affected by origin mode
+                (<a href="#decom">DECOM</a>). Only available if send-data is
+                enabled (<tt>set terminal send-data on</tt>) - if it is disabled
+                (the default), this control sequence is ignored.
             </p>
             <p>
                 If the terminal is on the XTerm Alternate Screen, then the
                 page is ignored and DECRQCRA operates only on the alternate
                 screen.
+            </p>
+            <p>
+                The response is <tt><cc>DCS</cc> <em>Pi</em> ! ~ D...D <cc>ST</cc></tt>
+                where <em>Pi</em> is the request ID, and D...D is a string of
+                four hexadecimal digits indicating the checksum.
+            </p>
+            <p>
+                You can also compute a checksum using the same algorithm with
+                the K95 function <tt>\fterminalchecksum()</tt>.
             </p>
         </section>
         <section role="ctlseq" id="decpkfmr" mnemonic="DECPKFMR"

--- a/kermit/k95/ckoco3.c
+++ b/kermit/k95/ckoco3.c
@@ -6762,6 +6762,116 @@ decdwl_escape(bool dwlflag) {
     }
 }
 
+int
+calculate_decrqcra_checksum(int top, int left, int bot, int right, int page, BOOL obey_margins) {
+    int checksum=0;
+    int x, y, height, width, max_page;
+
+    height = VscrnGetHeight(VTERM) - (tt_status[VTERM] ? 1 : 0);
+    width = VscrnGetWidth(VTERM);
+    max_page = term_max_page(VTERM);
+
+    if (top < 1) top = 1;
+    if (left < 1) left = 1;
+    if (bot < 1) bot = height;
+    if (right < 1) right = width;
+    if (page < 1) page = 0;
+    else page = page - 1;
+
+    if (obey_margins) {
+        if (top < vscrn_page_margin_top(VTERM,page)) top = vscrn_page_margin_top(VTERM,page);
+        if (top > vscrn_page_margin_bot(VTERM,page) + 1) top = vscrn_page_margin_bot(VTERM,page) + 1;
+        if (left < vscrn_page_margin_left(VTERM,page)) left = vscrn_page_margin_left(VTERM,page);
+        if (left > vscrn_page_margin_right(VTERM,page) + 1) left = vscrn_page_margin_right(VTERM,page) + 1;
+        if (bot < vscrn_page_margin_top(VTERM,page)) bot = vscrn_page_margin_top(VTERM,page);
+        if (bot > vscrn_page_margin_bot(VTERM,page)) bot = vscrn_page_margin_bot(VTERM,page);
+        if (right < vscrn_page_margin_left(VTERM,page)) right = vscrn_page_margin_left(VTERM,page);
+        if (right > vscrn_page_margin_right(VTERM,page)) right = vscrn_page_margin_right(VTERM,page);
+    } else {
+        if (bot > height) bot = height;
+        if (top > bot) top = 1;
+        if (right > width) right = width;
+        if (left > right) left = 1;
+    }
+
+    if (page > max_page) page = max_page;
+
+    debug(F111, "DECRQCRA", "top", top);
+    debug(F111, "DECRQCRA", "left", left);
+    debug(F111, "DECRQCRA", "bot", bot);
+    debug(F111, "DECRQCRA", "right", right);
+    debug(F111, "DECRQCRA", "page", page);
+
+    for ( y=top-1; y<bot; y++ ) {
+        videoline * line = VscrnGetPageLineFromTop(VTERM, y, page);
+        for ( x=left-1; x<right; x++ ) {
+            unsigned short c, a;
+            unsigned char cellattr, fgcoloridx = 0, bgcoloridx = 0;
+
+            c = line->cells[x].c;
+            a = line->vt_char_attrs[x];
+
+            /* These return 0 for RGB colors */
+            fgcoloridx = cell_video_attr_foreground(line->cells[x].video_attr);
+            bgcoloridx = cell_video_attr_background(line->cells[x].video_attr);
+
+            /* Xterm implements the following behaviour to
+             * supposedly match what the VT525 does (I don't
+             * have access to a VT525 to confirm the
+             * behaviour myself): If the current background
+             * color is the default and the current foreground
+             * is *not* the default, then ignore the bold attribute
+             * if its set.
+             */
+            if (a & VT_CHAR_ATTR_BOLD) {
+                  unsigned char df_fg, df_bg;
+                  df_fg = cell_video_attr_foreground(defaultattribute);
+                  df_bg = cell_video_attr_background(defaultattribute);
+                  if (df_bg == bgcoloridx && df_fg != fgcoloridx) {
+                      checksum -= 0x80;
+                  }
+            }
+
+            if (fgcoloridx < 16) {
+                fgcoloridx = sgrindex[fgcoloridx%8];
+            } else {
+                /* FG color index is outside the range of
+                 * valid values for the VT525. */
+                fgcoloridx = 0;
+            }
+
+            if (bgcoloridx < 16) {
+                bgcoloridx = sgrindex[bgcoloridx%8];
+            } else {
+                /* BG color index is outside the range of
+                 * valid values for the VT525. */
+                bgcoloridx = 0;
+            }
+
+            debug(F111, "DECRQCRA iteration", "x", x);
+            debug(F111, "DECRQCRA iteration", "y", y);
+            debug(F111, "DECRQCRA iteration", "c", c);
+            debug(F111, "DECRQCRA iteration", "checksum", checksum);
+
+            checksum += c;
+
+            debug(F111, "DECRQCRA iteration", "checksum+c", checksum);
+
+            if (a & VT_CHAR_ATTR_PROTECTED) checksum += 0x04;
+            if (a & VT_CHAR_ATTR_INVISIBLE) checksum += 0x08;
+            if (a & VT_CHAR_ATTR_UNDERLINE) checksum += 0x10;
+            if (a & VT_CHAR_ATTR_REVERSE) checksum += 0x20;
+            if (a & VT_CHAR_ATTR_BLINK) checksum += 0x40;
+            if (a & VT_CHAR_ATTR_BOLD) checksum += 0x80;
+            /*checksum += bgcoloridx;
+            checksum += fgcoloridx * 0x10;*/
+            debug(F111, "DECRQCRA iteration", "checksum+attrs", checksum);
+        }
+    }
+    debug(F111, "DECRQCRA", "checksum", checksum);
+    return checksum;
+}
+
 void
 udkreset( void )
 {
@@ -18615,7 +18725,6 @@ vtcsi(void)
                         int checksum=0, pid=1;
                         int top, left, bot, right, page, max_page;
                         int row, col;
-                        int x, y;
                         char buf[20];
 
                         if (k < 3) pn[3] = 1;
@@ -18624,21 +18733,22 @@ vtcsi(void)
                         if (k < 6) pn[6] = VscrnGetWidth(VTERM);
                         k = 6;
 
-                        /*checksum &= 0xffff;*/
                         pid = pn[1];
                         page = pn[2];
-                        top = pn[3] + (vscrn_c_page_margin_top(VTERM) > 1 ? vscrn_c_page_margin_top(VTERM) : 0);
-                        left = pn[4] + (vscrn_c_page_margin_left(VTERM) > 1 ? vscrn_c_page_margin_left(VTERM) : 0);
-                        bot = pn[5];
-                        right = pn[6];
 
                         max_page = term_max_page(VTERM);
-						if (page < 0) page = 0;
+						if (page < 1) page = 1;
 						if (page > max_page) page = max_page;
 
                         if (on_alternate_buffer(VTERM)) {
                             page = ALTERNATE_BUFFER_PAGE(VTERM);
                         }
+
+                        /*checksum &= 0xffff;*/
+                        top = pn[3] + (vscrn_page_margin_top(VTERM,page) > 1 ? vscrn_page_margin_top(VTERM,page) : 0);
+                        left = pn[4] + (vscrn_page_margin_left(VTERM,page) > 1 ? vscrn_page_margin_left(VTERM,page) : 0);
+                        bot = pn[5];
+                        right = pn[6];
 
                         debug(F111, "DECRQCRA", "pid", pid);
                         debug(F111, "DECRQCRA", "init-top", pn[3]);
@@ -18646,102 +18756,20 @@ vtcsi(void)
                         debug(F111, "DECRQCRA", "init-bot", pn[5]);
                         debug(F111, "DECRQCRA", "init-right", pn[6]);
 
+                        debug(F111, "DECRQCRA", "margintop", vscrn_page_margin_top(VTERM,page));
+                        debug(F111, "DECRQCRA", "marginleft", vscrn_page_margin_left(VTERM,page));
+                        debug(F111, "DECRQCRA", "marginbot", vscrn_page_margin_bot(VTERM,page));
+                        debug(F111, "DECRQCRA", "marginright", vscrn_page_margin_right(VTERM,page));
 
-                        debug(F111, "DECRQCRA", "margintop", vscrn_c_page_margin_top(VTERM));
-                        debug(F111, "DECRQCRA", "marginleft", vscrn_c_page_margin_left(VTERM));
-                        debug(F111, "DECRQCRA", "marginbot", vscrn_c_page_margin_bot(VTERM));
-                        debug(F111, "DECRQCRA", "marginright", vscrn_c_page_margin_right(VTERM));
+                        checksum = calculate_decrqcra_checksum(
+                            top, left, bot, right, page, TRUE);
 
-                        if (top < vscrn_c_page_margin_top(VTERM)) top = vscrn_c_page_margin_top(VTERM);
-                        if (top > vscrn_c_page_margin_bot(VTERM) + 1) top = vscrn_c_page_margin_bot(VTERM) + 1;
-                        if (left < vscrn_c_page_margin_left(VTERM)) left = vscrn_c_page_margin_left(VTERM);
-                        if (left > vscrn_c_page_margin_right(VTERM) + 1) left = vscrn_c_page_margin_right(VTERM) + 1;
-                        if (bot < vscrn_c_page_margin_top(VTERM)) bot = vscrn_c_page_margin_top(VTERM);
-                        if (bot > vscrn_c_page_margin_bot(VTERM)) bot = vscrn_c_page_margin_bot(VTERM);
-                        if (right < vscrn_c_page_margin_left(VTERM)) right = vscrn_c_page_margin_left(VTERM);
-                        if (right > vscrn_c_page_margin_right(VTERM)) right = vscrn_c_page_margin_right(VTERM);
-
-
-                        debug(F111, "DECRQCRA", "top", top);
-                        debug(F111, "DECRQCRA", "left", left);
-                        debug(F111, "DECRQCRA", "bot", bot);
-                        debug(F111, "DECRQCRA", "right", right);
-
-                        for ( y=top-1; y<bot; y++ ) {
-                            videoline * line = VscrnGetPageLineFromTop(VTERM, y, page);
-                            for ( x=left-1; x<right; x++ ) {
-                                unsigned short c, a;
-                                unsigned char cellattr, fgcoloridx = 0, bgcoloridx = 0;
-
-                                c = line->cells[x].c;
-                                a = line->vt_char_attrs[x];
-
-                                /* These return 0 for RGB colors */
-                                fgcoloridx = cell_video_attr_foreground(line->cells[x].video_attr);
-                                bgcoloridx = cell_video_attr_background(line->cells[x].video_attr);
-
-                                /* Xterm implements the following behaviour to
-                                 * supposedly match what the VT525 does (I don't
-                                 * have access to a VT525 to confirm the
-                                 * behaviour myself): If the current background
-                                 * color is the default and the current foreground
-                                 * is *not* the default, then ignore the bold attribute
-                                 * if its set.
-                                 */
-                                if (a & VT_CHAR_ATTR_BOLD) {
-                                      unsigned char df_fg, df_bg;
-                                      df_fg = cell_video_attr_foreground(defaultattribute);
-                                      df_bg = cell_video_attr_background(defaultattribute);
-                                      if (df_bg == bgcoloridx && df_fg != fgcoloridx) {
-                                          checksum -= 0x80;
-                                      }
-                                }
-
-                                if (fgcoloridx < 16) {
-                                    fgcoloridx = sgrindex[fgcoloridx%8];
-                                } else {
-                                    /* FG color index is outside the range of
-                                     * valid values for the VT525. */
-                                    fgcoloridx = 0;
-                                }
-
-                                if (bgcoloridx < 16) {
-                                    bgcoloridx = sgrindex[bgcoloridx%8];
-                                } else {
-                                    /* BG color index is outside the range of
-                                     * valid values for the VT525. */
-                                    bgcoloridx = 0;
-                                }
-
-                                debug(F111, "DECRQCRA iteration", "x", x);
-                                debug(F111, "DECRQCRA iteration", "y", y);
-                                debug(F111, "DECRQCRA iteration", "c", c);
-                                debug(F111, "DECRQCRA iteration", "checksum", checksum);
-
-                                checksum += c;
-
-                                debug(F111, "DECRQCRA iteration", "checksum+c", checksum);
-
-                                if (a & VT_CHAR_ATTR_PROTECTED) checksum += 0x04;
-                                if (a & VT_CHAR_ATTR_INVISIBLE) checksum += 0x08;
-                                if (a & VT_CHAR_ATTR_UNDERLINE) checksum += 0x10;
-                                if (a & VT_CHAR_ATTR_REVERSE) checksum += 0x20;
-                                if (a & VT_CHAR_ATTR_BLINK) checksum += 0x40;
-                                if (a & VT_CHAR_ATTR_BOLD) checksum += 0x80;
-                                /*checksum += bgcoloridx;
-                                checksum += fgcoloridx * 0x10;*/
-                                debug(F111, "DECRQCRA iteration", "checksum+attrs", checksum);
-                            }
+                        if (send_c1) {
+                            sprintf(buf, "\033P%d!~%04X%c", pid, checksum,_ST8);
+                        } else {
+                            sprintf(buf, "\033P%d!~%04X\033\\", pid, checksum);
                         }
-                        debug(F111, "DECRQCRA", "checksum", checksum);
-
-						/* TODO: Use sendescseq and ST below if send_c1.
-								Note that sendescseq buffer may need enlarging */
-                        sprintf(buf, "\033P%d!~%04X\033\\", pid, checksum);
-
-                        // TODO: Call sendesqseq instead (and check for any other places
-                        //       where we should be doing this but aren't)
-                        sendchars(buf, strlen(buf));
+                        sendescseq(buf);
                     }
 
                     break;

--- a/kermit/k95/ckuus2.c
+++ b/kermit/k95/ckuus2.c
@@ -12338,6 +12338,19 @@ represent.\n");
         hmsga(hmfmonname);              /* Literal string was too long */
         break;
 
+#ifdef OS2
+      case FN_TERMCKS:
+        printf("\\fterminalchecksum(n1,n2,n3,n4,n5)\n\
+  Returns a checksum of the terminal screen using the same algorithm as the\n\
+  DECRQCRA control sequence found on the DEC VT420 and VT520 terminals.\n\
+  n1 is the top line, n2 is the left column, n3 is the bottom line and n4 is\n\
+  the right column, and n5 is the page number. Unlike DECRQCRA, any margins \n\
+  set do not apply. All parameters are optional and default to a checksum of\n\
+  the entire page that is currently being displayed. All coordinates and page\n\
+  numbers start from 1.");
+        break;
+#endif /* OS2 */
+
       default:
         printf("Sorry, help not available for \"%s\"\n",cmdbuf);
     }

--- a/kermit/k95/ckuus4.c
+++ b/kermit/k95/ckuus4.c
@@ -1231,6 +1231,9 @@ struct keytab fnctab[] = {              /* Function names */
     { "substitute", FN_SUBST,0},        /* Substitute chars */
     { "substring",  FN_SUB,  0},        /* Extract substring from argument */
     { "tablelook",  FN_TLOOK,0},        /* Table lookup */
+#ifdef OS2
+    { "terminalchecksum", FN_TERMCKS,0},/* Terminal screen checksum */
+#endif /* OS2 */
     { "time",       FN_TIME, 0},        /* Free-format time to hh:mm:ss */
     { "tod2secs",   FN_NTIM, CM_INV},   /* Time-of-day-to-secs-since-midnite */
     { "todtosecs",  FN_NTIM, CM_INV},   /* Time-of-day-to-secs-since-midnite */
@@ -13224,6 +13227,27 @@ fneval(fn,argp,argn,xp) char *fn, *argp[]; int argn; char * xp;
 	goto fnend;
     }
 #endif /* HAVE_LOCALE */
+
+#ifdef OS2
+    if (cx == FN_TERMCKS) {
+        int calculate_decrqcra_checksum(int, int, int, int, int, BOOL);
+
+        int top = -1, left = -1, bot = -1, right = -1, page = -1, checksum = 0;
+        if (argn > 0 && bp[0] && *bp[0] && chknum(bp[0])) top = atoi(bp[0]);
+        if (argn > 1 && bp[1] && *bp[1] && chknum(bp[1])) left = atoi(bp[1]);
+        if (argn > 2 && bp[2] && *bp[2] && chknum(bp[2])) bot = atoi(bp[2]);
+        if (argn > 3 && bp[3] && *bp[3] && chknum(bp[3])) right = atoi(bp[3]);
+        if (argn > 4 && bp[4] && *bp[4] && chknum(bp[4])) page = atoi(bp[4]);
+
+        checksum = calculate_decrqcra_checksum(
+            top, left, bot, right, page-1, FALSE);
+
+        _snprintf(fnval, FNVALL, "%d", checksum);
+        failed = 0;
+
+        goto fnend;
+    }
+#endif /* OS2 */
 
 /* Note: when adding new functions remember to update dohfunc in ckuus2.c. */
 

--- a/kermit/k95/ckuusr.h
+++ b/kermit/k95/ckuusr.h
@@ -2695,6 +2695,10 @@ struct stringint {			/* String and (wide) integer */
 #define FN_DAYNAME 170			/* Day name according to locale */
 #define FN_MONNAME 171			/* Month name according to locale */
 
+#ifdef OS2
+#define FN_TERMCKS 172          /* Checksum of the terminal screen */
+#endif /* OS2 */
+
 #endif /* NOSPL */
 
 /* Time Units */


### PR DESCRIPTION
This makes DECRQCRAs checksums available from kermit script via a new function, \fterminalchecksum(). Takes the same rectangular area and page coordinates as DECRQCRA but isn't constrained by DECOM. If no parameters are given, it does the entire visible page.

Main use case is being able to improve automation of VTTEST by comparing the terminal buffer state to a known correct/pass state, but it could be useful for other automation tasks rather than just searching for strings on screen.