### PR TITLE
Fix potential crash while exiting console version of K95

### DIFF
--- a/kermit/k95/ckokey.c
+++ b/kermit/k95/ckokey.c
@@ -1541,10 +1541,15 @@ _PROTOTYP( int rlog_naws, (void) ) ;
      debug(F100,buf,"",0) ;
 #endif /* COMMENT */
      if ( VscrnGetWidth(mode) != r.dwSize.X || VscrnGetHeight(mode) != r.dwSize.Y ){
+         int bufsize, newWidth, newHeight;
+         bufsize = VscrnGetBufferSize(mode, FALSE, TRUE);
+         if (bufsize == 0) return;
+         newWidth = min(MAXTERMCOL, r.dwSize.X);
+         newHeight = min(MAXTERMROW, r.dwSize.Y);
          sz = (VscrnGetEnd(mode, FALSE, TRUE) - VscrnGetTop(mode, FALSE, TRUE)
-                + VscrnGetBufferSize(mode, FALSE, TRUE) + 1)%VscrnGetBufferSize(mode, FALSE, TRUE) ;
-         VscrnSetWidth( mode, r.dwSize.X ) ;
-         VscrnSetHeight( mode, r.dwSize.Y ) ;
+                + bufsize + 1)%bufsize ;
+         VscrnSetWidth( mode, newWidth ) ;
+         VscrnSetHeight( mode, newHeight ) ;
          VscrnScroll( mode, UPWARD, 1, sz, sz, TRUE, SP, TRUE ) ;
          cleartermscreen(mode);
 #ifdef TCPSOCKET


### PR DESCRIPTION
While K95 is exiting, Windows can report a buffer size larger than what K95 supports. As TermScrnUpd only allocates a buffer large enough for the maximum terminal dimensions supported by K95, this larger size reported by Windows can cause TermScrnUpd to overrun its buffer.

This bug is reproduceable on versions of K95 going back to 1.1.17, though its possible that the console environment changes introduced with Windows 10 v1809 are what makes it possible to trigger.