### PR TITLE
Stop the TermScrnUpd thread on exit

### DIFF
--- a/kermit/k95/ckoco2.c
+++ b/kermit/k95/ckoco2.c
@@ -87,6 +87,9 @@ int tt_url_hilite = 1;
 int tt_url_hilite_attr = VT_CHAR_ATTR_BOLD | VT_CHAR_ATTR_UNDERLINE;
 #else /* KUI */
 int tt_url_hilite_attr = VT_CHAR_ATTR_BOLD;
+#ifdef ONETERMUPD
+BOOL TermScrnUpdActive = TRUE;
+#endif /* ONETERMUPD */
 #endif /* KUI */
 extern int updmode ;
 extern int priority ;
@@ -4484,7 +4487,7 @@ TermScrnUpd( void * threadinfo)
 #ifndef ONETERMUPD
     while (IsConnectMode())
 #else
-    while ( 1 )
+    while ( TermScrnUpdActive )
 #endif /* ONETERMUPD */
     {
         /* Need to add some code in here to check variables such as  */
@@ -5108,13 +5111,6 @@ TermScrnUpd( void * threadinfo)
         ReleaseScreenMutex() ;
     }
 
-#ifndef ONETERMUPD
-    /*
-     * When ONETERMUPD is defined, the above loop is while(1) and contains
-     * no breaks which means it runs forever - that means all the code here
-     * is unreachable so don't try to compile it (or we get unreachable code
-     * warnings)
-     */
     StopVscrnTimer() ;
 
 #ifdef NT
@@ -5131,8 +5127,26 @@ TermScrnUpd( void * threadinfo)
     free(thecells) ;
     PostTermScrnUpdThreadDownSem();
     ckThreadEnd(threadinfo) ;
-#endif /* ONETERMUPD */
 }
+
+#ifdef ONETERMUPD
+int
+TermScrnUpdCleanup( void ) {
+    int n = 0;
+    if ( !tidTermScrnUpd )
+        return(0);
+
+    debug(F100,"TermScrnUpdCleanup called","",0);
+    ResetTermScrnUpdThreadDownSem();
+    TermScrnUpdActive = 0 ;
+    VscrnIsDirty(vmode); /* In case the thread is waiting for something to do */
+    while ( !WaitAndResetTermScrnUpdThreadDownSem( 1000 )) {
+        debug(F111,"Waiting for TermScrnUpdThreadDownSem","n",n) ;
+    }
+    tidTermScrnUpd = (TID) 0 ;   /* This will be closed by the thread */
+    return 0 ;
+}
+#endif /* ONETERMUPD */
 #endif /* KUI */
 
 #ifdef PCFONTS

--- a/kermit/k95/ckocon.h
+++ b/kermit/k95/ckocon.h
@@ -1494,6 +1494,7 @@ _PROTOTYP( USHORT VscrnWrtUCS2StrAtt, ( BYTE vmode, PUSHORT UCS2Str, USHORT Leng
                                         USHORT Row, USHORT Column, cell_video_attr_t* Attr ) ) ;
 #ifndef KUI
 _PROTOTYP( void   TermScrnUpd, ( void * ) ) ;
+_PROTOTYP( int    TermScrnUpdCleanup, ( void ) );
 #endif /* KUI */
 _PROTOTYP( videoline * VscrnGetPageLineFromTop, ( BYTE, SHORT, int ) ) ;
 _PROTOTYP( videoline * VscrnGetLineFromTop, ( BYTE, SHORT, BOOL ) ) ;

--- a/kermit/k95/ckotio.c
+++ b/kermit/k95/ckotio.c
@@ -2490,6 +2490,8 @@ syscleanup() {
     debug(F100,"keybufcleanup done","",0);
 #endif /* NOLOCAL */
 
+    if ( !k95stdout ) TermScrnUpdCleanup() ;
+
     le_clean();
 
     CloseAlarmMutex() ;
@@ -2524,7 +2526,7 @@ syscleanup() {
 #ifdef NT
     CloseSerialMutex() ;
 #ifndef KUI
-    if ( !stdout )
+    if ( !k95stdout )
         CloseHandle(VioHandle);
     VioHandle = 0 ;
 #endif /* ! KUI */


### PR DESCRIPTION
The TermScrnUpd thread is never stopped during exit. This means it never cleans up its resources (not that it really matters), and its still running when any mutexes, semaphores, and thread local storage it depends on is cleaned up.

If there is/was a reason why this thread should be left running all the way to process termination it is not obvious to me. So make it stop once its no longer needed.