### PR TITLE
Use an updated version of ConPTY

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,10 @@ env:
   LIBSSH_VERSION: 0.10.6
   # TODO: When upgrading to 0.11, drop -DCMAKE_POLICY_VERSION_MINIMUM=3.5 from
   #       the ARM build jobs, and the /F flag from all the others.
+  #
+  # Microsoft.Windows.Console.ConPTY from Nuget
+  #    https://www.nuget.org/packages/Microsoft.Windows.Console.ConPTY/
+  CONPTY_VERSION: 1.24.260512001
   # OpenZinc is available from http://openzinc.com/Downloads/OZ1.zip
   # But we don't want to waste the resources of the generous OpenZinc developer,
   # so we grab it from a mirror
@@ -417,7 +421,8 @@ jobs:
             ${{github.workspace}}\libdes\Debug
             ${{github.workspace}}\kerberos\current
             ${{github.workspace}}\rexx
-          key: vs${{matrix.toolset}}-${{matrix.arch}}-sdk${{env.winsdk}}+zlib-${{env.ZLIB_VERSION}}+openssl-${{steps.cfg.outputs.openssl}}+${{env.OPENSSL_MAKE}}+libssh-${{env.LIBSSH_VERSION}}+dynamic+regina-${{env.REGINA_VERSION}}+rexxre+ver4
+            ${{github.workspace}}\conpty
+          key: vs${{matrix.toolset}}-${{matrix.arch}}-sdk${{env.winsdk}}+zlib-${{env.ZLIB_VERSION}}+openssl-${{steps.cfg.outputs.openssl}}+${{env.OPENSSL_MAKE}}+libssh-${{env.LIBSSH_VERSION}}+dynamic+regina-${{env.REGINA_VERSION}}+rexxre+ver4-${{env.CONPTY_VERSION}}
           nocache: ${{vars.NOCACHE}}
       - name: Get libssh url group
         if: steps.cache-optional-dependencies.outputs.cache-hit != 'true'
@@ -512,6 +517,12 @@ jobs:
           del rexxre.zip
           dir rexxre
           # CD out of the rexx directory
+          cd ..
+  
+          cd conpty
+          $env:root="${{ github.workspace }}"
+          $env:CONPTY_VERSION="${{ env.CONPTY_VERSION }}"
+          cmd /c getconpty.bat
           cd ..
   
           # Install perl modules required by OpenSSL build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -422,7 +422,7 @@ jobs:
             ${{github.workspace}}\kerberos\current
             ${{github.workspace}}\rexx
             ${{github.workspace}}\conpty
-          key: vs${{matrix.toolset}}-${{matrix.arch}}-sdk${{env.winsdk}}+zlib-${{env.ZLIB_VERSION}}+openssl-${{steps.cfg.outputs.openssl}}+${{env.OPENSSL_MAKE}}+libssh-${{env.LIBSSH_VERSION}}+dynamic+regina-${{env.REGINA_VERSION}}+rexxre+ver4-${{env.CONPTY_VERSION}}
+          key: vs${{matrix.toolset}}-${{matrix.arch}}-sdk${{env.winsdk}}+zlib-${{env.ZLIB_VERSION}}+openssl-${{steps.cfg.outputs.openssl}}+${{env.OPENSSL_MAKE}}+libssh-${{env.LIBSSH_VERSION}}+dynamic+regina-${{env.REGINA_VERSION}}+rexxre+conpty-${{env.CONPTY_VERSION}}+ver1
           nocache: ${{vars.NOCACHE}}
       - name: Get libssh url group
         if: steps.cache-optional-dependencies.outputs.cache-hit != 'true'

--- a/conpty/.gitignore
+++ b/conpty/.gitignore
@@ -1,0 +1,2 @@
+nuget.exe
+Microsoft.Windows.Console.ConPTY.**

--- a/conpty/.gitignore
+++ b/conpty/.gitignore
@@ -1,2 +1,2 @@
 nuget.exe
-Microsoft.Windows.Console.ConPTY.**
+Microsoft.Windows.Console.ConPTY**

