### PR TITLE
Implement XTVERSION control sequence

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -363,6 +363,7 @@ as part of K95 at this time, the default terminal remains VT220 for now.
    - [DECMC-11](https://davidrg.github.io/ckwin/dev/ctlseqs.html#decmc-11) - Print All Pages
    - [DECSPMA](https://davidrg.github.io/ckwin/dev/ctlseqs.html#decspma) - Set and query the number of available pages
    - [DECSNLS](https://davidrg.github.io/ckwin/dev/ctlseqs.html#decsnls) - Set number of lines per screen
+ - [XTVERSION](https://davidrg.github.io/ckwin/dev/ctlseqs.html#xtversion) (k95 terminal type only)
 
 ### Fixed Bugs
  - Fixed an issue introduced in beta 7 which could cause SSH connections made

--- a/doc/ctlseqs.xml
+++ b/doc/ctlseqs.xml
@@ -14319,9 +14319,34 @@ DCS $ q 3 , } ST</pre>
         </section>
         <section role="ctlseq" id="decsbca" not-implemented="true" todo="true"
                  mnemonic="DECSBCA" title="Select Bar Code Attributes">
-            <ctlseq>CSI </ctlseq>
+            <ctlseq>CSI <param-multi/> , q</ctlseq>
             <termsupp first="la30" series="print" additional=""/>
             <ref src="dap:130"/>
+        </section>
+
+        <section role="ctlseq" id="xtversion" mnemonic="XTVERSION" badges="k95"
+                 title="Report program name and version" groups="isxterm">
+            <ctlseq>CSI &gt; 0 q</ctlseq>
+            <ref src="xt:h4-Functions-using-CSI-_-ordered-by-the-final-character-lparen-s-rparen:CSI-gt-Ps-q:Ps-=-0.1F0B"/>
+            <p>
+                Reports the program name and version as a DCS string of the
+                form <tt><cc>DCS</cc>&gt;|<em>text</em><cc>ST</cc></tt>.
+                Different terminals report their name and version differently.
+                Xterm gives a response like "Xterm(390)", while Kermit 95
+                responds with something like "Kermit 95 3.0.0". A full response
+                from Kermit 95 should look like:
+                <tt><cc>DCS</cc>&gt;|Kermit 95 3.0.0<cc>ST</cc></tt>.
+            </p>
+            <p>
+                Doing anything with the response value other than displaying it
+                to the user is strongly discouraged. Instead of checking the
+                version of the terminal emulator in use, applications should
+                check for supported features using control sequences such as
+                <a href="#decrqm">DECRQM</a> or <a href="#decrqss">DECRQSS</a>.
+                Kermit 95 only implements this control sequence so that existing
+                applications expecting a response don't have to wait for a
+                timeout instead.
+            </p>
         </section>
 
         <section role="ctlseq" ctlseq="CSI q" not-implemented="true"

--- a/kermit/k95/ckoco3.c
+++ b/kermit/k95/ckoco3.c
@@ -21838,7 +21838,35 @@ vtcsi(void)
                     }
                     break;
                 }
-                else {
+				if (zdsext && (ISXTERM(tt_type_mode) || ISK95(tt_type_mode))) {
+					if (k < 1) pn[1] = 0;
+					switch (pn[1]) {
+					case 0: /* XTVERSION */
+						{
+							/* TODO: If we were emulating XTerm, then ideally
+							 *  	 we'd respond with the version of XTerm we
+							 * 		 are emulating. */
+							char resp[256] ;
+							extern char *ck_s_name;
+							extern char *ck_s_xver;
+							if (send_c1) {
+                        		sprintf(resp, "P>|%s %s%c",
+                                 	ck_s_name,
+                                 	ck_s_xver,
+								 	_ST8);
+							} else {
+								sprintf(resp, "P>|%s %s%c\\",
+                                 	ck_s_name,
+                                 	ck_s_xver,
+								 	ESC);
+							}
+                        	sendescseq(resp);
+						}
+						break;
+					default:
+						break;
+					}
+                } else {
                     /* Load LEDs */
                     for ( i=1 ; i<=k ; i++ ) {
                         switch ( pn[i] ) {


### PR DESCRIPTION
This is just for the benefit of programs expecting a response so they don't have to timeout instead.