--- a/conpty/README.md
+++ b/conpty/README.md
@@ -1,0 +1,27 @@
+# ConPTY 
+
+On modern Windows, Kermit 95 can be used as a local terminal using ConPTY. The
+version of ConPTY built-in to Windows tends to be fairly out of date and comes
+with limitations that may impact which of Kermit 95s terminal features 
+applications can use.
+
+If conpty.dll and openconsole.exe are bundled with Kermit 95, then Kermit 95
+will use those instead of the built-in version shipped with Windows.
+
+Microsoft currently provides signed conpty.dll and openconsole.exe binaries via
+Nuget which you can download using the `getconpty.bat` script. From inside the
+root of the Kermit 95 source tree:
+
+```bat
+setenv.bat
+cd conpty
+getconpty.bat
+```
+
+This will fetch nuget.exe if required, then fetch a specific version (set near
+the top of `getconpty.bat`) of the ConPTY package and update the environment 
+variables so that ConPTY and OpenConsole are picked up by the `mkdist.bat` 
+script.
+
+You only need to run this once - `setenv.bat` will pick up the downloaded ConPTY
+package automatically next time.

--- a/conpty/getconpty.bat
+++ b/conpty/getconpty.bat
@@ -1,0 +1,61 @@
+@echo off
+
+REM Microsoft-signed ConPTY binaries are available from nuget. That means we
+REM need Nuget in order to fetch them
+
+if "%NUGET_URL%" == "" set NUGET_URL=https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+if "%CONPTY_VERSION%" == "" set CONPTY_VERSION=1.24.260512001
+
+where nuget.exe >nul 2>nul
+if %errorlevel% equ 0 (
+    echo Found Nuget
+    goto :getpkg
+)
+
+echo Nuget not found
+where curl.exe >nul 2>nul
+if %errorlevel% equ 0 (
+    REM but we have url! Fetch nuget
+    echo Downloading nuget with curl...
+    curl --output nuget.exe %NUGET_URL%
+    if exist nuget.exe goto :getpkg
+)
+
+echo Curl not found. Download:
+echo    https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+echo And place it in:
+echo    %root%\conpty
+echo Then re-run this script
+goto :end
+
+:getpkg
+echo Getting package...
+nuget install Microsoft.Windows.Console.ConPTY -version %CONPTY_VERSION% -OutputDirectory %root%\conpty
+echo Done!
+
+if exist Microsoft.Windows.Console.ConPTY.%CONPTY_VERSION% (
+    if exist Microsoft.Windows.Console.ConPTY rmdir /S /Q Microsoft.Windows.Console.ConPTY
+    ren Microsoft.Windows.Console.ConPTY.%CONPTY_VERSION%  Microsoft.Windows.Console.ConPTY
+)
+
+if not "%CK_DIST_DLLS%"=="%CK_DIST_DLLS:conpty.dll=%" (
+    echo DIST DLLs already up-to-date.
+    goto :end
+)
+
+set CONPTY_ARCH=none
+if "%CKB_TARGET_ARCH%" == "AMD64" set CONPTY_ARCH=x64
+if "%CKB_TARGET_ARCH%" == "ARM64" set CONPTY_ARCH=arm64
+if "%CKB_TARGET_ARCH%" == "x86" set CONPTY_ARCH=x86
+if "%CONPTY_ARCH%" == "none" goto :end
+
+set CK_DIST_DLLS=%CK_DIST_DLLS% %root%\conpty\Microsoft.Windows.Console.ConPTY\runtimes\win-%CONPTY_ARCH%\native\conpty.dll
+set CK_DIST_DLLS=%CK_DIST_DLLS% %root%\conpty\Microsoft.Windows.Console.ConPTY\build\native\runtimes\%CONPTY_ARCH%\OpenConsole.exe
+
+echo DIST DLLs updated:
+echo %CK_DIST_DLLS%
+
+:end
+set CONPTY_VERSION=
+set NUGET_URL=
+set CONPTY_ARCH=

--- a/conpty/getconpty.bat
+++ b/conpty/getconpty.bat
@@ -36,6 +36,12 @@ echo Done!
 if exist Microsoft.Windows.Console.ConPTY.%CONPTY_VERSION% (
     if exist Microsoft.Windows.Console.ConPTY rmdir /S /Q Microsoft.Windows.Console.ConPTY
     ren Microsoft.Windows.Console.ConPTY.%CONPTY_VERSION%  Microsoft.Windows.Console.ConPTY
+    copy %root%\conpty\Microsoft.Windows.Console.ConPTY\build\native\runtimes\x86\OpenConsole.exe %root%\conpty\Microsoft.Windows.Console.ConPTY\x86-openconsole.exe
+    copy %root%\conpty\Microsoft.Windows.Console.ConPTY\build\native\runtimes\x64\OpenConsole.exe %root%\conpty\Microsoft.Windows.Console.ConPTY\x64-openconsole.exe
+    copy %root%\conpty\Microsoft.Windows.Console.ConPTY\build\native\runtimes\arm64\OpenConsole.exe %root%\conpty\Microsoft.Windows.Console.ConPTY\arm64-openconsole.exe
+) else (
+    echo Package download failed.
+    goto :end
 )
 
 if not "%CK_DIST_DLLS%"=="%CK_DIST_DLLS:conpty.dll=%" (
@@ -43,15 +49,30 @@ if not "%CK_DIST_DLLS%"=="%CK_DIST_DLLS:conpty.dll=%" (
     goto :end
 )
 
-set CONPTY_ARCH=none
-if "%CKB_TARGET_ARCH%" == "AMD64" set CONPTY_ARCH=x64
-if "%CKB_TARGET_ARCH%" == "ARM64" set CONPTY_ARCH=arm64
-if "%CKB_TARGET_ARCH%" == "x86" set CONPTY_ARCH=x86
-if "%CONPTY_ARCH%" == "none" goto :end
+if "%CKB_TARGET_ARCH%" == "x86" goto :archx8632
+if "%CKB_TARGET_ARCH%" == "AMD64" goto :archx8664
+if "%CKB_TARGET_ARCH%" == "ARM64" goto :archarm64
+goto :end
 
-set CK_DIST_DLLS=%CK_DIST_DLLS% %root%\conpty\Microsoft.Windows.Console.ConPTY\runtimes\win-%CONPTY_ARCH%\native\conpty.dll
-set CK_DIST_DLLS=%CK_DIST_DLLS% %root%\conpty\Microsoft.Windows.Console.ConPTY\build\native\runtimes\%CONPTY_ARCH%\OpenConsole.exe
+:archx8632
+set CK_DIST_DLLS=%CK_DIST_DLLS% %root%\conpty\Microsoft.Windows.Console.ConPTY\x86-OpenConsole.exe
+set CK_DIST_DLLS=%CK_DIST_DLLS% %root%\conpty\Microsoft.Windows.Console.ConPTY\x64-OpenConsole.exe
+set CK_DIST_DLLS=%CK_DIST_DLLS% %root%\conpty\Microsoft.Windows.Console.ConPTY\arm64-OpenConsole.exe
+set CK_DIST_DLLS=%CK_DIST_DLLS% %root%\conpty\Microsoft.Windows.Console.ConPTY\runtimes\win-x86\native\conpty.dll
+goto :done
 
+:archx8664
+set CK_DIST_DLLS=%CK_DIST_DLLS% %root%\conpty\Microsoft.Windows.Console.ConPTY\x64-OpenConsole.exe
+set CK_DIST_DLLS=%CK_DIST_DLLS% %root%\conpty\Microsoft.Windows.Console.ConPTY\arm64-OpenConsole.exe
+set CK_DIST_DLLS=%CK_DIST_DLLS% %root%\conpty\Microsoft.Windows.Console.ConPTY\runtimes\win-x64\native\conpty.dll
+goto :done
+
+:archarm64
+set CK_DIST_DLLS=%CK_DIST_DLLS% %root%\conpty\Microsoft.Windows.Console.ConPTY\runtimes\win-arm64\native\conpty.dll
+set CK_DIST_DLLS=%CK_DIST_DLLS% %root%\conpty\Microsoft.Windows.Console.ConPTY\build\native\runtimes\arm64\OpenConsole.exe
+goto :done
+
+:done
 echo DIST DLLs updated:
 echo %CK_DIST_DLLS%
 

--- a/doc/changes.md
+++ b/doc/changes.md
@@ -249,6 +249,8 @@ as part of K95 at this time, the default terminal remains VT220 for now.
  - The default screen update interval is now 20 milliseconds giving a frame rate
    of 50 frames per second. The old default was 100 milliseconds (10fps), but
    overridden by the default k95custom.ini.
+ - An updated version of ConPTY is now packaged with kermit 95 for modern x86,
+   x86-64 and arm64 hosts to enable better terminal emulation in PTY sessions.
 
 ### New terminal control sequences
 > [!NOTE]

--- a/doc/changes.md
+++ b/doc/changes.md
@@ -251,6 +251,8 @@ as part of K95 at this time, the default terminal remains VT220 for now.
    overridden by the default k95custom.ini.
  - An updated version of ConPTY is now packaged with kermit 95 for modern x86,
    x86-64 and arm64 hosts to enable better terminal emulation in PTY sessions.
+ - The PTY command will now launch the Windows shell (cmd.exe) by default if no
+   other command is specified
 
 ### New terminal control sequences
 > [!NOTE]

--- a/kermit/k95/cknpty.c
+++ b/kermit/k95/cknpty.c
@@ -45,6 +45,7 @@
 static HPCON hPc = NULL;
 static BOOL conPtyAvailable = FALSE, conPtyChecked = FALSE;
 static HINSTANCE hkernel=NULL;
+static HINSTANCE hconpty=NULL;
 
 typedef HRESULT (WINAPI *CreatePseudoConsole_t)(
     _In_ COORD size,
@@ -92,30 +93,82 @@ UpdateProcThreadAttribute_t p_UpdateProcThreadAttribute;
 
 void load_conpty() {
     FARPROC p;
+    wchar_t conptyPath[CKMAXPATH];
+    DWORD pathLen;
+
     /* Only bother doing this load library business once */
     conPtyChecked = TRUE;
 
     hkernel = LoadLibrary("kernel32.dll");
 
-    p = GetProcAddress(hkernel, "CreatePseudoConsole");
+    /* First, try to load from the same directory as the executable */
+
+    /* Get the location of the K95 executable */
+    pathLen = GetModuleFileNameW(NULL, conptyPath, MAX_PATH);
+
+    /* If there is enough space to tack on "conpty.dll"... */
+    if (pathLen > 0 && pathLen < MAX_PATH - 11) {
+        /* Find the last backslash - the executable name comes after that */
+        wchar_t *c = wcsrchr(conptyPath, L'\\');
+        if (c != NULL) {
+            /* Replace the executable name with "conpty.dll" */
+            wcsncpy_s(c, MAX_PATH - (c - conptyPath), L"\\conpty.dll", 11);
+
+            hconpty = LoadLibraryW(conptyPath);
+        }
+    }
+
+    if (hconpty == NULL) {
+        /* If that fails, look for it on the path */
+        debug(F100, "Failed to load bundled ConPTY, trying PATH", 0, 0);
+        hconpty = LoadLibrary("conpty.dll");
+        if (hconpty == NULL) {
+            /* If that fails, use the version of ConPTY shipped with windows */
+            debug(F100, "Failed to load bundled ConPTY from PATH, falling back to kernel32", 0, 0);
+            hconpty = hkernel;
+        }
+    }
+
+    p = GetProcAddress(hconpty, "CreatePseudoConsole");
     if (p == NULL) {
         conPtyAvailable = FALSE;
         return;
     }
     p_CreatePseudoConsole = (CreatePseudoConsole_t)p;
 
-    p = GetProcAddress(hkernel, "ClosePseudoConsole");
+    p = GetProcAddress(hconpty, "ClosePseudoConsole");
+    if (p == NULL) {
+        debug(F100, "Failed to load ClosePseudoConsole from conpty.dll", 0, 0);
+        conPtyAvailable = FALSE;
+        return;
+    }
     p_ClosePseudoConsole = (ClosePseudoConsole_t)p;
 
-    p = GetProcAddress(hkernel, "ResizePseudoConsole");
+    p = GetProcAddress(hconpty, "ResizePseudoConsole");
+    if (p == NULL) {
+        debug(F100, "Failed to load ResizePseudoConsole from conpty.dll", 0, 0);
+        conPtyAvailable = FALSE;
+        return;
+    }
     p_ResizePseudoConsole = (ResizePseudoConsole_t)p;
 
     p = GetProcAddress(hkernel, "InitializeProcThreadAttributeList");
+    if (p == NULL) {
+        debug(F100, "Failed to load InitializeProcThreadAttributeList from kernel32.dll", 0, 0);
+        conPtyAvailable = FALSE;
+        return;
+    }
     p_InitializeProcThreadAttributeList = (InitializeProcThreadAttributeList_t)p;
 
     p = GetProcAddress(hkernel, "UpdateProcThreadAttribute");
+    if (p == NULL) {
+        debug(F100, "Failed to load UpdateProcThreadAttribute from kernel32.dll", 0, 0);
+        conPtyAvailable = FALSE;
+        return;
+    }
     p_UpdateProcThreadAttribute = (UpdateProcThreadAttribute_t)p;
 
+    debug(F100, "ConPTY functions loaded", 0, 0);
     conPtyAvailable = TRUE;
 }
 

--- a/kermit/k95/ckuus7.c
+++ b/kermit/k95/ckuus7.c
@@ -11303,6 +11303,14 @@ setlin(xx, zz, fc) int xx, zz, fc;
             cmfdbi(&nx,_CMIFI,"Filename","","",0,0,xxstring,NULL,NULL);
 #endif /* NETFILE */
 #ifdef PTYORPIPE
+#ifdef NT
+#ifdef CK_CONPTY
+        } else if (mynet == NET_PTY) {
+            /* On Windows, run the shell if nothing else is specified. Otherwise
+             * we try to run dftty which is "0" which is unhelpful. */
+            cmfdbi(&nx,_CMTXT,"Command","cmd.exe","",0,0,xxstring,NULL,NULL);
+#endif /* CK_CONPTY */
+#endif /* NT */
         } else if (mynet == NET_CMD || mynet == NET_PTY) {
             cmfdbi(&nx,_CMTXT,"Command","","",0,0,xxstring,NULL,NULL);
 #endif /* PTYORPIPE */

--- a/kermit/k95/mkdist.bat
+++ b/kermit/k95/mkdist.bat
@@ -92,6 +92,23 @@ copy %WATCOM%\binnt\plbr*.dll dist
 @echo Copy enabled optional dependencies
 for %%I in (%CK_DIST_DLLS%) do copy %%I dist\
 
+REM Move any variants of OpenConsole.exe being shipped into
+REM architecture-specific directories where conpty.dll will look for them
+if exist dist\x86-openconsole.exe (
+    if not exist dist\x86\NUL mkdir dist\x86
+    move dist\x86-openconsole.exe dist\x86\OpenConsole.exe
+)
+
+if exist dist\x64-openconsole.exe (
+    if not exist dist\x64\NUL mkdir dist\x64
+    move dist\x64-openconsole.exe dist\x64\OpenConsole.exe
+)
+
+if exist dist\arm64-openconsole.exe (
+    if not exist dist\arm64\NUL mkdir dist\arm64
+    move dist\arm64-openconsole.exe dist\arm64\OpenConsole.exe
+)
+
 @echo Copy licenses
 copy ..\..\COPYING dist
 if exist dist\ssh.dll copy %libssh_root%\COPYING dist\COPYING.libssh

--- a/setenv.bat
+++ b/setenv.bat
@@ -554,6 +554,20 @@ set CKB_IBMTCP20=no
 if exist %ibm20dir%\lib\tcp32dll.lib set CKB_IBMTCP20=yes
 if exist %ibm20dir%\lib\tcp32dll.lib echo found %ibm20dir%\lib\tcp32dll.lib
 
+REM Try to find updated ConPTY library
+if not exist %root%\conpty\Microsoft.Windows.Console.ConPTY\inc\conpty.h goto :noconpty
+echo Found updated ConPTY in %root%\conpty\Microsoft.Windows.Console.ConPTY
+set CONPTY_ARCH=none
+if "%CKB_TARGET_ARCH%" == "AMD64" set CONPTY_ARCH=x64
+if "%CKB_TARGET_ARCH%" == "ARM64" set CONPTY_ARCH=arm64
+if "%CKB_TARGET_ARCH%" == "x86" set CONPTY_ARCH=x86
+if "%CONPTY_ARCH%" == "none" goto :noconpty
+
+set CK_CONPTY_DIST=%root%\conpty\Microsoft.Windows.Console.ConPTY\runtimes\win-%CONPTY_ARCH%\native\conpty.dll
+set CK_CONPTY_DIST=%CK_CONPTY_DIST% %root%\conpty\Microsoft.Windows.Console.ConPTY\build\native\runtimes\%CONPTY_ARCH%\OpenConsole.exe
+
+:noconpty
+
 REM --------------------------------------------------------------
 REM Detect compiler so the OpenZinc build environment can be setup 
 REM --------------------------------------------------------------
@@ -1007,6 +1021,11 @@ REM        and remove their dist files.
 
 set CK_DIST_DLLS=%CK_ZLIB_DIST_DLLS% %CK_SSL_DIST_DLLS% %CK_SSH_DIST_DLLS% %CK_SRP_DIST_DLLS% %CK_K4W_DIST_FILES% %CKB_REXX_DIST_DLLS% %CK_DIST_ASAN%
 
+REM ConPTY is only supported on Visual C++ 2019 (CKB_MSC_VER=192) or higher
+if %CKB_MSC_VER% GEQ 192 (
+    set CK_DIST_DLLS=%CK_DIST_DLLS% %CK_CONPTY_DIST%
+)
+
 REM If this build can run on Windows 9x, include ctrl2cap for swapping the
 REM CTRL and Caps Lock keys, and the accent grave and esc keys:
 if "%CKB_9X_COMPATIBLE%" == "yes" set CK_DIST_DLLS=%CK_DIST_DLLS% %root%\kermit\ctrl2cap\ctrl2cap.vxd %root%\kermit\ctrl2cap\ctrl2cap.txt %root%\kermit\ctrl2cap\ctrl2cap.license
@@ -1019,13 +1038,10 @@ echo.
 echo Library path set to:
 echo    %lib%
 echo.
-echo DIST DLLs set to:
+echo DIST files set to:
 echo    %CK_DIST_DLLS%
 echo.
 echo Compiler: %CK_COMPILER_NAME%
-echo.
-echo Dist files set to:
-echo    %CK_DIST_DLLS%
 echo.
 echo Optional Dependencies:
 echo     zlib: %CKF_ZLIB%
@@ -1038,6 +1054,8 @@ echo      SRP: %CKF_SRP%
 echo Kerberos: %CKF_K4W% (Kerberos+SSL: %CKF_K4W_SSL%, DNS-SRV: %CKF_K4W_WSHELPER%, KRB4: %CKF_K4W_KRB4%)
 if "%CKF_REXX%" == "yes" echo     REXX: %CKF_REXX% (%REXX_LIB%)
 if "%CKF_REXX%" == "no" echo     REXX: %CKF_REXX%
+if "%CK_CONPTY_DIST%" == "" echo   ConPTY: No
+if "%CK_CONPTY_DIST%" neq "" echo   ConPTY: Yes
 echo.
 if "%BUILD_ZINC%" == "yes" echo OpenZinc is required for building the dialer. You can build it by extracting
 if "%BUILD_ZINC%" == "yes" echo the OpenZinc distribution to %root%\zinc and running

--- a/setenv.bat
+++ b/setenv.bat
@@ -557,15 +557,35 @@ if exist %ibm20dir%\lib\tcp32dll.lib echo found %ibm20dir%\lib\tcp32dll.lib
 REM Try to find updated ConPTY library
 if not exist %root%\conpty\Microsoft.Windows.Console.ConPTY\inc\conpty.h goto :noconpty
 echo Found updated ConPTY in %root%\conpty\Microsoft.Windows.Console.ConPTY
-set CONPTY_ARCH=none
-if "%CKB_TARGET_ARCH%" == "AMD64" set CONPTY_ARCH=x64
-if "%CKB_TARGET_ARCH%" == "ARM64" set CONPTY_ARCH=arm64
-if "%CKB_TARGET_ARCH%" == "x86" set CONPTY_ARCH=x86
-if "%CONPTY_ARCH%" == "none" goto :noconpty
 
-set CK_CONPTY_DIST=%root%\conpty\Microsoft.Windows.Console.ConPTY\runtimes\win-%CONPTY_ARCH%\native\conpty.dll
-set CK_CONPTY_DIST=%CK_CONPTY_DIST% %root%\conpty\Microsoft.Windows.Console.ConPTY\build\native\runtimes\%CONPTY_ARCH%\OpenConsole.exe
+if "%CKB_TARGET_ARCH%" == "x86" goto :conptyx8632
+if "%CKB_TARGET_ARCH%" == "AMD64" goto :conptyx8664
+if "%CKB_TARGET_ARCH%" == "ARM64" goto :conptyarm64
 
+goto :noconpty
+
+:conptyx8632
+REM x86-32 can run on x86-64 and arm64, so all three variants of openconsole are needed
+set CK_CONPTY_DIST=%CK_CONPTY_DIST% %root%\conpty\Microsoft.Windows.Console.ConPTY\x86-OpenConsole.exe
+set CK_CONPTY_DIST=%CK_CONPTY_DIST% %root%\conpty\Microsoft.Windows.Console.ConPTY\x64-OpenConsole.exe
+set CK_CONPTY_DIST=%CK_CONPTY_DIST% %root%\conpty\Microsoft.Windows.Console.ConPTY\arm64-OpenConsole.exe
+set CK_CONPTY_DIST=%CK_CONPTY_DIST% %root%\conpty\Microsoft.Windows.Console.ConPTY\runtimes\win-x86\native\conpty.dll
+goto :conptydone
+
+:conptyx8664
+REM x86-64 can run on arm64 too, so both variants of openconsole are needed
+set CK_CONPTY_DIST=%CK_CONPTY_DIST% %root%\conpty\Microsoft.Windows.Console.ConPTY\x64-OpenConsole.exe
+set CK_CONPTY_DIST=%CK_CONPTY_DIST% %root%\conpty\Microsoft.Windows.Console.ConPTY\arm64-OpenConsole.exe
+set CK_CONPTY_DIST=%CK_CONPTY_DIST% %root%\conpty\Microsoft.Windows.Console.ConPTY\runtimes\win-x64\native\conpty.dll
+goto :conptydone
+
+:conptyarm64
+REM arm64 only works on arm64, so only one variant of openconsole needed
+set CK_CONPTY_DIST=%CK_CONPTY_DIST% %root%\conpty\Microsoft.Windows.Console.ConPTY\runtimes\win-arm64\native\conpty.dll
+set CK_CONPTY_DIST=%CK_CONPTY_DIST% %root%\conpty\Microsoft.Windows.Console.ConPTY\build\native\runtimes\arm64\OpenConsole.exe
+goto :conptydone
+
+:conptydone
 :noconpty
 
 REM --------------------------------------------------------------


### PR DESCRIPTION
Try to load conpty.dll from the executable directory first, then from the path. If conpty.dll can't be found then fall back to the older ConPTY implementation in kernel32.dll.

This seems to be enough to get, eg, vtnibbler working properly in 64bit builds of K95, but the 32bit builds don't seem to work with 32bit builds of conpty for some reason.

TODO:

- [x] Fetch updated conpty and openconsole from nuget
- [x] Figure out why 32bit conpty and openconsole don't work on 64bit windows
  - [x] Confirm 32bit K95 with 32bit conpty.dll and openconsole.exe work fine on 32bit Windows 10
  - [x] Fix bug in K95 if it is one, or disable loading of conpty.dll in 32bit builds running on 64bit windows if its a known compatibility problem.
- [x] Make sure that loading a bundled conpty.dll on older windows (eg windows 7) doesn't result in the PTY command becoming available but not working.