### PR TITLE
Initial attempt at proper smooth scroll.

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -402,6 +402,7 @@ as part of K95 at this time, the default terminal remains VT220 for now.
  - [DECDLDA](https://davidrg.github.io/ckwin/dev/ctlseqs.html#decdlda) - Set how many font buffers are available (VT520 only), queryable with DECRQSS
  - [DECSWBV](https://davidrg.github.io/ckwin/dev/ctlseqs.html#decswbv) - Set Warning Bell Volume
  - [DECPS](https://davidrg.github.io/ckwin/dev/ctlseqs.html#decps) - Play Sound (VT520)
+ - [DECSCLM](https://davidrg.github.io/ckwin/dev/ctlseqs.html#decsclm) - Smooth Scroll (K95G only)
  - [DECSSCLS](https://davidrg.github.io/ckwin/dev/ctlseqs.html#decsscls) - Set Scroll Speed
 
 ### Fixed Bugs

--- a/doc/changes.md
+++ b/doc/changes.md
@@ -402,6 +402,7 @@ as part of K95 at this time, the default terminal remains VT220 for now.
  - [DECDLDA](https://davidrg.github.io/ckwin/dev/ctlseqs.html#decdlda) - Set how many font buffers are available (VT520 only), queryable with DECRQSS
  - [DECSWBV](https://davidrg.github.io/ckwin/dev/ctlseqs.html#decswbv) - Set Warning Bell Volume
  - [DECPS](https://davidrg.github.io/ckwin/dev/ctlseqs.html#decps) - Play Sound (VT520)
+ - [DECSSCLS](https://davidrg.github.io/ckwin/dev/ctlseqs.html#decsscls) - Set Scroll Speed
 
 ### Fixed Bugs
  - Fixed an issue introduced in beta 7 which could cause SSH connections made

--- a/doc/changes.md
+++ b/doc/changes.md
@@ -167,6 +167,7 @@ as part of K95 at this time, the default terminal remains VT220 for now.
    `SET TERM CLEAR-ON-RESIZE { ON, OFF }` 
  - Soft-fonts (DRCS) for VT220 and higher emulations are now supported
  - The VT520 Play Sound control sequence is now supported.
+ - Proper Smooth Scroll is now supported in K95G.
 
 ### Enhancements
  - The Control Sequences documentation ([preliminary version available online](https://davidrg.github.io/ckwin/dev/ctlseqs.html))
@@ -253,6 +254,9 @@ as part of K95 at this time, the default terminal remains VT220 for now.
    x86-64 and arm64 hosts to enable better terminal emulation in PTY sessions.
  - The PTY command will now launch the Windows shell (cmd.exe) by default if no
    other command is specified
+ - WYSE WY-50 and compatible escape sequences for setting the smooth scrolling
+   speed (`ESC `` <`, `ESC `` =`, `ESC `` >`, `ESC `` ?`) now set the
+   appropriate smooth-scroll speed.
 
 ### New terminal control sequences
 > [!NOTE]

--- a/doc/ctlseqs.xml
+++ b/doc/ctlseqs.xml
@@ -6238,7 +6238,6 @@ VT420:
                     DECSLCK    SP v         Set Lock Key Style
                     DECSMBV    SP u         Set Margin Bell Volume
                     DECSPP      + w         Set Port Parameter
-                    DECSSCLS   SP p         Set Scroll Speed
                     DECSTRL     " u         Set Transmit Rate Limit
                     DECSWBV    SP t         Set Warning Bell Volume
                     DECTME     SP ~         Terminal Mode Emulation
@@ -6315,6 +6314,19 @@ VT420:
                     and the conformance level will reflect the chosen terminal
                     type. The only part of this response you can actually change
                     via DECRQSS is the 8-bit/7-bit controls setting.
+                </p>
+            </section>
+            <section role="parameter" id="decrqss-decsscls" mnemonic="DECSSCLS"
+                     title="Scroll Speed">
+                <ctlseq><param-text/> = SP p</ctlseq>
+                <ref src="vt510:DECRQSS.html"/>
+                <ref src="vt52x:266"/>
+                <termsupp first="vt510" series="vt" additional=""/>
+                <p>
+                    Reports the current <a href="#decsscls">DECSSCLS</a>
+                    setting - the scroll mode and speed. A response for Jump
+                    Scroll might look like <tt><cc>DCS</cc> 1 $ r 9 SP [q] <cc>ST</cc></tt>
+                    (where SP is the space character)
                 </p>
             </section>
             <section role="parameter" id="decrqss-decscusr" mnemonic="DECSCUSR"
@@ -9760,7 +9772,8 @@ DCS $ q 3 , } ST</pre>
                     In K95G this enables proper smooth scroll. On VT220 and
                     higher emulations as well as the K95 terminal type, changing
                     DECSCLM does not take effect until after the next scroll
-                    event.
+                    event. For terminals supporting multiple speeds, this sets
+                    the slow speed (SMOOTH-2).
                 </p>
             </section>
             <section role="parameter" id="decscnm" mnemonic="DECSCNM" title="Reverse screen">
@@ -14812,12 +14825,86 @@ DCS $ q 3 , } ST</pre>
             <p>Resets the terminal</p>
         </section>
         <section role="ctlseq" mnemonic="DECSSCLS" id="decsscls"
-                 title="Set Scroll Speed"
-                 not-implemented="true" todo="true">
+                 title="Set Scroll Speed" badges="vt520 k95">
             <ctlseq>CSI <param-single/> SP p</ctlseq>
             <ref src="vt510:DECSSCLS.html"/>
             <ref src="vt52x:300"/>
             <termsupp first="vt510" series="vt" additional=""/>
+            <p>Selects from one of a number of smooth-scroll speeds, or sets
+                jump-scroll mode. Only supported by K95G.
+            </p>
+            <p>The VT520 only offers three settings:</p>
+            <ul>
+                <li>0-3: smooth-2, 9 lines per second</li>
+                <li>4-8: smooth-4, 18 lines per second</li>
+                <li>9: jump scroll</li>
+            </ul>
+            <p>
+                The K95 terminal type expands this to a wider range of speeds:
+            </p>
+            <table>
+                <tr>
+                    <th><em>Ps</em></th>
+                    <th>Mode</th>
+                    <th>Lines Per Second</th>
+                </tr>
+                <tr>
+                    <td>0</td>
+                    <td>Smooth</td>
+                    <td>3</td>
+                </tr>
+                <tr>
+                    <td>1</td>
+                    <td>Smooth</td>
+                    <td>6</td>
+                </tr>
+                <tr>
+                    <td>2</td>
+                    <td>Smooth-2</td>
+                    <td>9</td>
+                </tr>
+                <tr>
+                    <td>3</td>
+                    <td>Smooth</td>
+                    <td>12</td>
+                </tr>
+                <tr>
+                    <td>4</td>
+                    <td>Smooth-4</td>
+                    <td>18</td>
+                </tr>
+                <tr>
+                    <td>5</td>
+                    <td>Smooth</td>
+                    <td>22</td>
+                </tr>
+                <tr>
+                    <td>6</td>
+                    <td>Smooth</td>
+                    <td>27</td>
+                </tr>
+                <tr>
+                    <td>7</td>
+                    <td>Smooth</td>
+                    <td>31</td>
+                </tr>
+                <tr>
+                    <td>8</td>
+                    <td>Smooth</td>
+                    <td>36</td>
+                </tr>
+                <tr>
+                    <td>9</td>
+                    <td>Jump</td>
+                    <td>As fast as received</td>
+                </tr>
+            </table>
+            <p>
+                This setting can be queried via
+                <a href="#decrqss-decsscls">DECRQSS</a>, and the status of
+                smooth scroll (any speed) or jump scroll can be queried via
+                <a href="#decrqm-4">DECRQM</a>.
+            </p>
         </section>
         <section role="ctlseq" mnemonic="DECSCL" id="decscl" title="Select Conformance Level">
             <ctlseq>CSI <param-single symbol="Pl"/> ; <param-single symbol="Pc"/> " p</ctlseq>

--- a/doc/ctlseqs.xml
+++ b/doc/ctlseqs.xml
@@ -2302,6 +2302,12 @@ DECTSR		462
                 the terminal scrolls up one line. Otherwise, the cursor remains at the end
                 of the line
             </p>
+            <p>
+                If a downwards smooth scroll (as a result of an
+                <a href="#ri">RI</a> on the top line) is currently in progress,
+                then a line feed anywhere is blocked until the smooth-scroll
+                finishes.
+            </p>
 
             <p badges="s97801">
                 If in page mode and the cursor is at the bottom margin, the cursor is sent

--- a/doc/ctlseqs.xml
+++ b/doc/ctlseqs.xml
@@ -1951,6 +1951,10 @@ DECTSR		462
             <!-- 0x8D -->
             <p>Reverse Index—moves the cursor up one, scrolling the screen
                 if the cursor is already at the top margin.</p>
+            <p>If the cursor is at the top of the screen and smooth scrolling is
+                enabled (<tt>SET TERM SCREEN-UPDATE SMOOTH</tt>) the contents of
+                the screen will scroll smoothly down.
+            </p>
         </section>
         <section role="ctlseq" id="ssg2l" ctlseq="ESC N" mnemonic="SS2" title="Single shift G2, left" groups="isvt220 isansi">
             <ref src="e48:84"/>

--- a/doc/ctlseqs.xml
+++ b/doc/ctlseqs.xml
@@ -9385,8 +9385,7 @@ DCS $ q 3 , } ST</pre>
                 <ctlseq><param-single/> = 4</ctlseq>
                 <termsupp first="sco" series="sco" additional=""/>
                 <p>
-                    Enable Smooth Scrolling. Only supported in the console
-                    version of K95 at this time (not K95G).
+                    Enable Smooth Scrolling.
                 </p>
             </section>
             <section role="parameter" mnemonic="IRM" id="sm-4"

--- a/doc/ctlseqs.xml
+++ b/doc/ctlseqs.xml
@@ -9769,7 +9769,7 @@ DCS $ q 3 , } ST</pre>
                     inserts a brief pause on each scroll.
                 </p>
                 <p>
-                    In K95G this enables proper smooth scroll. On VT220 and
+                    In K95G this enables proper smooth scroll. On VT100 and
                     higher emulations as well as the K95 terminal type, changing
                     DECSCLM does not take effect until after the next scroll
                     event. For terminals supporting multiple speeds, this sets

--- a/doc/ctlseqs.xml
+++ b/doc/ctlseqs.xml
@@ -9711,8 +9711,15 @@ DCS $ q 3 , } ST</pre>
                 <ref src="vt510:DECRQM.html#T5-8"/>
                 <ref src="vt52x:277"/>
                 <termsupp first="vt100" series="vt" additional="vt132 vt220 vt330 vt340 vt420 vt510 dtterm"/>
-                <p>Console version only: Enable smooth (slow) scrolling mode.
-                    K95G (the GUI version) presently ignores this setting.
+                <p>Enable smooth (slow) scrolling mode.</p>
+                <p>In the console versions of K95 for Windows and OS/2 this just
+                    inserts a brief pause on each scroll.
+                </p>
+                <p>
+                    In K95G this enables proper smooth scroll. On VT220 and
+                    higher emulations as well as the K95 terminal type, changing
+                    DECSCLM does not take effect until after the next scroll
+                    event.
                 </p>
             </section>
             <section role="parameter" id="decscnm" mnemonic="DECSCNM" title="Reverse screen">
@@ -11714,9 +11721,11 @@ DCS $ q 3 , } ST</pre>
                 <ref src="vt52x:277"/>
                 <termsupp first="vt100" series="vt" additional="vt132 vt220 vt330 vt340 vt420 vt510 dtterm"/>
                 <p>
-                    Switches to Jump (fast) scrolling. Only affects the console version
-                    of K95—the GUI version (K95G) only supports jump scrolling at the moment so
-                    is always in this mode
+                    Switches to Jump (fast) scrolling.
+                </p>
+                <p>
+                    In K95G for VT220 and higher emulations this does not take
+                    effect until after the next scroll event.
                 </p>
             </section>
             <section role="parameter" mnemonic="DECSCNM" id="r-decscnm" title="Normal screen">

--- a/doc/manual/setterm.html
+++ b/doc/manual/setterm.html
@@ -595,18 +595,32 @@ on your computer.  If you are using a speech or Braille device, you should use
 <dd>Chooses the mechanism used for screen updating and the update frequency.
 <tt>SMOOTH</tt> means the screen is repainted every time a character arrives.
 <tt>FAST</tt> means the screen is repainted at fixed intervals.  The default
-is <tt>FAST</tt> with an interval of 100 milliseconds (1/10 second).  Use
+is <tt>FAST</tt> with an interval of 20 milliseconds (1/50 second). In console
+versions of Kermit (not K95G), use
 <tt>SMOOTH</tt> to give priority to echoing; use <tt>FAST</tt> to give
 priority to throughput.  Vary the interval to achieve optimum results for your
 PC.  On VT100 and above, the host may use escape sequences to switch Kermit
 between <tt>FAST</tt> and <tt>SMOOTH</tt>; <tt>FAST</tt> is selected by the
 Jump-scrolling escape sequence; <tt>SMOOTH</tt> is selected by the VT100
-smooth-scrolling sequence.  However, note that K95 does not presently
-implement smooth scrolling in the VT100 sense.  If the host switches K95 from
+smooth-scrolling sequence. K95G instead implements proper smooth scrolling, and
+the escape sequence controls that, rather than the screen update mode.
+If the host switches K95 from
 <tt>SMOOTH</tt> to <tt>FAST</tt>, the most recently specified (or if none,
 default) update interval is used.  If you are using a speech or Braille
 device, you should <tt>SET TERMINAL SCREEN-UPDATE SMOOTH</tt>. SMOOTH is not
 supported by K95G at this time.
+
+<p>
+<dt><tt><a name="sttscr">SET TERMINAL SCROLL-MODE <i>{</i> JUMP, SMOOTH <i>[ speed ]</i>, SMOOTH-2, SMOOTH-4 <i>}</i></tt>
+<dd>Sets the scrolling mode. When in Jump Scrolling mode, the terminal
+    adds new lines as fast as they are received, while Smooth Scrolling mode
+    adds them smoothly at a speed that makes them recogniszable if not readable.
+<p> The <tt>SMOOTH</tt> option lets you specify a speed from 1 to 36 lines per
+    second, while <tt>SMOOTH-2</tt> and <tt>SMOOTH-4</tt> correspond to slow and
+    fast speeds on those terminals that offer two speed options. For the K95
+    terminal type, <tt>SMOOTH-2</tt> is nine lines per second and
+    <tt>SMOOTH-4</tt> is twice that. For terminals offering only one speed
+    option, <tt>SMOOTH-4</tt> is the same as <tt>SMOOTH-2</tt>.
 
 <p>
 <dt><tt><a name="t_scroll">SET TERMINAL SCROLLBACK <i>lines</i></tt>

--- a/kermit/k95/ckoco2.c
+++ b/kermit/k95/ckoco2.c
@@ -95,6 +95,7 @@ extern bool in_smooth_scroll;
 extern bool smooth_scroll_upwards;
 extern bool decsclm_pending;
 extern int smooth_scroll_top, smooth_scroll_bottom;
+extern int smooth_scroll_left, smooth_scroll_right;
 extern videoline s_scroll_backup_line;
 extern int tt_type;
 #endif /* KUI */
@@ -3742,11 +3743,20 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
 
     #ifdef KUI
     smooth_scroll_top = smooth_scroll_bottom = -1;
-    if ((updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2) && vmode == VTERM
+    smooth_scroll_left = smooth_scroll_right = -1;
+    if (updmode >= TTU_SMOOTH && vmode == VTERM
         && page == vscrn_current_page_number(VTERM, TRUE)
-        && (!lrmm || tt_type != TT_VT420)) {
-        /* The VT420 does not smooth-scroll between the left and right margins,
-         * but the VT520 does */
+        && (!lrmm || ISK95(tt_type))) {
+        /* No DEC terminal scrolls between the L/R margins, but K95 does! */
+
+        if (topmargin != 0 || bottommargin != VscrnGetPageHeight(vmode, TRUE)) {
+            smooth_scroll_top = topmargin;
+            smooth_scroll_bottom = bottommargin;
+        }
+        if (lrmm) {
+            smooth_scroll_left = leftmargin;
+            smooth_scroll_right = rightmargin;
+        }
 
         if (updown == DOWNWARD_SMOOTHLY &&
             bottommargin == VscrnGetPageHeight(vmode, TRUE)) {
@@ -3755,11 +3765,11 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
              * one extra line in the screen buffer to do the job. */
             bottommargin += 1;
             use_backup_line = FALSE;
-        } else if (updown == UPWARD && topmargin == 0 && savetobuffer) {
+        } else if (updown == UPWARD && (topmargin == 0 && savetobuffer && !lrmm)) {
             /* If we're scrolling upward and the top margin is screen top, and
              * we're saving to scrollback, we get the top line preserved for
              * free! */
-            use_backup_line = FALSE;
+             use_backup_line = FALSE;
         } else {
             /* Else we have to preserve the line that is being erased manually.
              * The Smooth Scroll Backup Line will be used to hold it. */
@@ -4015,7 +4025,7 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
     debug(F100,"VscrnScroll releases mutex","",0);
 
 #ifdef KUI
-    if ((updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2) && vmode == VTERM &&
+    if (updmode >= TTU_SMOOTH && vmode == VTERM &&
             page == vscrn_current_page_number(VTERM, TRUE)
             && updown != UPWARD_JUMP && updown != DOWNWARD) {
 
@@ -4023,19 +4033,17 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
          * until it completes.*/
         in_smooth_scroll = TRUE;
         smooth_scroll_upwards = updown == UPWARD;
-        if (use_backup_line) {
-            smooth_scroll_top = topmargin;
-            smooth_scroll_bottom = bottommargin;
-        } else {
-            smooth_scroll_top = smooth_scroll_bottom = -1;
-        }
+
         ResetSmoothScrollFinishedSem();
+    } else {
+        smooth_scroll_top = smooth_scroll_bottom = -1;
+        smooth_scroll_left = smooth_scroll_right = -1;
     }
 
     /* The VT220 and up defer DECSCLM taking effect until after the next scroll.
      * */
     if (decsclm_pending) {
-        if (updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2) updmode = TTU_FAST;
+        if (updmode >= TTU_SMOOTH) updmode = TTU_FAST;
         else updmode = TTU_SMOOTH;
         decsclm_pending = FALSE;
     }

--- a/kermit/k95/ckoco2.c
+++ b/kermit/k95/ckoco2.c
@@ -95,6 +95,7 @@ extern int scrollmode, tt_scrollmode;
 extern bool in_smooth_scroll;
 extern bool smooth_scroll_upwards;
 extern bool decsclm_pending;
+extern int smooth_speed_pending;
 extern int smooth_speed;
 extern int smooth_scroll_top, smooth_scroll_bottom;
 extern int smooth_scroll_left, smooth_scroll_right;
@@ -4045,10 +4046,24 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
     /* The VT220 and up defer DECSCLM taking effect until after the next scroll.
      * */
     if (decsclm_pending) {
-        if (scrollmode >= TTS_SMOOTH) updmode = TTS_JUMP;
-        else {
-            scrollmode = TTS_SMOOTH_2;
-            smooth_speed = SmoothScrollSpeed(TTS_SMOOTH_2);
+        if (smooth_speed_pending == -1) {
+            if (scrollmode >= TTS_SMOOTH) scrollmode = TTS_JUMP;
+            else {
+                scrollmode = TTS_SMOOTH_2;
+                smooth_speed = SmoothScrollSpeed(TTS_SMOOTH_2);
+            }
+        } else {
+            int speed_2 = SmoothScrollSpeed(TTS_SMOOTH_2);
+            int speed_4 = SmoothScrollSpeed(TTS_SMOOTH_4);
+            if (smooth_speed_pending == speed_2) {
+                scrollmode = TTS_SMOOTH_2;
+            } else if (smooth_speed_pending == speed_4) {
+                scrollmode = TTS_SMOOTH_4;
+            } else {
+                scrollmode = TTS_SMOOTH;
+            }
+            smooth_speed = smooth_speed_pending;
+            smooth_speed_pending = -1;
         }
         decsclm_pending = FALSE;
     }

--- a/kermit/k95/ckoco2.c
+++ b/kermit/k95/ckoco2.c
@@ -3627,6 +3627,7 @@ VscrnSetBufferSize( BYTE vmode, ULONG newsize, int new_page_count )
 void
 BackupLineForSmoothScroll(videoline *line) {
     s_scroll_backup_line.width = line->width;
+    s_scroll_backup_line.vt_line_attr = line->vt_line_attr;
     s_scroll_backup_line.markbeg = line->markbeg;
     s_scroll_backup_line.markshowend = line->markshowend;
     s_scroll_backup_line.markend = line->markend;

--- a/kermit/k95/ckoco2.c
+++ b/kermit/k95/ckoco2.c
@@ -89,6 +89,9 @@ int tt_url_hilite_attr = VT_CHAR_ATTR_BOLD | VT_CHAR_ATTR_UNDERLINE;
 int tt_url_hilite_attr = VT_CHAR_ATTR_BOLD;
 #endif /* KUI */
 extern int updmode ;
+#ifdef KUI
+extern bool in_smooth_scroll;
+#endif /* KUI */
 extern int priority ;
 extern int tt_modechg;
 extern cell_video_attr_t defaultattribute ;
@@ -3694,6 +3697,15 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
     static vt_cell_attr_t blank_cell_attrs[MAXTERMCOL];
 #endif /* KUI */
 
+#ifdef KUI
+    // TODO: only if the view page
+    if (updmode == TTU_SMOOTH && vmode == VTERM && in_smooth_scroll
+        && page == vscrn_current_page_number(VTERM, TRUE) && updown == UPWARD) {
+        /* Wait for the last scroll to finish. */
+        WaitSmoothScrollFinishedSem(5000);
+    }
+#endif /* KUI */
+
     if ( fillchar == NUL )
         fillchar = SP ;
 
@@ -3723,8 +3735,10 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
         last_cellcolor = cellcolor ;
     }
 
+#ifndef KUI
     if ( updmode == TTU_SMOOTH )
         msleep(1) ;
+#endif /* KUI */
 
     debug(F111,"VscrnScroll","vmode",vmode);
     debug(F111,"VscrnScroll","updown",updown);
@@ -3985,6 +3999,14 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
     }
     ReleaseVscrnMutex( vmode ) ;
     debug(F100,"VscrnScroll releases mutex","",0);
+
+#ifdef KUI
+    if (updmode == TTU_SMOOTH && vmode == VTERM && updown == UPWARD &&
+            page == vscrn_current_page_number(VTERM, TRUE)) {
+        in_smooth_scroll = TRUE;
+        ResetSmoothScrollFinishedSem();
+    }
+#endif /* KUI */
 }
 
 

--- a/kermit/k95/ckoco2.c
+++ b/kermit/k95/ckoco2.c
@@ -3699,9 +3699,9 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
 #endif /* KUI */
 
 #ifdef KUI
-    // TODO: only if the view page
     if ((updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2) && vmode == VTERM
-        && in_smooth_scroll && page == vscrn_current_page_number(VTERM, TRUE)  && updown == UPWARD) {
+        && in_smooth_scroll && page == vscrn_current_page_number(VTERM, TRUE)
+        && updown == UPWARD) {
         /* Wait for the last scroll to finish. */
         WaitSmoothScrollFinishedSem(5000);
     }
@@ -3759,6 +3759,7 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
 
     debug(F101,"VscrnScroll has VscrnMutex","",vmode);
     switch (updown) {
+        case UPWARD_JUMP:
         case UPWARD:
             if (savetobuffer && topmargin == 0 && !lrmm) {
                 if (topmargin) {

--- a/kermit/k95/ckoco2.c
+++ b/kermit/k95/ckoco2.c
@@ -92,7 +92,7 @@ extern int updmode ;
 #ifdef KUI
 /* Smooth-Scroll related state */
 extern int scrollmode, tt_scrollmode;
-extern bool in_smooth_scroll;
+extern bool in_smooth_scroll, in_bg_smooth_scroll;
 extern bool smooth_scroll_upwards;
 extern bool decsclm_pending;
 extern int smooth_speed_pending;
@@ -101,6 +101,7 @@ extern int smooth_scroll_top, smooth_scroll_bottom;
 extern int smooth_scroll_left, smooth_scroll_right;
 extern videoline s_scroll_backup_line;
 extern int tt_type;
+extern DWORD bg_smooth_scroll_ends;
 #endif /* KUI */
 extern int priority ;
 extern int tt_modechg;
@@ -4028,16 +4029,31 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
     debug(F100,"VscrnScroll releases mutex","",0);
 
 #ifdef KUI
-    if (scrollmode >= TTS_SMOOTH && vmode == VTERM &&
-            page == vscrn_current_page_number(VTERM, TRUE)
+    if (scrollmode >= TTS_SMOOTH && vmode == VTERM
             && updown != UPWARD_JUMP && updown != DOWNWARD) {
-
         /* Begin a new smooth-scroll! This will block any further LF characters
-         * until it completes.*/
-        in_smooth_scroll = TRUE;
-        smooth_scroll_upwards = updown == UPWARD;
+         * until it completes*/
 
-        ResetSmoothScrollFinishedSem();
+        if (page == vscrn_current_page_number(VTERM, TRUE)) {
+            /* Cursor on the visible page. The renderer will manage the smooth
+             * scroll and post a semaphore when it is done.
+             */
+            in_smooth_scroll = TRUE;
+            in_bg_smooth_scroll = FALSE;
+            smooth_scroll_upwards = updown == UPWARD;
+
+            ResetSmoothScrollFinishedSem();
+        } else {
+            /* Cursor is on a background page. There is nothing for the renderer
+             * to render, so we'll just set a flag, and the next LF will complete
+             * the smooth scroll. */
+
+            float ms_per_line = 1000.0f / (float)(smooth_speed < 1 ? 6 : smooth_speed);
+
+            in_smooth_scroll = FALSE;
+            bg_smooth_scroll_ends = timeGetTime() + (DWORD)ms_per_line;
+            in_bg_smooth_scroll = TRUE;
+        }
     } else {
         smooth_scroll_top = smooth_scroll_bottom = -1;
         smooth_scroll_left = smooth_scroll_right = -1;

--- a/kermit/k95/ckoco2.c
+++ b/kermit/k95/ckoco2.c
@@ -91,6 +91,7 @@ int tt_url_hilite_attr = VT_CHAR_ATTR_BOLD;
 extern int updmode ;
 #ifdef KUI
 extern bool in_smooth_scroll;
+extern bool decsclm_pending;
 #endif /* KUI */
 extern int priority ;
 extern int tt_modechg;
@@ -4006,6 +4007,15 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
         in_smooth_scroll = TRUE;
         ResetSmoothScrollFinishedSem();
     }
+
+    /* The VT220 and up defer DECSCLM taking effect until after the next scroll.
+     * */
+    if (decsclm_pending) {
+        if (updmode == TTU_SMOOTH) updmode = TTU_FAST;
+        else updmode = TTU_SMOOTH;
+        decsclm_pending = FALSE;
+    }
+
 #endif /* KUI */
 }
 

--- a/kermit/k95/ckoco2.c
+++ b/kermit/k95/ckoco2.c
@@ -90,9 +90,13 @@ int tt_url_hilite_attr = VT_CHAR_ATTR_BOLD;
 #endif /* KUI */
 extern int updmode ;
 #ifdef KUI
+/* Smooth-Scroll related state */
 extern bool in_smooth_scroll;
-bool    smooth_scroll_upwards;
+extern bool smooth_scroll_upwards;
 extern bool decsclm_pending;
+extern int smooth_scroll_top, smooth_scroll_bottom;
+extern videoline s_scroll_backup_line;
+extern int tt_type;
 #endif /* KUI */
 extern int priority ;
 extern int tt_modechg;
@@ -2525,6 +2529,16 @@ int VscrnGetHeight( BYTE vmode ) {
     return VscrnGetHeightEx(vmode, TRUE);
 }
 
+/* Gets the height of the screen excluding the status line */
+int VscrnGetPageHeight(BYTE vmode, BOOL orStatusLine) {
+
+    if ( vmode == VTERM && decsasd == SASD_STATUS && orStatusLine )
+        vmode = VSTATUS ;
+
+    return (vscrn[vmode].height ? vscrn[vmode].height : MAXTERMROW) -(tt_status[vmode]?2:1);
+
+}
+
 /*---------------------------------------------------------------------------*/
 /* VscrnGetDisplayHeight                                    | Page: n/a      */
 /*---------------------------------------------------------------------------*/
@@ -3660,6 +3674,29 @@ clear_cell_attrs(videoline *dest, int start, int end) {
 #endif /* PACKED_CELL_ATTRS */
 #endif /* KUI */
 
+#ifdef KUI
+/* Takes a backup copy of a video line for smooth scroll operations */
+void
+BackupLineForSmoothScroll(videoline *line) {
+    s_scroll_backup_line.width = line->width;
+    s_scroll_backup_line.markbeg = line->markbeg;
+    s_scroll_backup_line.markshowend = line->markshowend;
+    s_scroll_backup_line.markend = line->markend;
+    memcpy(s_scroll_backup_line.cells,
+        line->cells,
+        sizeof(viocell) * MAXTERMCOL);
+    memcpy(s_scroll_backup_line.vt_char_attrs,
+        line->vt_char_attrs,
+        sizeof(vt_char_attr_t) * MAXTERMCOL);
+    memcpy(s_scroll_backup_line.cell_attrs,
+        line->cell_attrs,
+        sizeof(vt_cell_attr_t) * MAXTERMCOL);
+    memcpy(s_scroll_backup_line.hyperlinks,
+        line->hyperlinks,
+        sizeof(unsigned short) * MAXTERMCOL);
+}
+#endif /* KUI */
+
 /*---------------------------------------------------------------------------*/
 /* VscrnScrollPage                                          | Page: Specified*/
 /*---------------------------------------------------------------------------*/
@@ -3692,6 +3729,9 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
     int i, x, vs_width, lrmm;
     long  obeg, oend, otop, nbeg, nend, ntop ;
     cell_video_attr_t cellcolor = geterasecolor(vmode) ;
+#ifdef KUI
+    bool use_backup_line = FALSE;
+#endif /* KUI */
 
     static CHAR last_fillchar = 0;
     static cell_video_attr_t last_cellcolor = cell_video_attr_init_vio_attribute(0);
@@ -3699,16 +3739,6 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
     static vt_char_attr_t blank_attrs[MAXTERMCOL];
 #ifdef KUI
     static vt_cell_attr_t blank_cell_attrs[MAXTERMCOL];
-#endif /* KUI */
-
-#ifdef KUI
-    if ((updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2) && vmode == VTERM
-        && in_smooth_scroll && page == vscrn_current_page_number(VTERM, TRUE)
-        && updown == DOWNWARD_SMOOTHLY) {
-        /* The current bottom line needs to be preserved through the scroll
-         * operation */
-        bottommargin += 1;
-    }
 #endif /* KUI */
 
     if ( fillchar == NUL )
@@ -3760,6 +3790,54 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
     if (rightmargin < 0 || rightmargin > vs_width-1) rightmargin = vs_width-1;
     lrmm = (leftmargin != 0 || rightmargin != vs_width-1) &&
         leftmargin < rightmargin;
+
+    #ifdef KUI
+    smooth_scroll_top = smooth_scroll_bottom = -1;
+    if ((updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2) && vmode == VTERM
+        && page == vscrn_current_page_number(VTERM, TRUE)
+        && (!lrmm || tt_type != TT_VT420)) {
+        /* The VT420 does not smooth-scroll between the left and right margins,
+         * but the VT520 does */
+
+        if (updown == DOWNWARD_SMOOTHLY &&
+            bottommargin == VscrnGetPageHeight(vmode, TRUE)) {
+            /* When scrolling downward, we need to preserve the bottom line. If
+             * the bottom margin is the page margin, then we can just preserve
+             * one extra line in the screen buffer to do the job. */
+            bottommargin += 1;
+            use_backup_line = FALSE;
+        } else if (updown == UPWARD && topmargin == 0 && savetobuffer) {
+            /* If we're scrolling upward and the top margin is screen top, and
+             * we're saving to scrollback, we get the top line preserved for
+             * free! */
+            use_backup_line = FALSE;
+        } else {
+            /* Else we have to preserve the line that is being erased manually.
+             * The Smooth Scroll Backup Line will be used to hold it. */
+            use_backup_line = TRUE;
+
+            if (s_scroll_backup_line.cells == NULL) {
+                /* The backup line has never been used. Initialise it. */
+                s_scroll_backup_line.cells = malloc(
+                    sizeof(viocell) * MAXTERMCOL);
+                s_scroll_backup_line.vt_char_attrs = malloc(
+                    sizeof(vt_char_attr_t) * MAXTERMCOL);
+                s_scroll_backup_line.cell_attrs = malloc(
+                    sizeof(vt_cell_attr_t) * MAXTERMCOL);
+                s_scroll_backup_line.hyperlinks = malloc(
+                    sizeof(unsigned short) * MAXTERMCOL);
+                memset(s_scroll_backup_line.cells, 0,
+                    sizeof(viocell) * MAXTERMCOL);
+                memset(s_scroll_backup_line.vt_char_attrs, 0,
+                    sizeof(vt_char_attr_t) * MAXTERMCOL);
+                memset(s_scroll_backup_line.cell_attrs, 0,
+                    sizeof(vt_cell_attr_t) * MAXTERMCOL);
+                memset(s_scroll_backup_line.hyperlinks, 0,
+                    sizeof(unsigned short) * MAXTERMCOL);
+            }
+        }
+    }
+#endif /* KUI */
 
     debug(F101,"VscrnScroll has VscrnMutex","",vmode);
     switch (updown) {
@@ -3831,6 +3909,15 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
                 vscrn_page_t *p = &vscrn[vmode].pages[page];
 
                 for ( i = topmargin ; i <= bottommargin - nlines ; i++ ) {
+#ifdef KUI
+                    if (i == topmargin && use_backup_line) {
+                        /* Take a copy of the line at the top margin as the
+                         * smooth scroll process will need it. */
+                        BackupLineForSmoothScroll(
+                            VscrnGetPageLineFromTop(vmode, i, page));
+                    }
+#endif /* KUI */
+
                     if (!lrmm) {
                         /* save line to be deleted */
                         linetodelete = *VscrnGetPageLineFromTop(vmode, i, page) ;
@@ -3921,6 +4008,15 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
             vscrn_page_t *p = &vscrn[vmode].pages[page];
 
             for ( i = bottommargin ; i >= topmargin+nlines ; i-- ) {
+#ifdef KUI
+                if (i == bottommargin && use_backup_line) {
+                    /* Take a copy of the line at the bottom margin as the
+                     * smooth scroll process will need it. */
+                    BackupLineForSmoothScroll(
+                        VscrnGetPageLineFromTop(vmode, i, page));
+                }
+#endif /* KUI */
+
                 if (!lrmm)
                 {
                     /* save line to be deleted */
@@ -4016,6 +4112,12 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
          * until it completes.*/
         in_smooth_scroll = TRUE;
         smooth_scroll_upwards = updown == UPWARD;
+        if (use_backup_line) {
+            smooth_scroll_top = topmargin;
+            smooth_scroll_bottom = bottommargin;
+        } else {
+            smooth_scroll_top = smooth_scroll_bottom = -1;
+        }
         ResetSmoothScrollFinishedSem();
     }
 

--- a/kermit/k95/ckoco2.c
+++ b/kermit/k95/ckoco2.c
@@ -91,9 +91,11 @@ int tt_url_hilite_attr = VT_CHAR_ATTR_BOLD;
 extern int updmode ;
 #ifdef KUI
 /* Smooth-Scroll related state */
+extern int scrollmode, tt_scrollmode;
 extern bool in_smooth_scroll;
 extern bool smooth_scroll_upwards;
 extern bool decsclm_pending;
+extern int smooth_speed;
 extern int smooth_scroll_top, smooth_scroll_bottom;
 extern int smooth_scroll_left, smooth_scroll_right;
 extern videoline s_scroll_backup_line;
@@ -3744,7 +3746,7 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
     #ifdef KUI
     smooth_scroll_top = smooth_scroll_bottom = -1;
     smooth_scroll_left = smooth_scroll_right = -1;
-    if (updmode >= TTU_SMOOTH && vmode == VTERM
+    if (scrollmode >= TTS_SMOOTH && vmode == VTERM
         && page == vscrn_current_page_number(VTERM, TRUE)
         && (!lrmm || ISK95(tt_type))) {
         /* No DEC terminal scrolls between the L/R margins, but K95 does! */
@@ -4025,7 +4027,7 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
     debug(F100,"VscrnScroll releases mutex","",0);
 
 #ifdef KUI
-    if (updmode >= TTU_SMOOTH && vmode == VTERM &&
+    if (scrollmode >= TTS_SMOOTH && vmode == VTERM &&
             page == vscrn_current_page_number(VTERM, TRUE)
             && updown != UPWARD_JUMP && updown != DOWNWARD) {
 
@@ -4043,8 +4045,11 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
     /* The VT220 and up defer DECSCLM taking effect until after the next scroll.
      * */
     if (decsclm_pending) {
-        if (updmode >= TTU_SMOOTH) updmode = TTU_FAST;
-        else updmode = TTU_SMOOTH;
+        if (scrollmode >= TTS_SMOOTH) updmode = TTS_JUMP;
+        else {
+            scrollmode = TTS_SMOOTH_2;
+            smooth_speed = SmoothScrollSpeed(TTS_SMOOTH_2);
+        }
         decsclm_pending = FALSE;
     }
 
@@ -5925,6 +5930,9 @@ VscrnInit( BYTE vmode )
           crossedoutattribute = colorcrossedout ;
           dimattribute = colordim ;
           updmode = tt_updmode ;  /* Set screen update mode */
+#ifdef KUI
+          scrollmode = tt_scrollmode;
+#endif /* KUI */
       }
       old_height = VscrnGetHeight(VTERM)-(tt_status[vmode]?1:0);
 	  old_width = VscrnGetWidth(VTERM);

--- a/kermit/k95/ckoco2.c
+++ b/kermit/k95/ckoco2.c
@@ -5934,7 +5934,15 @@ VscrnInit( BYTE vmode )
             	{
             	    extern bool decncsm;
                 	if ( !VscrnIsClear(vmode, p ) && !decncsm && !decscpp_resize) {
+#ifdef KUI
+                	    /* Suppress smooth-scroll, as we aren't really doing a scroll */
+                	    int updmode_backup = updmode;
+                	    updmode = TTU_FAST;
+#endif /* KUI */
                     	VscrnScrollPage( vmode, UPWARD, 0, sz-1, -1, -1, sz-1, TRUE, SP, p ) ;
+#ifdef KUI
+                	    updmode = updmode_backup;
+#endif /* KUI */
                     	clrscr = 1 ;
                 	}
             	}

--- a/kermit/k95/ckoco2.c
+++ b/kermit/k95/ckoco2.c
@@ -3700,8 +3700,8 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
 
 #ifdef KUI
     // TODO: only if the view page
-    if (updmode == TTU_SMOOTH && vmode == VTERM && in_smooth_scroll
-        && page == vscrn_current_page_number(VTERM, TRUE) && updown == UPWARD) {
+    if ((updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2) && vmode == VTERM
+        && in_smooth_scroll && page == vscrn_current_page_number(VTERM, TRUE)  && updown == UPWARD) {
         /* Wait for the last scroll to finish. */
         WaitSmoothScrollFinishedSem(5000);
     }
@@ -4002,8 +4002,8 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
     debug(F100,"VscrnScroll releases mutex","",0);
 
 #ifdef KUI
-    if (updmode == TTU_SMOOTH && vmode == VTERM && updown == UPWARD &&
-            page == vscrn_current_page_number(VTERM, TRUE)) {
+    if ((updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2) && vmode == VTERM &&
+            page == vscrn_current_page_number(VTERM, TRUE) && updown == UPWARD) {
         in_smooth_scroll = TRUE;
         ResetSmoothScrollFinishedSem();
     }
@@ -4011,7 +4011,7 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
     /* The VT220 and up defer DECSCLM taking effect until after the next scroll.
      * */
     if (decsclm_pending) {
-        if (updmode == TTU_SMOOTH) updmode = TTU_FAST;
+        if (updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2) updmode = TTU_FAST;
         else updmode = TTU_SMOOTH;
         decsclm_pending = FALSE;
     }
@@ -5934,15 +5934,7 @@ VscrnInit( BYTE vmode )
             	{
             	    extern bool decncsm;
                 	if ( !VscrnIsClear(vmode, p ) && !decncsm && !decscpp_resize) {
-#ifdef KUI
-                	    /* Suppress smooth-scroll, as we aren't really doing a scroll */
-                	    int updmode_backup = updmode;
-                	    updmode = TTU_FAST;
-#endif /* KUI */
-                    	VscrnScrollPage( vmode, UPWARD, 0, sz-1, -1, -1, sz-1, TRUE, SP, p ) ;
-#ifdef KUI
-                	    updmode = updmode_backup;
-#endif /* KUI */
+                    	VscrnScrollPage( vmode, UPWARD_JUMP, 0, sz-1, -1, -1, sz-1, TRUE, SP, p ) ;
                     	clrscr = 1 ;
                 	}
             	}

--- a/kermit/k95/ckoco2.c
+++ b/kermit/k95/ckoco2.c
@@ -4059,7 +4059,7 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
         smooth_scroll_left = smooth_scroll_right = -1;
     }
 
-    /* The VT220 and up defer DECSCLM taking effect until after the next scroll.
+    /* The VT100 and up defer DECSCLM taking effect until after the next scroll.
      * */
     if (decsclm_pending) {
         if (smooth_speed_pending == -1) {

--- a/kermit/k95/ckoco2.c
+++ b/kermit/k95/ckoco2.c
@@ -91,6 +91,7 @@ int tt_url_hilite_attr = VT_CHAR_ATTR_BOLD;
 extern int updmode ;
 #ifdef KUI
 extern bool in_smooth_scroll;
+bool    smooth_scroll_upwards;
 extern bool decsclm_pending;
 #endif /* KUI */
 extern int priority ;
@@ -3666,7 +3667,9 @@ clear_cell_attrs(videoline *dest, int start, int end) {
  *
  * Parameters:
  *     vmode        vscreen to scroll
- *     updown       Scroll UPWARD or DOWNWARD
+ *     updown       Scroll UPWARD* or DOWNWARD*
+ *                  UPWARD and DOWNWARD_SMOOTHLY may smooth scroll
+ *                  UPWARD_JUMP and DOWNWARD will never smooth scroll
  *     topmargin    Top line of region to scroll. Zero based.
  *     bottommargin Bottom line of region to scroll. Zero based.
  *     leftmargin   Left column of region to scroll. Use -1 for entire line.
@@ -3701,9 +3704,15 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
 #ifdef KUI
     if ((updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2) && vmode == VTERM
         && in_smooth_scroll && page == vscrn_current_page_number(VTERM, TRUE)
-        && updown == UPWARD) {
+        && updown != UPWARD_JUMP && updown != DOWNWARD) {
         /* Wait for the last scroll to finish. */
         WaitSmoothScrollFinishedSem(5000);
+
+        if (DOWNWARD_SMOOTHLY) {
+            /* The current bottom line needs to be preserved through the scroll
+             * operation */
+            bottommargin += 1;
+        }
     }
 #endif /* KUI */
 
@@ -3912,6 +3921,7 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
 #endif /* NOKVERBS */
             break;
 
+        case DOWNWARD_SMOOTHLY:
         case DOWNWARD: {
             vscrn_page_t *p = &vscrn[vmode].pages[page];
 
@@ -4004,8 +4014,10 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
 
 #ifdef KUI
     if ((updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2) && vmode == VTERM &&
-            page == vscrn_current_page_number(VTERM, TRUE) && updown == UPWARD) {
+            page == vscrn_current_page_number(VTERM, TRUE)
+            && updown != UPWARD_JUMP && updown != DOWNWARD) {
         in_smooth_scroll = TRUE;
+        smooth_scroll_upwards = updown == UPWARD;
         ResetSmoothScrollFinishedSem();
     }
 

--- a/kermit/k95/ckoco2.c
+++ b/kermit/k95/ckoco2.c
@@ -4029,7 +4029,7 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
     debug(F100,"VscrnScroll releases mutex","",0);
 
 #ifdef KUI
-    if (scrollmode >= TTS_SMOOTH && vmode == VTERM
+    if (scrollmode >= TTS_SMOOTH && vmode == VTERM && (!lrmm || ISK95(tt_type))
             && updown != UPWARD_JUMP && updown != DOWNWARD) {
         /* Begin a new smooth-scroll! This will block any further LF characters
          * until it completes*/

--- a/kermit/k95/ckoco2.c
+++ b/kermit/k95/ckoco2.c
@@ -3704,15 +3704,10 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
 #ifdef KUI
     if ((updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2) && vmode == VTERM
         && in_smooth_scroll && page == vscrn_current_page_number(VTERM, TRUE)
-        && updown != UPWARD_JUMP && updown != DOWNWARD) {
-        /* Wait for the last scroll to finish. */
-        WaitSmoothScrollFinishedSem(5000);
-
-        if (DOWNWARD_SMOOTHLY) {
-            /* The current bottom line needs to be preserved through the scroll
-             * operation */
-            bottommargin += 1;
-        }
+        && updown == DOWNWARD_SMOOTHLY) {
+        /* The current bottom line needs to be preserved through the scroll
+         * operation */
+        bottommargin += 1;
     }
 #endif /* KUI */
 
@@ -4016,6 +4011,9 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
     if ((updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2) && vmode == VTERM &&
             page == vscrn_current_page_number(VTERM, TRUE)
             && updown != UPWARD_JUMP && updown != DOWNWARD) {
+
+        /* Begin a new smooth-scroll! This will block any further LF characters
+         * until it completes.*/
         in_smooth_scroll = TRUE;
         smooth_scroll_upwards = updown == UPWARD;
         ResetSmoothScrollFinishedSem();

--- a/kermit/k95/ckoco3.c
+++ b/kermit/k95/ckoco3.c
@@ -7488,11 +7488,19 @@ clrpage( BYTE vmode, CHAR fillchar, int page ) {
 						page);
     }
     else {
+#ifdef KUI
+        /* Suppress smooth-scroll, as we aren't really doing a scroll */
+        int updmode_backup = updmode;
+        updmode = TTU_FAST;
+#endif /* KUI */
         VscrnScrollPage(vmode,UPWARD,
                      	0,VscrnGetHeight(vmode)-(tt_status[vmode]?2:1),
                      	-1, -1,
                      	VscrnGetHeight(vmode)-(tt_status[vmode]?1:0),
                      	TRUE,fillchar, page);
+#ifdef KUI
+        updmode = updmode_backup;
+#endif /* KUI */
 
 #ifdef KUI
         if (ISDECTERM(tt_type_mode) || ISK95(tt_type_mode)) {

--- a/kermit/k95/ckoco3.c
+++ b/kermit/k95/ckoco3.c
@@ -267,7 +267,9 @@ extern int  scrninitialized[] ;
 extern bool scrollflag[] ;
 extern bool viewonly ;           /* View Only Terminal mode */
 extern int  updmode ;            /* Fast/Smooth scrolling */
+#ifdef KUI
 extern bool in_smooth_scroll ;
+#endif /* KUI */
 extern int priority ;
 extern TID  tidRdComWrtScr ;
 
@@ -19093,6 +19095,7 @@ wrtch(unsigned short ch) {
                 prtline( wherey[VTERM], LF ) ;
             }
             if ( decsasd == SASD_TERMINAL ) {
+#ifdef KUI
                 /* If a smooth scroll is in progress, a line feed anywhere is
                  * blocked until the scroll is finished. If we don't do this,
                  * then you'll see the prompt in GNU Less jump up a little every
@@ -19100,12 +19103,13 @@ wrtch(unsigned short ch) {
                  * also says "When a line feed is received the microprocessor
                  * waits for the current scroll to end" (pg 4-96) so this is
                  * probably the correct place for the wait. */
-                if ((updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2)
+                if (updmode >= TTU_SMOOTH
                     && vmode == VTERM && in_smooth_scroll
                     && vscrn_current_page_number(VTERM, FALSE) == vscrn_current_page_number(VTERM, TRUE)
                 ) {
                     WaitSmoothScrollFinishedSem(5000);
                 }
+#endif /* KUI */
 
                 if (wherey[vmode] == vscrn_c_page_margin_bot(VTERM)) {
                     if ( IS97801(tt_type_mode) ) {
@@ -21190,7 +21194,7 @@ vtcsi(void)
                             pn[2] = deccolm ? 1 : 2 ;
                             break;
                         case 4: /* DECSCLM */
-                            pn[2] = (updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2) ? 1 : 2 ;
+                            pn[2] = updmode >= TTU_SMOOTH ? 1 : 2 ;
                             break;
                         case 5: /* DECSCNM */
                             pn[2] = decscnm ? 1 : 2 ;

--- a/kermit/k95/ckoco3.c
+++ b/kermit/k95/ckoco3.c
@@ -26767,6 +26767,13 @@ vtcsi(void)
                                      SP,
                                      FALSE);
                     } else { /* Roll Mode */
+                        /* TODO:
+                         * This should scroll smoothly. But it shouldn't do so
+                         * using VscrnScrollPage. SD (and SU) are for panning
+                         * a viewport smaller than the page up and down (like
+                         * using the vertical scrollbar), and when smooth
+                         * scrolling is on it should pan smoothly.
+                         */
                         VscrnScrollPage(
                             VTERM,      /* Vscrn */
                             DOWNWARD,   /* Direction */
@@ -28600,7 +28607,7 @@ vtescape( void )
             if (ISVT100(tt_type_mode)) {
                 if (vscrn_c_page_margin_top(VTERM) == wherey[VTERM])
                     VscrnScrollPage(VTERM,
-                                 DOWNWARD,
+                                 DOWNWARD_SMOOTHLY,
                                  vscrn_c_page_margin_top(VTERM) - 1,
                                  vscrn_c_page_margin_bot(VTERM) - 1,
                                  vscrn_c_page_margin_left(VTERM) - 1,

--- a/kermit/k95/ckoco3.c
+++ b/kermit/k95/ckoco3.c
@@ -266,9 +266,14 @@ extern char     * d_name;
 extern int  scrninitialized[] ;
 extern bool scrollflag[] ;
 extern bool viewonly ;           /* View Only Terminal mode */
-extern int  updmode ;            /* Fast/Smooth scrolling */
 #ifdef KUI
+extern int  scrollmode ;            /* Fast/Smooth scrolling */
 extern bool in_smooth_scroll ;
+extern int smooth_speed;
+extern int tt_smooth_speed;
+#else
+extern int updmode;
+extern int tt_updmode;
 #endif /* KUI */
 extern int priority ;
 extern TID  tidRdComWrtScr ;
@@ -739,7 +744,9 @@ extern int cmd_cols;                    /* Screen columns */
 extern int tt_ctstmo;                   /* CTS timeout */
 extern int tt_pacing;                   /* Output-pacing */
 extern int tt_mouse;                    /* Mouse */
-extern int tt_updmode;                  /* Terminal Screen Update Mode */
+#ifdef KUI
+extern int tt_scrollmode;               /* Terminal Scrolling Mode */
+#endif /* KUI */
 extern int tt_url_hilite;
 extern int tt_url_hilite_attr;
 int tt_type_vt52 = TT_VT52 ;            /* Terminal Type Mode before entering VT52 mode */
@@ -11243,10 +11250,15 @@ doreset(int x) {                        /* x = 0 (soft), nonzero (hard) */
     udkreset() ;                        /* Reset UDKs     */
     deccolm = FALSE;                    /* default column mode */
     tt_cols[VTERM] = tt_cols_usr ;
+#ifdef KUI
+    scrollmode = tt_scrollmode;      /* set terminal scroll mode to original */
+    smooth_speed = tt_smooth_speed;
+#else
     if (tt_updmode == TTU_FAST ) /* set terminal scroll mode to original */
         JumpScroll();
     else
         SmoothScroll();
+#endif /* KUI */
     if (vmode==VTERM)
         SetCols(VTERM) ;
     naws();
@@ -19103,7 +19115,7 @@ wrtch(unsigned short ch) {
                  * also says "When a line feed is received the microprocessor
                  * waits for the current scroll to end" (pg 4-96) so this is
                  * probably the correct place for the wait. */
-                if (updmode >= TTU_SMOOTH
+                if (scrollmode >= TTS_SMOOTH
                     && vmode == VTERM && in_smooth_scroll
                     && vscrn_current_page_number(VTERM, FALSE) == vscrn_current_page_number(VTERM, TRUE)
                 ) {
@@ -21194,7 +21206,11 @@ vtcsi(void)
                             pn[2] = deccolm ? 1 : 2 ;
                             break;
                         case 4: /* DECSCLM */
+#ifdef KUI
+                            pn[2] = scrollmode >= TTS_SMOOTH ? 1 : 2 ;
+#else
                             pn[2] = updmode >= TTU_SMOOTH ? 1 : 2 ;
+#endif /* KUI */
                             break;
                         case 5: /* DECSCNM */
                             pn[2] = decscnm ? 1 : 2 ;

--- a/kermit/k95/ckoco3.c
+++ b/kermit/k95/ckoco3.c
@@ -270,6 +270,7 @@ extern bool viewonly ;           /* View Only Terminal mode */
 extern int  scrollmode ;            /* Fast/Smooth scrolling */
 extern bool in_smooth_scroll ;
 extern int smooth_speed;
+extern int smooth_speed_pending;
 extern int tt_smooth_speed;
 #else
 extern int updmode;
@@ -17322,6 +17323,43 @@ dodcs( void )
                     case SP: {
                         achar = (dcsnext<apclength)?apcbuf[dcsnext++]:0;
                         switch ( achar ) {
+                        case 'p': {    /* DECSSCLS */
+                            int decsscls = -1;
+#ifdef KUI
+                            /* The VT520 reports a recent speed change as though
+                             * it has already taken effect */
+                            int speed = smooth_speed_pending == -1
+                                ? smooth_speed : smooth_speed_pending;
+
+                            if (ISK95(tt_type_mode)) {
+                                if (scrollmode == TTS_JUMP) decsscls = 9;
+                                else if (speed <= 3) decsscls = 0;
+                                else if (speed <= 6) decsscls = 1;
+                                else if (speed <= 9) decsscls = 2;
+                                else if (speed <= 12) decsscls = 3;
+                                else if (speed <= 18) decsscls = 4;
+                                else if (speed <= 22) decsscls = 5;
+                                else if (speed <= 27) decsscls = 6;
+                                else if (speed <= 31) decsscls = 7;
+                                else if (speed <= 36) decsscls = 8;
+                            } else if (ISVT520(tt_type_mode)) {
+                                /* ?4l, 9 = 9
+                                 * ?4h, 0...3 = 2
+                                 * 4..8 = 4 */
+                                if (scrollmode == TTS_JUMP) decsscls = 9;
+                                else if (scrollmode == TTS_SMOOTH_2 ||
+                                         speed <= 9)
+                                    decsscls = 2;
+                                else decsscls = 4;
+                            }
+#endif /* KUI */
+                            if (decsscls >= 0) {
+                                char buf[10];
+                                _snprintf(buf, sizeof(buf), "%d p", decsscls);
+                                _snprintf(decrpss, DECRPSS_LEN,
+                                        fmt, 1, buf);
+                            }
+                        } /* 'p' */
                         case 'q': {    /*  DECSCUSR  */
                             _snprintf(decrpss, DECRPSS_LEN, fmt, 1,
                                  (tt_cursor == TTC_BLOCK && tt_cursor_blink == 1) ? "1 q"
@@ -27874,6 +27912,37 @@ vtcsi(void)
 						}
 					}
 					break;
+                case 'p':       /* DECSSCLS  - Set Scroll Speed - VT510 */
+#ifdef KUI
+                    if (ISK95(tt_type_mode)) {
+                        switch (pn[1]) {
+                        case 0: smooth_speed_pending = 3; break;
+                        case 1: smooth_speed_pending = 6; break;
+                        case 2: smooth_speed_pending = 9; break;
+                        case 3: smooth_speed_pending = 12; break;
+                        case 4: smooth_speed_pending = 18; break;
+                        case 5: smooth_speed_pending = 22; break;
+                        case 6: smooth_speed_pending = 27; break;
+                        case 7: smooth_speed_pending = 31; break;
+                        case 8: smooth_speed_pending = 36; break;
+                        }
+                        if (pn[1] == 9) JumpScroll();
+                        else if (pn[1] < 9) SmoothScroll();
+                    }
+                    else
+#endif /* KUI */
+                    if (ISVT520(tt_type_mode)) {
+                        if (pn[1] <= 3) SmoothScroll();
+                        else if (pn[1] <= 8) {
+#ifdef KUI
+                            smooth_speed_pending = 18;
+#endif /* KUI */
+                            SmoothScroll();
+                        } else if (pn[1] == 9) {
+                            JumpScroll();
+                        }
+                    }
+                    break;
                 case 'q':       /* DECSCUSR - Set Cursor Type - VT520 */
                     switch ( pn[1] ) {
                     case 0:

--- a/kermit/k95/ckoco3.c
+++ b/kermit/k95/ckoco3.c
@@ -268,10 +268,11 @@ extern bool scrollflag[] ;
 extern bool viewonly ;           /* View Only Terminal mode */
 #ifdef KUI
 extern int  scrollmode ;            /* Fast/Smooth scrolling */
-extern bool in_smooth_scroll ;
+extern bool in_smooth_scroll, in_bg_smooth_scroll ;
 extern int smooth_speed;
 extern int smooth_speed_pending;
 extern int tt_smooth_speed;
+extern DWORD bg_smooth_scroll_ends;
 #else
 extern int updmode;
 extern int tt_updmode;
@@ -19153,11 +19154,21 @@ wrtch(unsigned short ch) {
                  * also says "When a line feed is received the microprocessor
                  * waits for the current scroll to end" (pg 4-96) so this is
                  * probably the correct place for the wait. */
-                if (scrollmode >= TTS_SMOOTH
-                    && vmode == VTERM && in_smooth_scroll
-                    && vscrn_current_page_number(VTERM, FALSE) == vscrn_current_page_number(VTERM, TRUE)
-                ) {
-                    WaitSmoothScrollFinishedSem(5000);
+                if (scrollmode >= TTS_SMOOTH && vmode == VTERM) {
+                    if (in_smooth_scroll) {
+                        WaitSmoothScrollFinishedSem(5000);
+                    } else if (in_bg_smooth_scroll) {
+                        /* Smooth scrolling on a background page just introduces
+                         * a delay. There is nothing to render, so we just
+                         * pause for the length of time the renderer *would*
+                         * have spent scrolling the line */
+                        DWORD time = timeGetTime();
+                        int sleep_time = bg_smooth_scroll_ends - time;
+                        if (sleep_time > 0) {
+                            msleep(sleep_time);
+                        }
+                        in_bg_smooth_scroll = FALSE;
+                    }
                 }
 #endif /* KUI */
 

--- a/kermit/k95/ckoco3.c
+++ b/kermit/k95/ckoco3.c
@@ -267,6 +267,7 @@ extern int  scrninitialized[] ;
 extern bool scrollflag[] ;
 extern bool viewonly ;           /* View Only Terminal mode */
 extern int  updmode ;            /* Fast/Smooth scrolling */
+extern bool in_smooth_scroll ;
 extern int priority ;
 extern TID  tidRdComWrtScr ;
 
@@ -19080,6 +19081,20 @@ wrtch(unsigned short ch) {
                 prtline( wherey[VTERM], LF ) ;
             }
             if ( decsasd == SASD_TERMINAL ) {
+                /* If a smooth scroll is in progress, a line feed anywhere is
+                 * blocked until the scroll is finished. If we don't do this,
+                 * then you'll see the prompt in GNU Less jump up a little every
+                 * time you scroll up. The VT100 Technical Manual (EK-VT100-TM)
+                 * also says "When a line feed is received the microprocessor
+                 * waits for the current scroll to end" (pg 4-96) so this is
+                 * probably the correct place for the wait. */
+                if ((updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2)
+                    && vmode == VTERM && in_smooth_scroll
+                    && vscrn_current_page_number(VTERM, FALSE) == vscrn_current_page_number(VTERM, TRUE)
+                ) {
+                    WaitSmoothScrollFinishedSem(5000);
+                }
+
                 if (wherey[vmode] == vscrn_c_page_margin_bot(VTERM)) {
                     if ( IS97801(tt_type_mode) ) {
                         if ( !sni_pagemode )

--- a/kermit/k95/ckoco3.c
+++ b/kermit/k95/ckoco3.c
@@ -21113,7 +21113,7 @@ vtcsi(void)
                             pn[2] = deccolm ? 1 : 2 ;
                             break;
                         case 4: /* DECSCLM */
-                            pn[2] = (updmode == TTU_SMOOTH) ? 1 : 2 ;
+                            pn[2] = (updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2) ? 1 : 2 ;
                             break;
                         case 5: /* DECSCNM */
                             pn[2] = decscnm ? 1 : 2 ;

--- a/kermit/k95/ckoco3.c
+++ b/kermit/k95/ckoco3.c
@@ -7488,19 +7488,11 @@ clrpage( BYTE vmode, CHAR fillchar, int page ) {
 						page);
     }
     else {
-#ifdef KUI
-        /* Suppress smooth-scroll, as we aren't really doing a scroll */
-        int updmode_backup = updmode;
-        updmode = TTU_FAST;
-#endif /* KUI */
-        VscrnScrollPage(vmode,UPWARD,
+        VscrnScrollPage(vmode,UPWARD_JUMP,
                      	0,VscrnGetHeight(vmode)-(tt_status[vmode]?2:1),
                      	-1, -1,
                      	VscrnGetHeight(vmode)-(tt_status[vmode]?1:0),
                      	TRUE,fillchar, page);
-#ifdef KUI
-        updmode = updmode_backup;
-#endif /* KUI */
 
 #ifdef KUI
         if (ISDECTERM(tt_type_mode) || ISK95(tt_type_mode)) {

--- a/kermit/k95/ckocon.c
+++ b/kermit/k95/ckocon.c
@@ -3555,11 +3555,9 @@ conect(int async) {
 void
 SmoothScroll( void ) {
 #ifdef KUI
-    /* TODO: Should probably be for VT100 too, but I don't have one to test
-     * against to confirm. */
-    if (ISVT220(tt_type_mode)) {
-        /* The VT220 and up (maybe VT100 too?) defer changing the scroll mode
-         * state until after the next scroll event. */
+    if (ISVT100(tt_type_mode)) {
+        /* The VT100 and up defer changing the scroll mode state until after
+         * the next scroll event. */
         if (scrollmode >= TTS_SMOOTH && smooth_speed_pending == -1) return;
 
         /* This indicates to VscrnScrollPage that we want it to toggle the

--- a/kermit/k95/ckocon.c
+++ b/kermit/k95/ckocon.c
@@ -214,6 +214,7 @@ int     updmode         = TTU_FAST ;    /* Fast/Smooth scrolling */
 int     priority        = XYP_REG ;
 #ifdef KUI
 bool    in_smooth_scroll = FALSE;
+bool    smooth_scroll_upwards = FALSE;
 bool    decsclm_pending = FALSE;
 #endif /* KUI */
 

--- a/kermit/k95/ckocon.c
+++ b/kermit/k95/ckocon.c
@@ -3575,11 +3575,9 @@ SmoothScroll( void ) {
 void
 JumpScroll( void ) {
 #ifdef KUI
-    /* TODO: Should probably be for VT100 too, but I don't have one to test
-     * against to confirm. */
-    if (ISVT220(tt_type_mode)) {
-        /* The VT220 and up (maybe VT100 too?) defer changing the scroll mode
-         * state until after the next scroll event. */
+    if (ISVT100(tt_type_mode)) {
+        /* The VT100 and up defer changing the scroll mode state until after
+         * the next scroll event. */
         if (scrollmode == TTS_JUMP) return;
 
         /* This indicates to VscrnScrollPage that we want it to toggle the

--- a/kermit/k95/ckocon.c
+++ b/kermit/k95/ckocon.c
@@ -213,8 +213,10 @@ bool    viewonly = FALSE ;              /* View only terminal mode */
 int     updmode         = TTU_FAST ;    /* Fast/Smooth scrolling */
 int     priority        = XYP_REG ;
 #ifdef KUI
-bool    in_smooth_scroll = FALSE;         /* Smooth scroll in progress */
-bool    smooth_scroll_upwards = FALSE;   /* Direction is upwards */
+bool    in_smooth_scroll = FALSE;           /* Smooth scroll in progress */
+bool    smooth_scroll_upwards = FALSE;     /* Direction is upwards */
+int     smooth_scroll_left;               /* Left border of the scroll region */
+int     smooth_scroll_right;             /* Right border of the scroll region */
 int     smooth_scroll_bottom;           /* Bottom line of the smooth scroll */
 int     smooth_scroll_top;             /* Top line of the smooth scroll */
 bool    decsclm_pending = FALSE;      /* Toggle scroll mode after next scroll*/
@@ -3550,7 +3552,7 @@ SmoothScroll( void ) {
     if (ISVT220(tt_type_mode)) {
         /* The VT220 and up (maybe VT100 too?) defer changing the scroll mode
          * state until after the next scroll event. */
-        if (updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2) return;
+        if (updmode >= TTU_SMOOTH) return;
 
         /* This indicates to VscrnScrollPage that we want it to toggle the
          * scroll mode */

--- a/kermit/k95/ckocon.c
+++ b/kermit/k95/ckocon.c
@@ -213,14 +213,18 @@ bool    viewonly = FALSE ;              /* View only terminal mode */
 int     updmode         = TTU_FAST ;    /* Fast/Smooth scrolling */
 int     priority        = XYP_REG ;
 #ifdef KUI
-bool    in_smooth_scroll = FALSE;           /* Smooth scroll in progress */
-bool    smooth_scroll_upwards = FALSE;     /* Direction is upwards */
-int     smooth_scroll_left;               /* Left border of the scroll region */
-int     smooth_scroll_right;             /* Right border of the scroll region */
-int     smooth_scroll_bottom;           /* Bottom line of the smooth scroll */
-int     smooth_scroll_top;             /* Top line of the smooth scroll */
-bool    decsclm_pending = FALSE;      /* Toggle scroll mode after next scroll*/
-videoline s_scroll_backup_line =     /* Line the scroll event erased */
+int     scrollmode      = TTS_JUMP ;        /* Scroll mode - active setting */
+int     tt_scrollmode   = TTS_JUMP ;       /* Scroll mode - user setting */
+int     smooth_speed    = 6;              /* Speed in lines per second, active*/
+int     tt_smooth_speed = 6;             /* Speed in lines per second, user */
+bool    in_smooth_scroll = FALSE;       /* Smooth scroll in progress */
+bool    smooth_scroll_upwards = FALSE; /* Direction is upwards */
+int     smooth_scroll_left;           /* Left border of the scroll region */
+int     smooth_scroll_right;         /* Right border of the scroll region */
+int     smooth_scroll_bottom;       /* Bottom line of the smooth scroll */
+int     smooth_scroll_top;         /* Top line of the smooth scroll */
+bool    decsclm_pending = FALSE;  /* Toggle scroll mode after next scroll */
+videoline s_scroll_backup_line = /* Line the scroll event erased */
     { 0, NULL, NULL, NULL, NULL, 0, 0, 0, 0};
 #endif /* KUI */
 
@@ -330,7 +334,6 @@ extern int cmd_rows;                    /* Screen rows */
 extern int cmd_cols;                    /* Screen columns */
 extern int tt_ctstmo;                   /* CTS timeout */
 extern int tt_pacing;                   /* Output-pacing */
-extern int tt_updmode;                  /* Terminal Screen Update Mode */
 extern bool escapestatus[VNUM] ;        /* are we in ESCAPE mode? */
 /* extern int tt_idlesnd_tmo;           /* Idle Send Timeout, disabled */
 extern char * tt_idlesnd_str;           /* Idle Send String, none */
@@ -3552,15 +3555,18 @@ SmoothScroll( void ) {
     if (ISVT220(tt_type_mode)) {
         /* The VT220 and up (maybe VT100 too?) defer changing the scroll mode
          * state until after the next scroll event. */
-        if (updmode >= TTU_SMOOTH) return;
+        if (scrollmode >= TTS_SMOOTH) return;
 
         /* This indicates to VscrnScrollPage that we want it to toggle the
          * scroll mode */
         decsclm_pending = TRUE;
         return;
+    } else {
+        scrollmode = TTS_SMOOTH_2 ;
     }
-#endif /* KUI */
+#else
     updmode = TTU_SMOOTH ;
+#endif /* KUI */
 }
 
 void
@@ -3571,16 +3577,36 @@ JumpScroll( void ) {
     if (ISVT220(tt_type_mode)) {
         /* The VT220 and up (maybe VT100 too?) defer changing the scroll mode
          * state until after the next scroll event. */
-        if (updmode == TTU_FAST) return;
+        if (scrollmode == TTS_JUMP) return;
 
         /* This indicates to VscrnScrollPage that we want it to toggle the
          * scroll mode */
         decsclm_pending = TRUE;
         return;
+    } else {
+        scrollmode = TTS_JUMP;
     }
-#endif /* KUI */
+#else
     updmode = TTU_FAST ;
+#endif /* KUI */
 }
+
+#ifdef KUI
+/* Gets the standard smooth-scroll speed for a given smooth-scroll mode */
+int
+SmoothScrollSpeed(int mode) {
+    if (mode == TTS_SMOOTH) return tt_smooth_speed;
+    if (mode == TTS_SMOOTH_4) {
+        if (ISVT420(tt_type)) return 18;
+        /* if (ISVT340(tt_type)) return 12;  */
+        /* else fall through - terminal doesn't support smooth-4 */
+    }
+
+    if (ISVT420(tt_type)) return 9;
+    if (ISVT320(tt_type)) return 5;
+    return 6; /* 60Hz VT100, VT220 */
+}
+#endif /* KUI */
 
 char* protoString(void); /* Defined in ckoco3.c */
 

--- a/kermit/k95/ckocon.c
+++ b/kermit/k95/ckocon.c
@@ -214,6 +214,7 @@ int     updmode         = TTU_FAST ;    /* Fast/Smooth scrolling */
 int     priority        = XYP_REG ;
 #ifdef KUI
 bool    in_smooth_scroll = FALSE;
+bool    decsclm_pending = FALSE;
 #endif /* KUI */
 
 int tn_bold = 0;                        /* TELNET negotiation bold */
@@ -3538,11 +3539,39 @@ conect(int async) {
 
 void
 SmoothScroll( void ) {
+#ifdef KUI
+    /* TODO: Should probably be for VT100 too, but I don't have one to test
+     * against to confirm. */
+    if (ISVT220(tt_type_mode)) {
+        /* The VT220 and up (maybe VT100 too?) defer changing the scroll mode
+         * state until after the next scroll event. */
+        if (updmode == TTU_SMOOTH) return;
+
+        /* This indicates to VscrnScrollPage that we want it to toggle the
+         * scroll mode */
+        decsclm_pending = TRUE;
+        return;
+    }
+#endif /* KUI */
     updmode = TTU_SMOOTH ;
 }
 
 void
 JumpScroll( void ) {
+#ifdef KUI
+    /* TODO: Should probably be for VT100 too, but I don't have one to test
+     * against to confirm. */
+    if (ISVT220(tt_type_mode)) {
+        /* The VT220 and up (maybe VT100 too?) defer changing the scroll mode
+         * state until after the next scroll event. */
+        if (updmode == TTU_FAST) return;
+
+        /* This indicates to VscrnScrollPage that we want it to toggle the
+         * scroll mode */
+        decsclm_pending = TRUE;
+        return;
+    }
+#endif /* KUI */
     updmode = TTU_FAST ;
 }
 

--- a/kermit/k95/ckocon.c
+++ b/kermit/k95/ckocon.c
@@ -223,8 +223,9 @@ int     smooth_scroll_left;           /* Left border of the scroll region */
 int     smooth_scroll_right;         /* Right border of the scroll region */
 int     smooth_scroll_bottom;       /* Bottom line of the smooth scroll */
 int     smooth_scroll_top;         /* Top line of the smooth scroll */
-bool    decsclm_pending = FALSE;  /* Toggle scroll mode after next scroll */
-videoline s_scroll_backup_line = /* Line the scroll event erased */
+bool    smooth_speed_pending = -1;/* Speed in lines per second, pending */
+bool    decsclm_pending = FALSE; /* Toggle scroll mode after next scroll */
+videoline s_scroll_backup_line =/* Line the scroll event erased */
     { 0, NULL, NULL, NULL, NULL, 0, 0, 0, 0};
 #endif /* KUI */
 
@@ -3555,7 +3556,7 @@ SmoothScroll( void ) {
     if (ISVT220(tt_type_mode)) {
         /* The VT220 and up (maybe VT100 too?) defer changing the scroll mode
          * state until after the next scroll event. */
-        if (scrollmode >= TTS_SMOOTH) return;
+        if (scrollmode >= TTS_SMOOTH && smooth_speed_pending == -1) return;
 
         /* This indicates to VscrnScrollPage that we want it to toggle the
          * scroll mode */
@@ -3581,6 +3582,7 @@ JumpScroll( void ) {
 
         /* This indicates to VscrnScrollPage that we want it to toggle the
          * scroll mode */
+        smooth_speed_pending = -1;
         decsclm_pending = TRUE;
         return;
     } else {

--- a/kermit/k95/ckocon.c
+++ b/kermit/k95/ckocon.c
@@ -212,6 +212,9 @@ extern bool scrollstatus[] ;
 bool    viewonly = FALSE ;              /* View only terminal mode */
 int     updmode         = TTU_FAST ;    /* Fast/Smooth scrolling */
 int     priority        = XYP_REG ;
+#ifdef KUI
+bool    in_smooth_scroll = FALSE;
+#endif /* KUI */
 
 int tn_bold = 0;                        /* TELNET negotiation bold */
 int esc_exit = 0;                       /* Escape back = exit */

--- a/kermit/k95/ckocon.c
+++ b/kermit/k95/ckocon.c
@@ -227,6 +227,10 @@ bool    smooth_speed_pending = -1;/* Speed in lines per second, pending */
 bool    decsclm_pending = FALSE; /* Toggle scroll mode after next scroll */
 videoline s_scroll_backup_line =/* Line the scroll event erased */
     { 0, NULL, NULL, NULL, NULL, 0, 0, 0, 0};
+
+/* Smooth scroll in progress on a background (non-visible) page */
+bool    in_bg_smooth_scroll = FALSE;
+DWORD   bg_smooth_scroll_ends = 0;
 #endif /* KUI */
 
 int tn_bold = 0;                        /* TELNET negotiation bold */

--- a/kermit/k95/ckocon.c
+++ b/kermit/k95/ckocon.c
@@ -213,9 +213,13 @@ bool    viewonly = FALSE ;              /* View only terminal mode */
 int     updmode         = TTU_FAST ;    /* Fast/Smooth scrolling */
 int     priority        = XYP_REG ;
 #ifdef KUI
-bool    in_smooth_scroll = FALSE;
-bool    smooth_scroll_upwards = FALSE;
-bool    decsclm_pending = FALSE;
+bool    in_smooth_scroll = FALSE;         /* Smooth scroll in progress */
+bool    smooth_scroll_upwards = FALSE;   /* Direction is upwards */
+int     smooth_scroll_bottom;           /* Bottom line of the smooth scroll */
+int     smooth_scroll_top;             /* Top line of the smooth scroll */
+bool    decsclm_pending = FALSE;      /* Toggle scroll mode after next scroll*/
+videoline s_scroll_backup_line =     /* Line the scroll event erased */
+    { 0, NULL, NULL, NULL, NULL, 0, 0, 0, 0};
 #endif /* KUI */
 
 int tn_bold = 0;                        /* TELNET negotiation bold */

--- a/kermit/k95/ckocon.c
+++ b/kermit/k95/ckocon.c
@@ -3545,7 +3545,7 @@ SmoothScroll( void ) {
     if (ISVT220(tt_type_mode)) {
         /* The VT220 and up (maybe VT100 too?) defer changing the scroll mode
          * state until after the next scroll event. */
-        if (updmode == TTU_SMOOTH) return;
+        if (updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2) return;
 
         /* This indicates to VscrnScrollPage that we want it to toggle the
          * scroll mode */

--- a/kermit/k95/ckocon.h
+++ b/kermit/k95/ckocon.h
@@ -135,9 +135,16 @@
 #endif /* FALSE */
 #define FALSE 0
 
+/* VscrnScrollPage scroll directions. Upward will normally scroll smoothly if
+ * in that mode with UPWARD_JUMP for those situations (eg screen clearing) where
+ * that is not appropriate. DOWNWARD will always jump-scroll with
+ * DOWNWARD_SMOOTHLY for the one situation where smooth-scroll is appropriate.
+ */
 #define UPWARD_JUMP 5                   /* Scroll up, no smooth scrolling */
-#define UPWARD   6                      /* Scroll up */
+#define UPWARD   6                      /* Scroll up, */
 #define DOWNWARD 7                      /* Scroll down */
+#define DOWNWARD_SMOOTHLY 8             /* Scroll down, smooth scroll allowed */
+
 #define LBUFSIZE roll.bufsize           /* Maximum lines in rollback buffer */
 
 /*

--- a/kermit/k95/ckocon.h
+++ b/kermit/k95/ckocon.h
@@ -135,6 +135,7 @@
 #endif /* FALSE */
 #define FALSE 0
 
+#define UPWARD_JUMP 5                   /* Scroll up, no smooth scrolling */
 #define UPWARD   6                      /* Scroll up */
 #define DOWNWARD 7                      /* Scroll down */
 #define LBUFSIZE roll.bufsize           /* Maximum lines in rollback buffer */

--- a/kermit/k95/ckocon.h
+++ b/kermit/k95/ckocon.h
@@ -1698,6 +1698,9 @@ _PROTOTYP( void VscrnScrollPage, (BYTE, int, int, int, int, int, int, int, CHAR,
 _PROTOTYP( BOOL IsOS2FullScreen, (void) ) ;
 _PROTOTYP( void SmoothScroll, (void) ) ;
 _PROTOTYP( void JumpScroll, (void ) ) ;
+#ifdef KUI
+_PROTOTYP( int SmoothScrollSpeed, (int) ) ;
+#endif /* KUI */
 
 
 _PROTOTYP( APIRET VscrnSelect, ( BYTE, int ) ) ;

--- a/kermit/k95/ckosyn.c
+++ b/kermit/k95/ckosyn.c
@@ -121,6 +121,10 @@ HANDLE hevTAPIInit = (HANDLE) 0 ;
 HANDLE hevRichEditInit = (HANDLE) 0;
 HANDLE hevRichEditClose = (HANDLE) 0;
 HANDLE hmtxRichEdit = (HANDLE) 0 ;
+
+#ifdef KUI
+HANDLE hevSmoothScrollFinished = (HANDLE) 0;
+#endif /* KUI */
 #else /* NT */
 #ifdef OS2MOUSE
 #define INCL_MOU
@@ -197,6 +201,10 @@ HMUX hmtxZoutDump = (HMUX) 0;
 HEV hevRichEditInit = (HEV) 0;
 HEV hevRichEditClose = (HEV) 0;
 HMTX hmtxRichEdit = (HMTX) 0 ;
+
+#ifdef KUI
+HEV hevSmoothScrollFinished = (HEV) 0;
+#endif /* KUI */
 #endif /* NT */
 
 int CtrlCCount = -1 ;
@@ -4301,3 +4309,103 @@ CloseZoutDumpMutex( void )
     return rc ;
 #endif /* NT */
 }
+
+#ifdef KUI
+
+APIRET
+CreateSmoothScrollFinishedSem( BOOL posted ) {
+    if ( hevSmoothScrollFinished )
+#ifdef NT
+        CloseHandle( hevSmoothScrollFinished ) ;
+    hevSmoothScrollFinished = CreateEvent( NULL, TRUE, posted, NULL ) ;
+    return hevSmoothScrollFinished == NULL ? GetLastError() : 0 ;
+#else /* not NT */
+        DosCloseEventSem( hevSmoothScrollFinished ) ;
+    return DosCreateEventSem( NULL, &hevSmoothScrollFinished, 0, posted ) ;
+#endif /* NT */
+}
+
+
+APIRET
+PostSmoothScrollFinishedSem( void )
+{
+#ifdef NT
+    BOOL rc = 0 ;
+
+    rc = SetEvent( hevSmoothScrollFinished ) ;
+    return rc == TRUE ? 0 : GetLastError() ;
+#else /* not NT */
+    return DosPostEventSem( hevSmoothScrollFinished ) ;
+#endif /* NT */
+}
+
+APIRET
+WaitSmoothScrollFinishedSem( ULONG timo )
+{
+#ifdef NT
+    DWORD rc = 0 ;
+
+    rc = WaitForSingleObjectEx( hevSmoothScrollFinished, timo, TRUE ) ;
+    return rc == WAIT_OBJECT_0 ? 0 : rc ;
+#else /* not NT */
+    APIRET rc = 0 ;
+
+    rc = DosWaitEventSem( hevSmoothScrollFinished, timo ) ;
+    return rc ;
+#endif /* NT */
+}
+
+APIRET
+WaitAndResetSmoothScrollFinishedSem( ULONG timo )
+{
+#ifdef NT
+    DWORD rc = 0 ;
+
+    rc = WaitForSingleObjectEx( hevSmoothScrollFinished, timo, TRUE ) ;
+    if ( rc == WAIT_OBJECT_0 )
+        ResetEvent( hevSmoothScrollFinished ) ;
+    return rc == WAIT_OBJECT_0 ;
+#else /* not NT */
+    APIRET rc = 0 ;
+    ULONG  semcount = 0 ;
+
+    rc = DosWaitEventSem( hevSmoothScrollFinished, timo ) ;
+    if ( !rc )
+        DosResetEventSem( hevSmoothScrollFinished, &semcount ) ;
+    return semcount ;
+#endif /* NT */
+}
+
+APIRET
+ResetSmoothScrollFinishedSem( void )
+{
+#ifdef NT
+    BOOL rc = 0 ;
+
+    rc = ResetEvent( hevSmoothScrollFinished ) ;
+    return rc ;
+#else /* not NT */
+    APIRET rc = 0 ;
+    ULONG semcount = 0 ;
+
+    rc = DosResetEventSem( hevSmoothScrollFinished, &semcount ) ;
+    return rc ;
+#endif /* NT */
+}
+
+APIRET
+CloseSmoothScrollFinishedSem( void )
+{
+#ifdef NT
+    BOOL rc = 0 ;
+    rc = CloseHandle( hevSmoothScrollFinished ) ;
+    hevSmoothScrollFinished = (HANDLE) NULL ;
+    return rc == TRUE ? 0 : GetLastError() ;
+#else /* not NT */
+    APIRET rc ;
+    rc = DosCloseEventSem( hevSmoothScrollFinished ) ;
+    hevSmoothScrollFinished = 0 ;
+    return rc ;
+#endif /* NT */
+}
+#endif /* KUI */

--- a/kermit/k95/ckosyn.h
+++ b/kermit/k95/ckosyn.h
@@ -371,4 +371,13 @@ _PROTOTYP( APIRET RequestZoutDumpMutex, (unsigned long) ) ;
 _PROTOTYP( APIRET ReleaseZoutDumpMutex, (void) ) ;
 _PROTOTYP( APIRET CloseZoutDumpMutex, (void) ) ;
 
+#ifdef KUI
+_PROTOTYP( APIRET CreateSmoothScrollFinishedSem, (BOOL) ) ;
+_PROTOTYP( APIRET PostSmoothScrollFinishedSem, (void) ) ;
+ _PROTOTYP( APIRET WaitSmoothScrollFinishedSem, (unsigned long) ) ;
+_PROTOTYP( APIRET WaitAndResetSmoothScrollFinishedSem, (unsigned long) ) ;
+ _PROTOTYP( APIRET ResetSmoothScrollFinishedSem, (void) ) ;
+_PROTOTYP( APIRET CloseSmoothScrollFinishedSem, (void) ) ;
+#endif /* KUI */
+
 #endif /* CKOSYN_H */

--- a/kermit/k95/ckotio.c
+++ b/kermit/k95/ckotio.c
@@ -1904,6 +1904,7 @@ sysinit() {
     CreateCommMutex( FALSE );
 #ifdef KUI
     CreateDRCSBufferCriticalSection();
+    CreateSmoothScrollFinishedSem(FALSE);
 #endif /* KUI */
 #ifdef CK_SSL
     CreateSSLMutex( FALSE );
@@ -2519,6 +2520,7 @@ syscleanup() {
     CloseAlarmSem() ;
 #ifdef KUI
     CloseDRCSBufferCriticalSection();
+    CloseSmoothScrollFinishedSem();
 #endif /* KUI */
 #ifdef CK_SSL
     CloseSSLMutex() ;

--- a/kermit/k95/ckowys.c
+++ b/kermit/k95/ckowys.c
@@ -84,6 +84,9 @@ extern int tt_hidattr;
 extern int tt_sac;
 extern bool xprintff; /* Print formfeed */
 extern int tcsl;
+#ifdef KUI
+extern int smooth_speed; /* Smooth scroll speed (lines per second) */
+#endif /* KUI */
 
 extern struct _vtG G[];
 extern struct _vtG *GL, *GR;
@@ -2956,6 +2959,9 @@ wyseascii( int ch )
                     debug(F110,"Wyse Escape","Smooth scroll @ 1 row/second",0);
                     if ( debses )
                         break;
+#ifdef KUI
+                    smooth_speed = 1;
+#endif /* KUI */
                     SmoothScroll() ;
                     break;
                 case '=':
@@ -2963,6 +2969,9 @@ wyseascii( int ch )
                     debug(F110,"Wyse Escape","Smooth scroll @ 2 row/second",0);
                     if ( debses )
                         break;
+#ifdef KUI
+                    smooth_speed = 2;
+#endif /* KUI */
                     SmoothScroll() ;
                     break;
                 case '>':
@@ -2970,6 +2979,9 @@ wyseascii( int ch )
                     debug(F110,"Wyse Escape","Smooth scroll @ 4 row/second",0);
                     if ( debses )
                         break;
+#ifdef KUI
+                    smooth_speed = 4;
+#endif /* KUI */
                     SmoothScroll() ;
                     break;
                 case '?':
@@ -2977,6 +2989,9 @@ wyseascii( int ch )
                     debug(F110,"Wyse Escape","Smooth scroll @ 8 row/second",0);
                     if ( debses )
                         break;
+#ifdef KUI
+                    smooth_speed = 8;
+#endif /* KUI */
                     SmoothScroll() ;
                     break;
                 case '@':

--- a/kermit/k95/ckuus2.c
+++ b/kermit/k95/ckuus2.c
@@ -8551,21 +8551,24 @@ static char *hxyterm[] = {
 "  completely repainted each time there is a change.",
 " ",
 
-#ifdef KUI
-  "SET TERMINAL SCREEN-UPDATE { FAST, SMOOTH, SMOOTH-FAST } [ <milliseconds> ]",
-#else
 "SET TERMINAL SCREEN-UPDATE { FAST, SMOOTH } [ <milliseconds> ]",
-#endif /* KUI */
 "  Chooses the mechanism used for screen updating and the update frequency.",
-"  Defaults are FAST (jump) scrolling with updates every 20 milliseconds.",
+"  Defaults are FAST with updates every 20 milliseconds. The SMOOTH option",
+"  (not supported in K95G) updates the screen every time it changes.",
 " ",
 #ifdef KUI
-"  SMOOTH and SMOOTH-FAST are both smooth scrolling. For terminals that offered",
-"  two speed options, SMOOTH is the slow option and SMOOTH-FAST is the fast",
-"  option. For other terminals such as the VT100, VT220 and VT320 both options",
-"  are the same speed."
-#endif /* KUI */
+"SET TERMINAL SCROLL-MODE { JUMP, SMOOTH [ speed ], SMOOTH-2, SMOOTH-4 }",
+"  Sets the scrolling mode. When in Jump Scrolling mode, the terminal adds new",
+"  lines as fast as they are received, while Smooth Scrolling mode adds them",
+"  smoothly at a speed that makes them recogniszable if not readable.",
 " ",
+"  The SMOOTH option lets you specify a speed from 1 to 36 lines per second, ",
+"  while SMOOTH-2 and SMOOTH-4 correspond to slow and fast speeds on those ",
+"  terminals that offer two speed options. For the K95 terminal type, SMOOTH-2",
+"  is nine lines per second and SMOOTH-4 is twice that. For terminals offering",
+"  only one speed option, SMOOTH-4 is the same as SMOOTH-2.",
+" ",
+#endif /* KUI */
 
 "SET TERMINAL SCROLLBACK <lines>",
 "  Sets size of CONNECT virtual screen buffer.  <lines> includes the active",

--- a/kermit/k95/ckuus2.c
+++ b/kermit/k95/ckuus2.c
@@ -8551,9 +8551,20 @@ static char *hxyterm[] = {
 "  completely repainted each time there is a change.",
 " ",
 
+#ifdef KUI
+  "SET TERMINAL SCREEN-UPDATE { FAST, SMOOTH, SMOOTH-FAST } [ <milliseconds> ]",
+#else
 "SET TERMINAL SCREEN-UPDATE { FAST, SMOOTH } [ <milliseconds> ]",
+#endif /* KUI */
 "  Chooses the mechanism used for screen updating and the update frequency.",
-"  Defaults are FAST scrolling with updates every 100 milliseconds.",
+"  Defaults are FAST (jump) scrolling with updates every 20 milliseconds.",
+" ",
+#ifdef KUI
+"  SMOOTH and SMOOTH-FAST are both smooth scrolling. For terminals that offered",
+"  two speed options, SMOOTH is the slow option and SMOOTH-FAST is the fast",
+"  option. For other terminals such as the VT100, VT220 and VT320 both options",
+"  are the same speed."
+#endif /* KUI */
 " ",
 
 "SET TERMINAL SCROLLBACK <lines>",

--- a/kermit/k95/ckuus5.c
+++ b/kermit/k95/ckuus5.c
@@ -344,6 +344,9 @@ _PROTOTYP (int os2getcplist, (int *, int) );
 extern int tt_mouse;
 #endif /* OS2MOUSE */
 extern int tt_update, tt_updmode, updmode, tt_utf8;
+#ifdef KUI
+extern int tt_scrollmode, tt_smooth_speed;
+#endif /* KUI */
 #ifndef IKSDONLY
 extern int tt_status[];
 #endif /* IKSDONLY */
@@ -6390,6 +6393,27 @@ shotrm() {
           tt_roll[VTERM]?"insert":"overwrite","Scrollback", tt_scrsize[VTERM]);
     if (++lines > cmd_rows - 3) { if (!askmore()) return; else lines = 0; }
 
+#ifdef KUI
+    /* Terminal Scroll Mode (Smooth or Jump) */
+    if (tt_scrollmode == TTS_JUMP) {
+        printf(" %19s: %-13s  %13s: %s\n","Scroll-mode",
+        "jump","Speed", "n/a");
+    } else {
+        switch (tt_scrollmode) {
+        case TTS_SMOOTH_2: s = "smooth-2"; break;
+        case TTS_SMOOTH_4: s = "smooth-4"; break;
+        default: case TTS_SMOOTH: s = "smooth"; break;
+        }
+        printf(" %19s: %-13s  %13s: %d lines per second\n","Scroll-mode",
+        "jump","Speed", tt_smooth_speed);
+    }
+    if (++lines > cmd_rows - 3) { if (!askmore()) return; else lines = 0; }
+
+    /* Historically, TTU_SMOOTH has always meant "redraw the screen every time
+     * it changes" which is quite different from smooth scrolling. K95G does not
+     * currently implement TTU_SMOOTH. */
+    s = "fast";
+#else
     if (updmode == tt_updmode)
       if (updmode == TTU_FAST)
         s = "fast (fast)";
@@ -6400,6 +6424,7 @@ shotrm() {
         s = "fast (smooth)";
       else
         s = "smooth (fast)";
+#endif
 
     printf(" %19s: %-13s  %13s: %d ms\n","Screen-update: mode",s,
            "interval",tt_update);

--- a/kermit/k95/ckuus7.c
+++ b/kermit/k95/ckuus7.c
@@ -2205,8 +2205,14 @@ struct keytab msktab[] = { /* SET MS-DOS KERMIT compatibilities */
 int nmsk = (sizeof(msktab) / sizeof(struct keytab));
 
 struct keytab scrnupd[] = {             /* SET TERMINAL SCREEN-UPDATE */
-    { "fast",   TTU_FAST,   0 },
-    { "smooth", TTU_SMOOTH, 0 }
+    { "fast",   TTU_FAST,   0 },        /* Jump scroll */
+    { "jump",   TTU_FAST,   CM_INV },
+    { "smooth", TTU_SMOOTH, 0 },        /* Smooth scroll, slow (Smooth-2) */
+#ifdef KUI
+    { "smooth-fast", TTU_SMOOTH2, 0 },  /* Smooth scroll, fast (Smooth-4) */
+#else
+    { "smooth-fast", TTU_SMOOTH, CM_INV },
+#endif
 };
 int nscrnupd = (sizeof(scrnupd) / sizeof(struct keytab));
 

--- a/kermit/k95/ckuus7.c
+++ b/kermit/k95/ckuus7.c
@@ -5519,8 +5519,12 @@ settrm() {
             return(mode);
         } else {
             y = cmnum(
+#ifdef KUI
+            "Interval between screen updates in CONNECT mode, milliseconds",
+#else
             "Pause between FAST screen updates in CONNECT mode, milliseconds",
-                      "100",10,&x,xxstring
+#endif /* KUI */
+                      "20",10,&x,xxstring
                       );
             if (x < 0 || x > 1000 ) {
                 printf(

--- a/kermit/k95/ckuus7.c
+++ b/kermit/k95/ckuus7.c
@@ -1062,6 +1062,11 @@ static struct keytab trmtab[] = {
     { "screen-mode",     XYTSCNM,   0 },
     { "screen-optimize", XYTOPTI,   0 },
     { "screen-update",   XYTUPD,    0 },
+#ifdef KUI
+    { "scroll-mode",     XYTSCROLL, 0 },
+#else
+    { "scroll-mode",     XYTSCROLL, CM_INV },
+#endif /* KUI */
     { "scrollback",      XYSCRS,    0 },
     { "send-data",         XYTSEND, 0 },
     { "send-end-of-block", XYTSEOB, 0 },
@@ -1441,6 +1446,8 @@ extern int updmode;
 int tt_status[VNUM] = {1,1,0,0};        /* Terminal status line displayed */
 int tt_status_usr[VNUM] = {1,1,0,0};
 #else  /* KUI */
+extern int tt_scrollmode, scrollmode;
+extern int smooth_speed, tt_smooth_speed;
 extern CKFLOAT floatval;
 CKFLOAT tt_linespacing[VNUM] = {1.0,1.0,1.0,1.0};
 #ifdef K95G
@@ -2205,16 +2212,19 @@ struct keytab msktab[] = { /* SET MS-DOS KERMIT compatibilities */
 int nmsk = (sizeof(msktab) / sizeof(struct keytab));
 
 struct keytab scrnupd[] = {             /* SET TERMINAL SCREEN-UPDATE */
-    { "fast",   TTU_FAST,   0 },        /* Jump scroll */
-    { "jump",   TTU_FAST,   CM_INV },
-    { "smooth", TTU_SMOOTH, 0 },        /* Smooth scroll, slow (Smooth-2) */
-#ifdef KUI
-    { "smooth-fast", TTU_SMOOTH2, 0 },  /* Smooth scroll, fast (Smooth-4) */
-#else
-    { "smooth-fast", TTU_SMOOTH, CM_INV },
-#endif
+    { "fast",   TTU_FAST,   0 },
+    { "smooth", TTU_SMOOTH, 0 },
 };
 int nscrnupd = (sizeof(scrnupd) / sizeof(struct keytab));
+
+struct keytab scrmode[] = {             /* SET TERMINAL SCROLL-MODE */
+    { "jump",     TTS_JUMP,   0 },
+    { "smooth",   TTS_SMOOTH, 0 },
+    { "smooth-2", TTS_SMOOTH_2, 0 },
+    { "smooth-4", TTS_SMOOTH_4, 0 },
+};
+int nscrmode = (sizeof(scrmode) / sizeof(struct keytab));
+
 
 #ifdef PCFONTS
 /* This definition of the term_font[] table is only for     */
@@ -5544,6 +5554,36 @@ settrm() {
             return(setnum(&tt_update,x,y,10000));
         }
     }
+    case XYTSCROLL: {
+        int mode;
+        if ((mode = cmkey(scrmode,nscrmode,"","fast",xxstring)) < 0) {
+            return(mode);
+        } else {
+            int speed;
+            if (mode == TTS_SMOOTH) {
+                y = cmnum("Speed in lines per second","9",10,&speed,xxstring);
+            }
+            if ((y = cmcfm()) < 0) return(y);
+#ifdef KUI
+
+            if (mode == TTS_SMOOTH) {
+                if (speed < 1 || speed > 36 ) {
+                    printf("\n?The speed must be between 1 and 36 lines per second.\n");
+                    return(success = 0);
+                }
+            } else {
+                speed = SmoothScrollSpeed(mode);
+            }
+
+            smooth_speed = tt_smooth_speed = speed;
+            scrollmode = tt_scrollmode = mode;
+            return(setnum(&tt_smooth_speed,speed,y,36));
+#else
+            return(success = TRUE);
+#endif /* KUI */
+        }
+    }
+    break;
     case XYTCTRL:
           if ((x = cmkey(termctrl,ntermctrl,"","7",xxstring)) < 0) {
               return(x);

--- a/kermit/k95/ckuusr.h
+++ b/kermit/k95/ckuusr.h
@@ -1216,10 +1216,7 @@ struct stringint {			/* String and (wide) integer */
 #ifdef OS2
 #define   XYTUPD 25     /*  Terminal Screen-update */
 #define    TTU_FAST 0   /*     FAST but jerky */
-#define    TTU_SMOOTH 1 /*     SMOOTH but slow (Slow Smooth aka Smooth-2) */
-#ifdef KUI
-#define    TTU_SMOOTH2 2 /*    SMOOTH but less slow (Fast Smooth aka Smooth-4) */
-#endif /* KUI */
+#define    TTU_SMOOTH 1 /*     SMOOTH but slow */
 #define   XYTFON 26     /*  Terminal Full screen Font */
 #define    TTF_ROM    0 /*     ROM font */
 #define    TTF_CY1    1 /*     CYRILL1 font */
@@ -1352,6 +1349,11 @@ struct stringint {			/* String and (wide) integer */
 #define     P_COUNT   1
 #define     P_ACTIVE  2
 #define   XYTCLRRS  70  /* SET TERM CLEAR-ON-RESIZE */
+#define   XYTSCROLL 71  /* SET TERM SCROLL */
+#define     TTS_JUMP     0
+#define     TTS_SMOOTH   1
+#define     TTS_SMOOTH_2 2
+#define     TTS_SMOOTH_4 3
 #endif /* OS2 */
 
 #define XYATTR 34       /* Attribute packets  */

--- a/kermit/k95/ckuusr.h
+++ b/kermit/k95/ckuusr.h
@@ -1216,7 +1216,10 @@ struct stringint {			/* String and (wide) integer */
 #ifdef OS2
 #define   XYTUPD 25     /*  Terminal Screen-update */
 #define    TTU_FAST 0   /*     FAST but jerky */
-#define    TTU_SMOOTH 1 /*     SMOOTH but slow */
+#define    TTU_SMOOTH 1 /*     SMOOTH but slow (Slow Smooth aka Smooth-2) */
+#ifdef KUI
+#define    TTU_SMOOTH2 2 /*    SMOOTH but less slow (Fast Smooth aka Smooth-4) */
+#endif /* KUI */
 #define   XYTFON 26     /*  Terminal Full screen Font */
 #define    TTF_ROM    0 /*     ROM font */
 #define    TTF_CY1    1 /*     CYRILL1 font */

--- a/kermit/k95/kui/ikterm.cxx
+++ b/kermit/k95/kui/ikterm.cxx
@@ -9,6 +9,7 @@ extern vscrn_t vscrn[VNUM]; /* = {0,0,0,{0,0,0},0,-1,-1,-1,-1,{-1,-1,-1,-1,-1,-1
 extern int inecho;          /* do we echo script INPUT output? */
 extern int updmode ;
 extern bool in_smooth_scroll;
+extern bool smooth_scroll_upwards;
 extern int priority ;
 extern cell_video_attr_t defaultattribute ;
 extern int cursoron[], cursorena[],scrollflag[], scrollstatus[], flipscrnflag[];
@@ -142,7 +143,11 @@ BOOL IKTerm::getDrawInfo(BYTE vscrn_number)
         /* Increase the height so we have both the old top and new bottom in the
          * buffer */
         ys += 1;
-        page_top -= 1;
+        // Upwards means we include the old top
+        if (smooth_scroll_upwards) {
+            page_top -= 1;
+        }
+        // And downwards means we include the old bottom
     }
 
     textBuffer = kcp->textBuffer;

--- a/kermit/k95/kui/ikterm.cxx
+++ b/kermit/k95/kui/ikterm.cxx
@@ -11,6 +11,7 @@ extern int updmode ;
 extern bool in_smooth_scroll;
 extern bool smooth_scroll_upwards;
 extern int smooth_scroll_top, smooth_scroll_bottom;
+extern int smooth_scroll_left, smooth_scroll_right;
 extern videoline s_scroll_backup_line;
 extern int priority ;
 extern cell_video_attr_t defaultattribute ;
@@ -113,7 +114,6 @@ BOOL IKTerm::getDrawInfo(BYTE vscrn_number, bool smoothScroll)
 #endif /* EXCLUSIVE */
 
     xs = VscrnGetWidth( vnum );
-    ys = VscrnGetHeight( vnum );
 
     c = 0;
     cursor_offset = 0;
@@ -126,6 +126,29 @@ BOOL IKTerm::getDrawInfo(BYTE vscrn_number, bool smoothScroll)
         ReleaseVscrnMutex(vnum) ;
         return FALSE;
     }
+
+    // These variables are...
+    //      xs - x size? Width of the area to be rendered
+    //      xho - x horizontal offset? For horizontal scrolling
+    //      ys - Y size? Height of the area to be rendered
+    //      xo - Overlay X coordinate
+    //      yo - Overlay Y coordinate
+    //  pwidth - Physical screen width in columns.
+    // pheight - Physical screen height in rows.
+    //
+    // pwidth, pheight, tt_modechg, TVC_ENA, etc, are all just a result of much
+    // of this class being a copy&paste of the console-mode rendering code
+    // adjusted to output to K_CLIENT_PAINT instead of win32 conhost (or an OS/2
+    // vio window). In KUI builds pwidth and pheight are never assigned a value
+    // and the SET TERM VIDEO-CHANGE command does not assign a value to
+    // tt_modechg, so its always TVC_ENA.
+    //
+    // Someday all of this should change to implement the Windowing Extension.
+    // In that case TVC_W95 should be treated as TVC_ENA, and TVC_DIS would mean
+    // scrolling the viewport. A new vbuf->hscroll and associated KVerbs would
+    // need to be added too. This work will likely impact how the smooth scroll
+    // stuff works - it will need to determine if the scrolling area is even in
+    // the viewport, etc.
 
     xs = (tt_modechg == TVC_ENA ) ? vbuf->width : pwidth;
     xho = vbuf->hscroll > (MAXTERMCOL-pwidth) ? 
@@ -146,28 +169,49 @@ BOOL IKTerm::getDrawInfo(BYTE vscrn_number, bool smoothScroll)
     unsigned long page_top = page->top;
     unsigned long page_scrolltop = page->scrolltop;
 
-    bool scrollRegionOnly = smoothScroll && s_scroll_backup_line.cells != NULL
-        && smooth_scroll_top != -1 && smooth_scroll_bottom != -1;
+    // Scrolling between left and right margins.
+    bool lrmm = smooth_scroll_left != -1 && smooth_scroll_right != -1;
+    bool tbmm = smooth_scroll_top != -1 && smooth_scroll_bottom != -1;
+
+    // Scrolling between top and bottom margins with the help of a backup line
+    bool useBackupLine = (tbmm || lrmm ) && s_scroll_backup_line.cells != NULL;
 
     if (smoothScroll) {
         // TODO: Take pwidth and pheight into account for situations where the
         //       window is smaller than the buffer. This would primarily affect
         //       scrolling within a region - if the region fits into the
         //       viewport then we don't need to treat it as a scroll region.
-        if (scrollRegionOnly) {
-            page_top += smooth_scroll_top;
-            ys = 1 + smooth_scroll_bottom - smooth_scroll_top;
-        }
 
-        /* Increase the height so we have both the old top and new bottom in the
-         * buffer */
+        int height = ys;
+        int top = smooth_scroll_top < 0 ? 1 : smooth_scroll_top + 1;
+        int bot = smooth_scroll_bottom < 0 ? ys : smooth_scroll_bottom + 1;
+
+        // ys is the height of the region we're getting draw info for.
+        // Recalculate it taking the top and bottom margins into account.
+        ys = bot - top + 1;
+
+        // Then add one to account for the line saved by VscrnScrollPage that
+        // we'll slot in at either the top or bottom.
         ys += 1;
 
-        // Upwards means we include the old top
+        // The top of the area we're rendering will start at the top margin.
+        page_top += top - 1;
+
+        // If we're scrolling up, then it gets slotted in at the top so we need
+        // to make room there for it. Else it's slotted in at the bottom - the
+        // enlarged ys provides room.
         if (smooth_scroll_upwards) {
             page_top -= 1;
         }
-        // And downwards means we include the old bottom
+        else if (bot == height && useBackupLine) {
+            // If we're using the backup line, scrolling in the reverse
+            // direction, and the bottom of the scroll region is the screen
+            // bottom, then we've got to enlarge ys further, or the backup line
+            // gets placed in the wrong place and doesn't render.
+            ys += 1;
+        }
+    } else {
+        useBackupLine = lrmm = false;
     }
 
     textBuffer = kcp->textBuffer;
@@ -206,7 +250,7 @@ BOOL IKTerm::getDrawInfo(BYTE vscrn_number, bool smoothScroll)
             // operation, then the additional line that is scrolling away has
             // been stashed in s_scroll_backup_line by VscrnScrollPage. We need
             // to slot that in now.
-            if (scrollRegionOnly) {
+            if (useBackupLine) {
                 if (smooth_scroll_upwards && y == 0) {
                     // Substitute the top for the backup line
                     line = &s_scroll_backup_line;
@@ -429,7 +473,8 @@ BOOL IKTerm::getDrawInfo(BYTE vscrn_number, bool smoothScroll)
 
     /* Status Line Display */
     if ( (vnum == VTERM && tt_status[vnum] && decssdt != SSDT_BLANK ||
-         vnum != VTERM && tt_status[vnum] || decssdt_override) && !scrollRegionOnly)
+         vnum != VTERM && tt_status[vnum] || decssdt_override) &&
+         !useBackupLine && !lrmm)
     {
         if ( vnum == VTERM && decssdt == SSDT_HOST_WRITABLE && tt_status[vnum] == 1
                   && !decssdt_override && !scrollflag[vnum]) {
@@ -475,6 +520,7 @@ BOOL IKTerm::getDrawInfo(BYTE vscrn_number, bool smoothScroll)
     kcp->len = c;
     kcp->page = vscrn[vnum].view_page;
     kcp->page_length = page->linecount;
+    kcp->height = ys + tt_status[vnum];
     return TRUE;
 }
 

--- a/kermit/k95/kui/ikterm.cxx
+++ b/kermit/k95/kui/ikterm.cxx
@@ -10,6 +10,8 @@ extern int inecho;          /* do we echo script INPUT output? */
 extern int updmode ;
 extern bool in_smooth_scroll;
 extern bool smooth_scroll_upwards;
+extern int smooth_scroll_top, smooth_scroll_bottom;
+extern videoline s_scroll_backup_line;
 extern int priority ;
 extern cell_video_attr_t defaultattribute ;
 extern int cursoron[], cursorena[],scrollflag[], scrollstatus[], flipscrnflag[];
@@ -90,8 +92,15 @@ IKTerm::~IKTerm()
 BOOL IKTerm::getDrawInfo() {
     return getDrawInfo( vmode );
 }
+BOOL IKTerm::getDrawInfo(BYTE vscrn_number) {
+    return getDrawInfo( vscrn_number, FALSE );
+}
 
-BOOL IKTerm::getDrawInfo(BYTE vscrn_number)
+bool IKTerm::getSmoothScrollDrawInfo() {
+    return getDrawInfo( vmode, TRUE );
+}
+
+BOOL IKTerm::getDrawInfo(BYTE vscrn_number, bool smoothScroll)
 {
 	vnum = vscrn_number;
 #ifdef EXCLUSIVE
@@ -137,12 +146,23 @@ BOOL IKTerm::getDrawInfo(BYTE vscrn_number)
     unsigned long page_top = page->top;
     unsigned long page_scrolltop = page->scrolltop;
 
-    bool smooth_scrolling = (updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2)
-            && in_smooth_scroll && !scrollflag[vnum];
-    if (smooth_scrolling) {
+    bool scrollRegionOnly = smoothScroll && s_scroll_backup_line.cells != NULL
+        && smooth_scroll_top != -1 && smooth_scroll_bottom != -1;
+
+    if (smoothScroll) {
+        // TODO: Take pwidth and pheight into account for situations where the
+        //       window is smaller than the buffer. This would primarily affect
+        //       scrolling within a region - if the region fits into the
+        //       viewport then we don't need to treat it as a scroll region.
+        if (scrollRegionOnly) {
+            page_top += smooth_scroll_top;
+            ys = 1 + smooth_scroll_bottom - smooth_scroll_top;
+        }
+
         /* Increase the height so we have both the old top and new bottom in the
          * buffer */
         ys += 1;
+
         // Upwards means we include the old top
         if (smooth_scroll_upwards) {
             page_top -= 1;
@@ -181,6 +201,21 @@ BOOL IKTerm::getDrawInfo(BYTE vscrn_number)
                 line = &page->lines[(page_top+y)%page->linecount] ;
             else
                 line = &page->lines[(page_scrolltop+y)%page->linecount] ;
+
+            // If we're rendering only the scroll region for a smooth-scroll
+            // operation, then the additional line that is scrolling away has
+            // been stashed in s_scroll_backup_line by VscrnScrollPage. We need
+            // to slot that in now.
+            if (scrollRegionOnly) {
+                if (smooth_scroll_upwards && y == 0) {
+                    // Substitute the top for the backup line
+                    line = &s_scroll_backup_line;
+                } else if (!smooth_scroll_upwards && y == ys - 1) {
+                    // Substitute the bottom for the backup line
+                    line = &s_scroll_backup_line;
+                }
+            }
+
             lineAttr[y] = line->vt_line_attr;
 #ifdef NEW_EXCLUSIVE
             /* Give mutex back */
@@ -393,8 +428,8 @@ BOOL IKTerm::getDrawInfo(BYTE vscrn_number)
 #endif /* EXCLUSIVE */
 
     /* Status Line Display */
-    if ( vnum == VTERM && tt_status[vnum] && decssdt != SSDT_BLANK ||
-         vnum != VTERM && tt_status[vnum] || decssdt_override)
+    if ( (vnum == VTERM && tt_status[vnum] && decssdt != SSDT_BLANK ||
+         vnum != VTERM && tt_status[vnum] || decssdt_override) && !scrollRegionOnly)
     {
         if ( vnum == VTERM && decssdt == SSDT_HOST_WRITABLE && tt_status[vnum] == 1
                   && !decssdt_override && !scrollflag[vnum]) {

--- a/kermit/k95/kui/ikterm.cxx
+++ b/kermit/k95/kui/ikterm.cxx
@@ -136,7 +136,8 @@ BOOL IKTerm::getDrawInfo(BYTE vscrn_number)
     unsigned long page_top = page->top;
     unsigned long page_scrolltop = page->scrolltop;
 
-    bool smooth_scrolling = updmode == TTU_SMOOTH && in_smooth_scroll && !scrollflag[vnum];
+    bool smooth_scrolling = (updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2)
+            && in_smooth_scroll && !scrollflag[vnum];
     if (smooth_scrolling) {
         /* Increase the height so we have both the old top and new bottom in the
          * buffer */

--- a/kermit/k95/kui/ikterm.cxx
+++ b/kermit/k95/kui/ikterm.cxx
@@ -8,6 +8,7 @@ extern enum markmodes markmodeflag[] ;
 extern vscrn_t vscrn[VNUM]; /* = {0,0,0,{0,0,0},0,-1,-1,-1,-1,{-1,-1,-1,-1,-1,-1,-1,-1,-1,-1},0,0}; */
 extern int inecho;          /* do we echo script INPUT output? */
 extern int updmode ;
+extern bool in_smooth_scroll;
 extern int priority ;
 extern cell_video_attr_t defaultattribute ;
 extern int cursoron[], cursorena[],scrollflag[], scrollstatus[], flipscrnflag[];
@@ -132,6 +133,17 @@ BOOL IKTerm::getDrawInfo(BYTE vscrn_number)
         yo = (ys - vbuf->popup->height) / 2 ;
     }
 
+    unsigned long page_top = page->top;
+    unsigned long page_scrolltop = page->scrolltop;
+
+    bool smooth_scrolling = updmode == TTU_SMOOTH && in_smooth_scroll && !scrollflag[vnum];
+    if (smooth_scrolling) {
+        /* Increase the height so we have both the old top and new bottom in the
+         * buffer */
+        ys += 1;
+        page_top -= 1;
+    }
+
     textBuffer = kcp->textBuffer;
     attrBuffer = kcp->attrBuffer;
     effectBuffer = kcp->effectBuffer;
@@ -160,9 +172,9 @@ BOOL IKTerm::getDrawInfo(BYTE vscrn_number)
 #endif /* NEW_EXCLUSIVE */
             /* Get the next line */
             if (!scrollflag[vnum])
-                line = &page->lines[(page->top+y)%page->linecount] ;
+                line = &page->lines[(page_top+y)%page->linecount] ;
             else
-                line = &page->lines[(page->scrolltop+y)%page->linecount] ;
+                line = &page->lines[(page_scrolltop+y)%page->linecount] ;
             lineAttr[y] = line->vt_line_attr;
 #ifdef NEW_EXCLUSIVE
             /* Give mutex back */
@@ -225,8 +237,8 @@ BOOL IKTerm::getDrawInfo(BYTE vscrn_number)
                 }
 
 #ifdef VSCRN_DEBUG
-                debug(F101,"OUCH!","",(scrollflag?(page->scrolltop+y)
-                                    :(page->top+y))%page->linecount);
+                debug(F101,"OUCH!","",(scrollflag?(page_scrolltop+y)
+                                    :(page_top+y))%page->linecount);
 #endif /* VSCRN_DEBUG */
             }
 
@@ -265,7 +277,7 @@ BOOL IKTerm::getDrawInfo(BYTE vscrn_number)
             if ( RequestVscrnMutex( vnum, -1 ) )
                 return FALSE;
 #endif /* NEW_EXCLUSIVE */
-            line = &page->lines[(page->scrolltop+y)%page->linecount] ;
+            line = &page->lines[(page_scrolltop+y)%page->linecount] ;
             lineAttr[y] = line->vt_line_attr;
 #ifdef NEW_EXCLUSIVE
             /* Give mutex back */
@@ -274,7 +286,7 @@ BOOL IKTerm::getDrawInfo(BYTE vscrn_number)
 
             if (line->cells)
             {
-                if ( VscrnIsLineMarked(vnum,page->scrolltop+y) )
+                if ( VscrnIsLineMarked(vnum,page_scrolltop+y) )
                 {
                     for ( x = 0 ; x < xs ; x++ )
                     {

--- a/kermit/k95/kui/ikterm.cxx
+++ b/kermit/k95/kui/ikterm.cxx
@@ -7,7 +7,6 @@ extern "C" {
 extern enum markmodes markmodeflag[] ;
 extern vscrn_t vscrn[VNUM]; /* = {0,0,0,{0,0,0},0,-1,-1,-1,-1,{-1,-1,-1,-1,-1,-1,-1,-1,-1,-1},0,0}; */
 extern int inecho;          /* do we echo script INPUT output? */
-extern int updmode ;
 extern bool in_smooth_scroll;
 extern bool smooth_scroll_upwards;
 extern int smooth_scroll_top, smooth_scroll_bottom;
@@ -16,7 +15,7 @@ extern videoline s_scroll_backup_line;
 extern int priority ;
 extern cell_video_attr_t defaultattribute ;
 extern int cursoron[], cursorena[],scrollflag[], scrollstatus[], flipscrnflag[];
-extern int tt_update, tt_updmode, tt_rows[], tt_cols[], tt_font, tt_roll[],
+extern int tt_update, tt_rows[], tt_cols[], tt_font, tt_roll[],
            tt_cursor, scrninitialized[], ttyfd, viewonly, carrier, network,
            tt_scrsize[], tt_modechg, pheight, pwidth, tt_status[], screenon, 
            decssdt, tt_url_hilite, tt_url_hilite_attr, tt_type_mode, ttnum;

--- a/kermit/k95/kui/ikterm.h
+++ b/kermit/k95/kui/ikterm.h
@@ -31,6 +31,9 @@ public:
     ~IKTerm();
     BOOL getDrawInfo();
     BOOL getDrawInfo(BYTE vscrn_number);
+    BOOL getDrawInfo(BYTE vscrn_number, bool smoothScroll);
+
+    bool getSmoothScrollDrawInfo();
 
     BOOL newKeyboardEvent( UINT chCharCode, LONG lKeyData, UINT keyDown, UINT sysKey );
     BOOL keyboardEvent( UINT chCharCode, LONG lKeyData, UINT keyDown );

--- a/kermit/k95/kui/ikterm.h
+++ b/kermit/k95/kui/ikterm.h
@@ -20,6 +20,7 @@ typedef struct _K_CLIENT_PAINT {
     unsigned long   maxWidth;
     int             page;
     int             page_length;
+    int             height;
 } K_CLIENT_PAINT;
 
 struct vscrn_struct;

--- a/kermit/k95/kui/kclient.cxx
+++ b/kermit/k95/kui/kclient.cxx
@@ -45,7 +45,8 @@ extern int tt_scrsize[];	/* Scrollback buffer size */
 extern int tt_status[];
 extern int tt_update;
 extern int tt_type;
-extern int updmode ;
+extern int scrollmode ;
+extern int smooth_speed;
 extern bool in_smooth_scroll;
 extern bool smooth_scroll_upwards;
 extern int smooth_scroll_top, smooth_scroll_bottom;
@@ -138,7 +139,7 @@ VOID CALLBACK KTimerProc( HWND hwnd, UINT msg, UINT_PTR id, DWORD dwtime )
     // debug(F111,"KTimerProc()","dwtime",dwtime);
     KClient* client = (KClient*) kglob->hwndset->find( hwnd );
     if( client ) {
-        if ((updmode >= TTU_SMOOTH && in_smooth_scroll) || client->smoothScrolling()) {
+        if ((scrollmode >= TTS_SMOOTH && in_smooth_scroll) || client->smoothScrolling()) {
             // We're smooth-scrolling.
             client->smoothScroll();
         } else {
@@ -849,7 +850,7 @@ void KClient::syncSize()
 /*------------------------------------------------------------------------
  Handle Smooth Scrolling
 ------------------------------------------------------------------------*/
-/* How Smooth Scroll works (updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2):
+/* How Smooth Scroll works (scrollmode >= TTS_SMOOTH):
  *   When a scroll completes, VscrnScrollPage will set in_smooth_scroll = TRUE
  *   and reset the Smooth-Scroll-Finished semaphore. On the next scroll,
  *   VscrnScrollPage will wait on the Smooth-Scroll-Finished and won't start the
@@ -991,32 +992,7 @@ bool KClient::smoothScrolling() {
 void KClient::smoothScroll() {
     smoothScrollTime += tt_update;
 
-    // Speed in lines per second
-    int fast, slow;
-
-    switch (tt_type) {
-    case TT_VT420:
-    case TT_VT520:
-    case TT_VT525:
-    case TT_K95:
-        slow = 9;
-        fast = 18;
-        break;
-    case TT_VT320: // Based on a video, looks to be the same as the VT220
-    case TT_VT220:
-    case TT_VT100:
-    default:
-        slow = fast = 6;
-        break;
-    }
-
-    float ms_per_line;
-
-    if (updmode == TTU_SMOOTH) {
-        ms_per_line = 1000.0f / (float)slow;
-    } else {
-        ms_per_line = 1000.0f / (float)fast;
-    }
+    float ms_per_line = 1000.0f / (float)(smooth_speed < 1 ? 6 : smooth_speed);
 
     // Update progress
     smoothScrollProgress = smoothScrollTime /  ms_per_line;

--- a/kermit/k95/kui/kclient.cxx
+++ b/kermit/k95/kui/kclient.cxx
@@ -1517,23 +1517,25 @@ void KClient::writeMe()
 
     // adjust the vertical scrollbar
     //
-    int max = (clientPaint->beg == 0) ? clientPaint->end + 1 : clientPaint->page_length;
-    vert->setRange( max, thi - (tt_status[vmode]?1:0), FALSE );
-    horz->setRange( clientPaint->maxWidth, VscrnGetWidth(vmode) );
+    if (!scroll_tbm && !scroll_lrm) {
+        int max = (clientPaint->beg == 0) ? clientPaint->end + 1 : clientPaint->page_length;
+        vert->setRange( max, thi - (tt_status[vmode]?1:0), FALSE );
+        horz->setRange( clientPaint->maxWidth, VscrnGetWidth(vmode) );
 
-    vscrollpos = max - (thi - (tt_status[vmode]?1:0));
-    if( scrollflag[vmode /* clientID */] )
-    {
-        if( clientPaint->scrolltop >= clientPaint->beg ) {
-            vscrollpos = clientPaint->scrolltop - clientPaint->beg;
-        }
-        else if( clientPaint->scrolltop < clientPaint->end ) {
-            vscrollpos = tt_scrsize[vmode /* clientID */] - clientPaint->beg 
-                    + clientPaint->scrolltop;
+        vscrollpos = max - (thi - (tt_status[vmode]?1:0));
+        if( scrollflag[vmode /* clientID */] )
+        {
+            if( clientPaint->scrolltop >= clientPaint->beg ) {
+                vscrollpos = clientPaint->scrolltop - clientPaint->beg;
+            }
+            else if( clientPaint->scrolltop < clientPaint->end ) {
+                vscrollpos = tt_scrsize[vmode /* clientID */] - clientPaint->beg
+                        + clientPaint->scrolltop;
+            }
         }
     }
 
-    // adjust the horizontal scrollbar (not currently used)
+    // adjust the horizontal scrollbar
     vert->setPos( vscrollpos );
     hscrollpos = VscrnGetScrollHorz(vmode);
     horz->setPos( hscrollpos );

--- a/kermit/k95/kui/kclient.cxx
+++ b/kermit/k95/kui/kclient.cxx
@@ -44,6 +44,8 @@ extern int tt_cursor_blink;
 extern int tt_scrsize[];	/* Scrollback buffer size */
 extern int tt_status[];
 extern int tt_update;
+extern int updmode ;
+extern bool in_smooth_scroll;
 extern vscrn_t vscrn[];
 extern int scrollflag[];
 extern enum markmodes markmodeflag[] ;
@@ -188,6 +190,8 @@ KClient::KClient( K_GLOBAL* kg, BYTE cid )
     , ws_blinking( 0 )
     , cursor_displayed( 0 )
     , screenNormal(FALSE)
+    , smoothScrollProgress( 0.0 )
+    , smoothScrollTime( 0 )
 {
     InitializeCriticalSection(&csDraw);
 
@@ -765,6 +769,8 @@ void KClient::checkBlink()
      * besides the cursor.*/
     if (ws_blinking && ((blinkOn && cursorCount == blinkInterval) || (cursorCount == 0)) )
         writeMe();
+    else if (smoothScrolling())
+        writeMe();
 
     else if (cursorCount%300 == 0) {
         if (ikterm->getCursorPos() && (_inFocus || (!_inFocus && cursor_displayed)))
@@ -824,6 +830,12 @@ void KClient::syncSize()
 }
 
 /*------------------------------------------------------------------------
+------------------------------------------------------------------------*/
+bool KClient::smoothScrolling() {
+    return updmode == TTU_SMOOTH && vmode == VTERM && in_smooth_scroll;
+}
+
+/*------------------------------------------------------------------------
     update the memory DC with all the drawing and then copy it 
     into the screen DC.  Also update the cursor position.
 ------------------------------------------------------------------------*/
@@ -831,6 +843,25 @@ void KClient::writeMe()
 {
     int twid, thi, hisv;
     //debug(F100,"KClient::writeMe()","",0);
+
+    if (smoothScrolling()) {
+        smoothScrollTime += tt_update;
+
+        // Update progress. The speeds are:
+        //  VT520, Slow - 9 lines per second, or 111.111ms per line
+        //  VT520, Fast - 18 lines per second, or 55.555ms per line
+        //  VT420, Slow - ?
+        //  VT420, Fast - ?
+        //  VT320         ?
+        //  VT220         6 lines per second
+        //  VT100         6 lines per second (60Hz power)
+        //                5 lines per second (50Hz power
+        // if (FAST) {
+        //    smoothScrollProgres = smoothScrollTime / 55.555;
+        //} else {  // Slow
+            smoothScrollProgress = smoothScrollTime /  111.111;
+        //}
+    }
 
     ::getDimensions( vmode /* clientID */, &twid, &thi );
     hisv = horz->isVisible();
@@ -853,6 +884,9 @@ void KClient::writeMe()
         syncSize();
     }
 
+    // Make sure soft-fonts are ready
+    softFont.refresh(twid, thi - tt_status[vmode]);
+
     int w, h;
     getSize( w, h );
 
@@ -862,6 +896,10 @@ void KClient::writeMe()
     r.top = 0;
     r.right = w;
     r.bottom = h;
+
+    if (smoothScrolling() && !scrollflag[VTERM]) {
+        r.bottom += font->getFontSpacedH();
+    }
 
     DWORD rgb = cell_video_attr_background_rgb(geterasecolor(vmode));
     if ( rgb != savebgcolor ) {
@@ -881,9 +919,6 @@ void KClient::writeMe()
             : cell_video_attr_foreground_rgb(colornormal);
         ruledLinePen = CreatePen(PS_SOLID, 1, rgb);
     }
-
-    // Make sure soft-fonts are ready
-    softFont.refresh(twid, thi - tt_status[vmode]);
 
     // Figure out which soft fonts are valid
     int validSoftFonts[DRCS_BUFFERS];
@@ -1176,7 +1211,8 @@ void KClient::writeMe()
     }
 
     // Draw the cursor
-    if( clientPaint->cursorVisible && cursor_displayed && _inFocus) {
+    if( clientPaint->cursorVisible && cursor_displayed && _inFocus &&
+            !smoothScrolling()) {
         int adjustedH = font->getFontH();
         if( tt_cursor == 2 )        // full
             ;
@@ -1208,7 +1244,34 @@ void KClient::writeMe()
     } else 
 #endif /* COMMENT */
     {
-        BitBlt( hdcScreen(), 0, 0, w, h, hdc(), 0, 0, SRCCOPY );
+        if (smoothScrolling() && !scrollflag[vmode]) {
+            int offset = 0;
+            int lineHeight = font->getFontSpacedH();
+
+            if (tt_status[vmode]) {
+                BitBlt(hdcScreen(),
+                    0, lineHeight * (thi - 1), w, lineHeight,
+                    hdc(), 0, thi * lineHeight,
+                    SRCCOPY);
+            }
+
+            offset = (int)(smoothScrollProgress * lineHeight);
+
+            if (offset > lineHeight) {
+                offset = lineHeight;
+            }
+
+            // Copy everything except the status line
+            BitBlt( hdcScreen(),
+                0, 0, w, lineHeight * (thi - (tt_status[vmode]?1:0)),
+                hdc(),
+                0, offset, SRCCOPY );
+
+            // Now grab the status line
+
+        } else {
+            BitBlt( hdcScreen(), 0, 0, w, h, hdc(), 0, 0, SRCCOPY );
+        }
     }
 
     // adjust the vertical scrollbar
@@ -1233,6 +1296,14 @@ void KClient::writeMe()
     vert->setPos( vscrollpos );
     hscrollpos = VscrnGetScrollHorz(vmode);
     horz->setPos( hscrollpos );
+
+    if (smoothScrollProgress >= 1) {
+        // Finished the smooth scroll event. Unblock scrolling.
+        smoothScrollProgress = 0;
+        smoothScrollTime = 0;
+        in_smooth_scroll = FALSE;
+        PostSmoothScrollFinishedSem();
+    }
 }
 
 void KClient::SetWorkStoreRect(RECT* rect, _K_WORK_STORE* kws, KFont *font,

--- a/kermit/k95/kui/kclient.cxx
+++ b/kermit/k95/kui/kclient.cxx
@@ -49,6 +49,7 @@ extern int updmode ;
 extern bool in_smooth_scroll;
 extern bool smooth_scroll_upwards;
 extern int smooth_scroll_top, smooth_scroll_bottom;
+extern int smooth_scroll_left, smooth_scroll_right;
 extern vscrn_t vscrn[];
 extern int scrollflag[];
 extern enum markmodes markmodeflag[] ;
@@ -137,7 +138,7 @@ VOID CALLBACK KTimerProc( HWND hwnd, UINT msg, UINT_PTR id, DWORD dwtime )
     // debug(F111,"KTimerProc()","dwtime",dwtime);
     KClient* client = (KClient*) kglob->hwndset->find( hwnd );
     if( client ) {
-        if (updmode >= TTU_SMOOTH && in_smooth_scroll) {
+        if ((updmode >= TTU_SMOOTH && in_smooth_scroll) || client->smoothScrolling()) {
             // We're smooth-scrolling.
             client->smoothScroll();
         } else {
@@ -904,9 +905,16 @@ void KClient::syncSize()
 bool KClient::getSmoothScrollDrawInfo() {
     BOOL success = TRUE;
 
+    DWORD rgb = cell_video_attr_background_rgb(geterasecolor(VTERM));
+    HBRUSH bgBrush = CreateSolidBrush( rgb );
+    HGDIOBJ tempObj;
+
     EnterCriticalSection(&csDraw);
 
-    if (smooth_scroll_top != -1 && smooth_scroll_bottom != -1) {
+    bool tbmm = smooth_scroll_top != -1 && smooth_scroll_bottom != -1;
+    bool lrmm = smooth_scroll_left != -1 && smooth_scroll_right != -1;
+
+    if (tbmm || lrmm) {
         // We're only scrolling part of the screen. That complicates matters
         // somewhat. This means we need to render the screen in two stages.
 
@@ -930,6 +938,17 @@ bool KClient::getSmoothScrollDrawInfo() {
             SelectObject(_hdcSScrollBlinkOff, scrollBlinkOffBitmap);
         }
 
+        // Fully erase both DCs. Normally clearPaintRgn() does this for _hdc.
+        // If we don't do this, then dragging the window larger while a smooth
+        // scroll is ongoing may reveal content from when the window was
+        // previously that size
+        tempObj = SelectObject(_hdcSScrollBlinkOn, bgBrush);
+        PaintRgn(_hdcSScrollBlinkOn, hrgnPaint);
+        SelectObject(_hdcSScrollBlinkOn, tempObj);
+
+        tempObj = SelectObject(_hdcSScrollBlinkOff, bgBrush);
+        PaintRgn(_hdcSScrollBlinkOff, hrgnPaint);
+        SelectObject(_hdcSScrollBlinkOff, tempObj);
 
         // And we have to render it twice - once with all of the blinking
         // elements ON, and again with them OFF.
@@ -941,6 +960,10 @@ bool KClient::getSmoothScrollDrawInfo() {
         // we prepared above.
     }
 
+    tempObj = SelectObject(_hdcScratch, bgBrush);
+    PaintRgn(_hdcScratch, hrgnPaint);
+    SelectObject(_hdcScratch, tempObj);
+
     memset( workTemp, '\0', workTempSize );
     success = success && ikterm->getSmoothScrollDrawInfo();
 
@@ -951,11 +974,18 @@ bool KClient::getSmoothScrollDrawInfo() {
         writeMe();
     }
 
+    DeleteObject( bgBrush );
+
     return success;
 }
 
 bool KClient::smoothScrolling() {
-    return updmode >= TTU_SMOOTH && vmode == VTERM && in_smooth_scroll;
+    // We're smooth scrolling if we're on VTERM, and either a smooth
+    // scroll was started (in_smooth_scroll), or has not yet been
+    // finished (smoothProgress > 0). We have to accept both, otherwise
+    // forcing smooth scroll off mid-scroll might not result in the
+    // semaphore being raised, etc.
+    return vmode == VTERM && (in_smooth_scroll || smoothScrollProgress > 0);
 }
 
 void KClient::smoothScroll() {
@@ -982,10 +1012,10 @@ void KClient::smoothScroll() {
 
     float ms_per_line;
 
-    if (updmode == TTU_SMOOTH2) {
-        ms_per_line = 1000.0f / (float)fast;
-    } else {
+    if (updmode == TTU_SMOOTH) {
         ms_per_line = 1000.0f / (float)slow;
+    } else {
+        ms_per_line = 1000.0f / (float)fast;
     }
 
     // Update progress
@@ -1041,17 +1071,69 @@ void KClient::smoothScroll() {
     }
 }
 
+/* Calculates the vertical offset based on current smooth scroll progres */
+int KClient::smoothScrollOffset(int lineHeight) const {
+    int offset = 0;
+
+    if (!smoothScrollRendering) return offset;
+
+    // Scroll progress determines how much of the old screen top we show
+    // and how much of the new screen bottom.
+    if (smooth_scroll_upwards) {
+        offset = (int)(smoothScrollProgress * lineHeight);
+    } else {
+        offset = (int)((1.0 - smoothScrollProgress) * lineHeight);
+    }
+
+    if (offset > lineHeight) offset = lineHeight;
+    if (offset < 0) offset = 0;
+
+    return offset;
+}
+
 /*------------------------------------------------------------------------
     update the memory DC with all the drawing and then copy it 
     into the screen DC.  Also update the cursor position.
 ------------------------------------------------------------------------*/
 void KClient::writeMe()
 {
+    /* TODO: Refactor this into a KTermGdiRenderer or similar.
+     *       - Only the actual terminal painting stuff should move
+     *          - It should take a k_CLIENT_PAINT and paint whatever it says
+     *          - It should be able to render to an arbitrary HDC at given
+     *            coordinates so that, eg, a single line could be repainted
+     *          - It should replace the existing renderToDc() function, and the
+     *            other screenshot stuff should move elsewhere (perhaps a
+     *            KTerminalScreenshot class?)
+     *          - All the Smooth-Scroll multi-render-and-composite stuff should
+     *            be a separate render function that repeatedly calls the
+     *            renderer as necessary to get all the bits it needs
+     *          - Anything not GDI-specific should be pushed into a parent class
+     *            (AbstractKTermRenderer?) to allow for other non-GDI renderer
+     *            implementations in the future (GDI+? Direct2D? OS/2 GPI?)
+     *       - The stuff for updating status bars should go to another function,
+     *         as should the stuff for deciding the visibility of blinking
+     *         stuff.
+     *       - The K_WORK_STORE stuff could probably be moved to IKTerm and done
+     *         at the same time data is being gathered from the terminal buffer.
+     *         I'm not sure there is a good reason to loop through all of the
+     *         screen data twice.
+     *       - IKTerm needs a more flexible API allowing arbitrary regions of
+     *         the terminal buffer to be obtained, along with a helper "whole
+     *         screen" method. This would allow, eg, screenshotting the entire
+     *         scrollback or rendering a single line so that blinking the cursor
+     *         doesn't require the whole terminal to be re-rendered.
+     */
+
     int twid, thi, hisv;
     //debug(F100,"KClient::writeMe()","",0);
 
-    bool scrollRegionRender = smoothScrollRendering
-        && smooth_scroll_top != -1 && smooth_scroll_bottom != -1;
+    // Smooth-scrolling between top and bottom margins
+    bool scroll_tbm = smoothScrollRendering
+         && smooth_scroll_top != -1 && smooth_scroll_bottom != -1;
+
+    bool scroll_lrm = smoothScrollRendering
+         && smooth_scroll_left != -1 && smooth_scroll_right != -1;
 
     ::getDimensions( vmode /* clientID */, &twid, &thi );
     hisv = horz->isVisible();
@@ -1079,12 +1161,19 @@ void KClient::writeMe()
 
     int lineHeight = font->getFontSpacedH();
 
-    int w, h, real_height;
+    int w, h, screen_height, screen_thi;
     getSize( w, h );
 
-    if (scrollRegionRender) {
-        real_height = h;
-        h = (1 + smooth_scroll_bottom - smooth_scroll_top) * lineHeight;
+    // Take backup copies of these, as during smooth-scroll events we'll be
+    // rendering one line more than the screen height.
+    screen_thi = thi;
+    screen_height = h;
+
+    if (smoothScrollRendering) {
+        // When rendering a smooth-scroll, we'll render as many lines as IKTerm
+        // gives us rather than whatever the screen height is.
+        thi = clientPaint->height;
+        h = thi * lineHeight;
     }
 
     // Erase the background with default color
@@ -1093,10 +1182,6 @@ void KClient::writeMe()
     r.top = 0;
     r.right = w;
     r.bottom = h;
-
-    if (smoothScrollRendering) {
-        r.bottom += lineHeight;
-    }
 
     DWORD rgb = cell_video_attr_background_rgb(geterasecolor(vmode));
     if ( rgb != savebgcolor ) {
@@ -1401,6 +1486,23 @@ void KClient::writeMe()
                 RECT rect;
                 SetWorkStoreRect(&rect, kws, font, twid, thi, margin());
 
+                // Apply the smooth scroll offset (if there is one) when smooth
+                // scrolling between the left and right margins so the lines
+                // don't jump around. One line height is added or removed to
+                // counteract the offset applied at compositing time.
+                if (smoothScrollRendering && scroll_lrm) {
+                    int offset;
+                    if (smooth_scroll_upwards) {
+                        offset = smoothScrollOffset(lineHeight) - lineHeight;
+                        rect.top += offset;
+                        rect.bottom += offset;
+                    } else {
+                        offset = smoothScrollOffset(lineHeight);
+                        rect.top += offset;
+                        rect.bottom += offset;
+                    }
+                }
+
                 drawRuledLines(hdc(), ruledLinePen, kws->length, font, rect,
                                rlTop, rlBottom, rlLeft, rlRight);
             }
@@ -1430,88 +1532,142 @@ void KClient::writeMe()
         cursor_displayed = 0;
 
     if( vmode /* clientID */ == VTERM && !::isConnected() )
-        drawDisabledState( w, h );
+        drawDisabledState( w, screen_height );
 
 #ifdef COMMENT
     if ( IsZoomed(parent->hwnd()) ) {
         int cx, cy, cw, ch;
         ((KAppWin *)parent)->getClientCoord( cx, cy, cw, ch );
 
-        StretchBlt( hdcScreen(), 0, 0, cw, ch, hdc(), 0, 0, w, h, SRCCOPY );
+        StretchBlt( hdcScreen(), 0, 0, cw, ch, hdc(), 0, 0, w, screen_height, SRCCOPY );
     } else 
 #endif /* COMMENT */
     {
         if (smoothScrollRendering) {
-            int offset = 0;
+            int offset = smoothScrollOffset(lineHeight);
 
-            // Scroll progress determines how much of the old screen top we show
-            // and how much of the new screen bottom.
-            if (smooth_scroll_upwards) {
-                offset = (int)(smoothScrollProgress * lineHeight);
-            } else {
-                offset = (int)((1.0 - smoothScrollProgress) * lineHeight);
-            }
-
-            if (offset > lineHeight) offset = lineHeight;
-            if (offset < 0) offset = 0;
-
-            if (scrollRegionRender) {
+            if (scroll_tbm || scroll_lrm) {
                 // We're scrolling only part of the screen. First, copy the
-                // non-scrolling bits prepared at the start of the scroll event.
+                // non-scrolling bits prepared at the start of the scroll event,
+                // then copy the scrolling portion.
 
-                int top = smooth_scroll_top * lineHeight;
-                int bottom = smooth_scroll_bottom * lineHeight;
-
-                // The top:
-                BitBlt( hdcScreen(),
-                    0, 0, w, top,
-                    blinkOn ? _hdcSScrollBlinkOn : _hdcSScrollBlinkOff,
-                    0, 0, SRCCOPY );
-
-                // The bottom:
-                BitBlt( hdcScreen(),
-                    0, bottom + lineHeight, w, real_height,
-                    blinkOn ? _hdcSScrollBlinkOn : _hdcSScrollBlinkOff,
-                    0, bottom + lineHeight, SRCCOPY );
-
-                // Then copy only the scrolling region
-                BitBlt( hdcScreen(),
-                    0, top, w, h,
-                    hdc(),
-                    0, offset, SRCCOPY );
-            } else {
                 // The bottom coordinate of the terminal area (excluding the status
                 // line)
+                int terminal_bottom = lineHeight * (screen_thi - (tt_status[vmode]?1:0));
+
+                // In pixels:
+                int top;   // Top of the scroll region (0 if top margin not set)
+                int height; // Height of the scroll region
+                int left;  // Left of the scroll region
+                int width; // Width of the scroll region
+
+                if (scroll_tbm) {
+                    int bottom; // Bottom of the scroll region
+
+                    top = smooth_scroll_top * lineHeight;
+                    bottom = (smooth_scroll_bottom+1) * lineHeight;
+                    height = (smooth_scroll_bottom - smooth_scroll_top + 1) * lineHeight;
+
+                    // The top:
+                    BitBlt( _hdcScratch,
+                        0, 0,    // left, top
+                        w, top,  // width, height
+                        blinkOn ? _hdcSScrollBlinkOn : _hdcSScrollBlinkOff,
+                        0, 0,    // left, top
+                        SRCCOPY
+                        );
+
+                    // The bottom:
+                    BitBlt( _hdcScratch,
+                        0, bottom,
+                        w,
+                        terminal_bottom - bottom +
+                            (!tt_status[vmode] ? margin():0),
+                        blinkOn ? _hdcSScrollBlinkOn : _hdcSScrollBlinkOff,
+                        0, bottom, SRCCOPY );
+
+                } else {
+                    top = 0;
+                    height = terminal_bottom;
+                }
+
+                if (scroll_lrm) {
+                    int right;
+
+                    left = smooth_scroll_left * font->getFontW();
+                    right = (smooth_scroll_right + 1) * font->getFontW();
+                    width = (1+smooth_scroll_right - smooth_scroll_left) * font->getFontW();
+
+                    // The left:
+                    BitBlt( _hdcScratch,
+                        0, top,                 // x, y
+                        left, height,       // width, height
+                        blinkOn ? _hdcSScrollBlinkOn : _hdcSScrollBlinkOff,
+                        0, top,                 // x, y
+                        SRCCOPY
+                        );
+
+                    // The right:
+                    BitBlt( _hdcScratch,
+                        right, top,
+                        w - right, height, // width, height
+                        blinkOn ? _hdcSScrollBlinkOn : _hdcSScrollBlinkOff,
+                        right, top,
+                        SRCCOPY
+                        );
+                } else {
+                    left = 0;
+                    width = w;
+                }
+
+                // Then copy only the scrolling region
+                BitBlt( _hdcScratch,
+                    left, top,
+                    width, height,
+                    hdc(),
+                    left,
+                    offset, SRCCOPY );
+
+                // Now grab the status line
+                if (tt_status[vmode]) {
+                    BitBlt(_hdcScratch,
+                        0, terminal_bottom,
+                        w, lineHeight + margin(),  // margin to fill to screen edge
+                        _hdcSScrollBlinkOn,
+                        0,
+                        (screen_thi-1) * lineHeight,  // this includes the status line, so -1
+                        SRCCOPY);
+                }
+
+                BitBlt( hdcScreen(), 0, 0, w, screen_height,
+                    _hdcScratch, 0, 0, SRCCOPY );
+
+
+            } else { // Smooth-scrolling the entire screen
+
                 int terminal_bottom = lineHeight * (thi - (tt_status[vmode]?1:0));
 
-                // The bottom of the screen area (including the status line)
-                int screen_bottom = terminal_bottom +
-                        lineHeight * (tt_status[vmode]?1:0);
-
                 // Copy everything except the status line
-                BitBlt( hdcScreen(),
+                BitBlt( _hdcScratch,
                     0, 0, w, terminal_bottom,
                     hdc(),
                     0, offset, SRCCOPY );
 
                 // Now grab the status line
                 if (tt_status[vmode]) {
-                    BitBlt(hdcScreen(),
-                        0, terminal_bottom,
-                        w, lineHeight,
-                        hdc(),
-                        0, thi * lineHeight,
-                        SRCCOPY);
+                    BitBlt(_hdcScratch,
+                       0, (screen_thi-1) * lineHeight,
+                       w, lineHeight + margin(),
+                       hdc(),
+                       0, (thi-1) * lineHeight,
+                       SRCCOPY);
                 }
 
-                // Lastly, fill anything *below* the status line in case we're
-                // mid-resize and the window is expanding.
-                r.top = screen_bottom+2; // +2 or a visible line appears below
-                                         // the status line.
-                FillRect( hdcScreen(), &r, bgBrush );
+                BitBlt( hdcScreen(), 0, 0, w, screen_height,
+                    _hdcScratch, 0, 0, SRCCOPY );
             }
         } else {
-            BitBlt( hdcScreen(), 0, 0, w, h, hdc(), 0, 0, SRCCOPY );
+           BitBlt( hdcScreen(), 0, 0, w, h, hdc(), 0, 0, SRCCOPY );
         }
     }
 

--- a/kermit/k95/kui/kclient.cxx
+++ b/kermit/k95/kui/kclient.cxx
@@ -1032,6 +1032,11 @@ void KClient::smoothScroll() {
         smoothScrollTime = 0;
         smoothScrollRendering = FALSE;
         in_smooth_scroll = FALSE;
+
+        // Force a refresh of the draw info in case we were rendering a scroll
+        // region.
+        getDrawInfo();
+
         PostSmoothScrollFinishedSem();
     }
 }

--- a/kermit/k95/kui/kclient.cxx
+++ b/kermit/k95/kui/kclient.cxx
@@ -137,8 +137,7 @@ VOID CALLBACK KTimerProc( HWND hwnd, UINT msg, UINT_PTR id, DWORD dwtime )
     // debug(F111,"KTimerProc()","dwtime",dwtime);
     KClient* client = (KClient*) kglob->hwndset->find( hwnd );
     if( client ) {
-        if ((updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2) && vmode == VTERM
-                && in_smooth_scroll) {
+        if (updmode >= TTU_SMOOTH && in_smooth_scroll) {
             // We're smooth-scrolling.
             client->smoothScroll();
         } else {
@@ -204,6 +203,7 @@ KClient::KClient( K_GLOBAL* kg, BYTE cid )
     , screenNormal(FALSE)
     , smoothScrollProgress( 0.0 )
     , smoothScrollTime( 0 )
+    , smoothScrollRendering ( FALSE )
 {
     InitializeCriticalSection(&csDraw);
 
@@ -262,6 +262,8 @@ KClient::~KClient()
     if ( _hdcSScrollBlinkOff != 0 ) DeleteDC( _hdcSScrollBlinkOff );
     DeleteObject( compatBitmap );
     DeleteObject( scratchBitmap );
+    DeleteObject( scrollBlinkOnBitmap );
+    DeleteObject( scrollBlinkOffBitmap );
     DeleteObject( hrgnPaint );
     DeleteObject( disabledBrush );
     DeleteObject( bgBrush );
@@ -899,10 +901,61 @@ void KClient::syncSize()
  *   region with an offset for scroll progress.
  */
 
+bool KClient::getSmoothScrollDrawInfo() {
+    BOOL success = TRUE;
+
+    EnterCriticalSection(&csDraw);
+
+    if (smooth_scroll_top != -1 && smooth_scroll_bottom != -1) {
+        // We're only scrolling part of the screen. That complicates matters
+        // somewhat. This means we need to render the screen in two stages.
+
+        // For the first stage we need to render the terminal as though
+        // we're not doing smooth scrolling. But don't render it to the
+        // screen - render it to another HDC off to the side. To do this,
+        // we'll use the static rendering functions originally created to
+        // render screenshots.
+        if (_hdcSScrollBlinkOn == 0) {
+            _hdcSScrollBlinkOn = CreateCompatibleDC( _hdcScreen );
+            scrollBlinkOnBitmap = CreateCompatibleBitmap( _hdcScreen
+                    , kglob->sysMets->screenWidth()
+                    , kglob->sysMets->screenHeight() );
+            SelectObject(_hdcSScrollBlinkOn, scrollBlinkOnBitmap);
+        }
+        if (_hdcSScrollBlinkOff == 0) {
+            _hdcSScrollBlinkOff = CreateCompatibleDC( _hdcScreen );
+            scrollBlinkOffBitmap = CreateCompatibleBitmap( _hdcScreen
+                    , kglob->sysMets->screenWidth()
+                    , kglob->sysMets->screenHeight() );
+            SelectObject(_hdcSScrollBlinkOff, scrollBlinkOffBitmap);
+        }
+
+
+        // And we have to render it twice - once with all of the blinking
+        // elements ON, and again with them OFF.
+        success = success && renderToDc(_hdcSScrollBlinkOn, font, VTERM, margin(), TRUE);
+        success = success && renderToDc(_hdcSScrollBlinkOff, font, VTERM, margin(), FALSE);
+
+        // The second stage will then only render the scrolling region, and
+        // it will copy all the non-scrolling content out of the pair of HDC
+        // we prepared above.
+    }
+
+    memset( workTemp, '\0', workTempSize );
+    success = success && ikterm->getSmoothScrollDrawInfo();
+
+    LeaveCriticalSection(&csDraw);
+
+    if (success) {
+        smoothScrollRendering = TRUE;
+        writeMe();
+    }
+
+    return success;
+}
 
 bool KClient::smoothScrolling() {
-    return updmode >= TTU_SMOOTH && vmode == VTERM && in_smooth_scroll
-        && !scrollflag[vmode];
+    return updmode >= TTU_SMOOTH && vmode == VTERM && in_smooth_scroll;
 }
 
 void KClient::smoothScroll() {
@@ -935,47 +988,51 @@ void KClient::smoothScroll() {
         ms_per_line = 1000.0f / (float)slow;
     }
 
+    // Update progress
     smoothScrollProgress = smoothScrollTime /  ms_per_line;
 
-    // If we're just starting our smooth scroll, refresh our copy of the vscrn
-    // so that we have the slightly enlarged buffer we need.
-    if (smoothScrollTime == tt_update) {
-        EnterCriticalSection(&csDraw);
+    // Figure out if we should *show* the smooth scroll.
+    bool popupActive = FALSE;
+    bool selectionActive = markmodeflag[VTERM] == marking;
+    bool viewingScrollback = scrollflag[VTERM];
+    bool onVterm = vmode == VTERM;
 
-        if (smooth_scroll_top != -1 && smooth_scroll_bottom != -1) {
-            // We're only scrolling part of the screen. That complicates matters
-            // somewhat. This means we need to render the screen in two stages.
+    if ( ! RequestVscrnMutex( VTERM, 200 ) ) {
+        popupActive = vscrn[VTERM].popup != NULL;
+        ReleaseVscrnMutex(VTERM);
+    }
 
-            // For the first stage we need to render the terminal as though
-            // we're not doing smooth scrolling. But don't render it to the
-            // screen - render it to another HDC off to the side. To do this,
-            // we'll use the static rendering functions originally created to
-            // render screenshots.
-            if (_hdcSScrollBlinkOn == 0) {
-                _hdcSScrollBlinkOn = CreateCompatibleDC( _hdcScreen );
-            }
-            if (_hdcSScrollBlinkOff == 0) {
-                _hdcSScrollBlinkOff = CreateCompatibleDC( _hdcScreen );
-            }
+    // We only render a smooth scroll event if the user is on VTERM, isn't
+    // selecting text, isn't viewing scrollback, and doesn't have a popup
+    // open. We still compute the smooth scroll though.
+    bool smoothRender = !popupActive && !selectionActive && !viewingScrollback
+        && onVterm;
 
-            // And we have to render it twice - once with all of the blinking
-            // elements ON, and again with them OFF.
-            renderToDc(_hdcSScrollBlinkOn, font, vmode, margin(), TRUE);
-            renderToDc(_hdcSScrollBlinkOn, font, vmode, margin(), FALSE);
-
-            // The second stage will then only render the scrolling region, and
-            // it will copy all the non-scrolling content out of the pair of HDC
-            // we prepared above.
+    if (smoothRender != smoothScrollRendering || VscrnClean(vmode)) {
+        // We're switching between Smooth Scroll rendering and Jump Scroll
+        // rendering. Refresh the draw info.
+        if (!smoothRender) {
+            smoothScrollRendering = smoothRender;
+            getDrawInfo();
+        } else {
+            getSmoothScrollDrawInfo();
         }
-
-        memset( workTemp, '\0', workTempSize );
-        ikterm->getSmoothScrollDrawInfo();
-
-        LeaveCriticalSection(&csDraw);
-
+    } else if (smoothRender) {
+        // Render current smoothScroll progress
         writeMe();
     } else {
+        // Same mode as before - just re-render the existing buffer snapshot
+        // if needed.
         checkBlink();
+    }
+
+    if (smoothScrollProgress >= 1) {
+        // Finished the smooth scroll event. Unblock scrolling.
+        smoothScrollProgress = 0;
+        smoothScrollTime = 0;
+        smoothScrollRendering = FALSE;
+        in_smooth_scroll = FALSE;
+        PostSmoothScrollFinishedSem();
     }
 }
 
@@ -988,8 +1045,7 @@ void KClient::writeMe()
     int twid, thi, hisv;
     //debug(F100,"KClient::writeMe()","",0);
 
-    bool sscroll = smoothScrolling();
-    bool scrollRegionRender = sscroll
+    bool scrollRegionRender = smoothScrollRendering
         && smooth_scroll_top != -1 && smooth_scroll_bottom != -1;
 
     ::getDimensions( vmode /* clientID */, &twid, &thi );
@@ -1033,7 +1089,7 @@ void KClient::writeMe()
     r.right = w;
     r.bottom = h;
 
-    if (sscroll && !scrollflag[VTERM]) {
+    if (smoothScrollRendering) {
         r.bottom += lineHeight;
     }
 
@@ -1348,7 +1404,7 @@ void KClient::writeMe()
 
     // Draw the cursor
     if( clientPaint->cursorVisible && cursor_displayed && _inFocus &&
-            !smoothScrolling()) {
+            !smoothScrollRendering) {
         int adjustedH = font->getFontH();
         if( tt_cursor == 2 )        // full
             ;
@@ -1380,7 +1436,7 @@ void KClient::writeMe()
     } else 
 #endif /* COMMENT */
     {
-        if (sscroll && !scrollflag[vmode]) {
+        if (smoothScrollRendering) {
             int offset = 0;
 
             // Scroll progress determines how much of the old screen top we show
@@ -1397,14 +1453,23 @@ void KClient::writeMe()
             if (scrollRegionRender) {
                 // We're scrolling only part of the screen. First, copy the
                 // non-scrolling bits prepared at the start of the scroll event.
+
+                int top = smooth_scroll_top * lineHeight;
+                int bottom = smooth_scroll_bottom * lineHeight;
+
+                // The top:
                 BitBlt( hdcScreen(),
-                    0, 0, w, real_height,
-                    !blink || blinkOn ? _hdcSScrollBlinkOff : _hdcSScrollBlinkOff,
+                    0, 0, w, top,
+                    blinkOn ? _hdcSScrollBlinkOn : _hdcSScrollBlinkOff,
                     0, 0, SRCCOPY );
 
-                // Then copy only the scrolling region
-                int top = smooth_scroll_top * lineHeight;
+                // The bottom:
+                BitBlt( hdcScreen(),
+                    0, bottom + lineHeight, w, real_height,
+                    blinkOn ? _hdcSScrollBlinkOn : _hdcSScrollBlinkOff,
+                    0, bottom + lineHeight, SRCCOPY );
 
+                // Then copy only the scrolling region
                 BitBlt( hdcScreen(),
                     0, top, w, h,
                     hdc(),
@@ -1467,14 +1532,6 @@ void KClient::writeMe()
     vert->setPos( vscrollpos );
     hscrollpos = VscrnGetScrollHorz(vmode);
     horz->setPos( hscrollpos );
-
-    if (smoothScrollProgress >= 1) {
-        // Finished the smooth scroll event. Unblock scrolling.
-        smoothScrollProgress = 0;
-        smoothScrollTime = 0;
-        in_smooth_scroll = FALSE;
-        PostSmoothScrollFinishedSem();
-    }
 }
 
 void KClient::SetWorkStoreRect(RECT* rect, _K_WORK_STORE* kws, KFont *font,
@@ -1676,6 +1733,7 @@ BOOL KClient::renderToDc(HDC hdc, KFont *font, int vnum, int margin, bool blinkO
     cell_video_attr_t prevAttr = cell_video_attr_init_vio_attribute(255);
     vt_char_attr_t prevEffect = uchar(-1);
     vt_cell_attr_t prevCellAttr = 0;
+    COLORREF textColor;
     BOOL blink;
 	Bool rlLeft = FALSE, rlTop = FALSE, rlRight = FALSE, rlBottom = FALSE;
     for( i = 0; i < wc; i++ )
@@ -1690,7 +1748,8 @@ BOOL KClient::renderToDc(HDC hdc, KFont *font, int vnum, int margin, bool blinkO
             /* to be set by the user and stored somewhere.                       */
             /* The RGBTable is now set via SET GUI RGB commands.                 */
             SetBkColor( hdc, cell_video_attr_background_rgb(prevAttr));
-            SetTextColor( hdc, cell_video_attr_foreground_rgb(prevAttr));
+            textColor = cell_video_attr_foreground_rgb(prevAttr);
+            SetTextColor( hdc, textColor);
         }
 
         // If a soft-font is being used, we can skip all of this as none of
@@ -1718,15 +1777,18 @@ BOOL KClient::renderToDc(HDC hdc, KFont *font, int vnum, int margin, bool blinkO
                 normal = !underline && !blink;
             }
 
-			if (dim) {
-				// Cut the colours intensity by dividing each component by 2.
-				// We can just quickly do this with a right-shift. Because there
-			    // are three separate numbers packed in we need to mask out the
-				// high bit of each as part of this so that the low bit of each
-				// value to the left is erased.
-				SetTextColor( hdc,
-					(cell_video_attr_foreground_rgb(prevAttr) >> 1) & 0x7F7F7F);
-			}
+            if (dim) {
+                // Cut the colours intensity by dividing each component by 2.
+                // We can just quickly do this with a right-shift. Because there
+                // are three separate numbers packed in we need to mask out the
+                // high bit of each as part of this so that the low bit of each
+                // value to the left is erased.
+                SetTextColor( hdc, (textColor >> 1) & 0x7F7F7F);
+            } else {
+                // If not dim, reset the textColor just in case dim is turned
+                // off without the text colour also changing.
+                SetTextColor( hdc, textColor);
+            }
 
             if( normal )
                 font->resetFont( hdc );
@@ -1735,20 +1797,12 @@ BOOL KClient::renderToDc(HDC hdc, KFont *font, int vnum, int margin, bool blinkO
                     font->setCrossedOutBoldUnderlineItalic( hdc );
                 else if( bold && underline )
                     font->setCrossedOutBoldUnderline( hdc );
-                /*else if( dim && underline && italic )
-                    font->setCrossedOutDimUnderlineItalic( hdc );
-                else if( dim && underline )
-                    font->setCrossedOutDimUnderline( hdc );*/
                 else if( underline && italic )
                     font->setCrossedOutUnderlineItalic( hdc );
                 else if( bold && italic )
                     font->setCrossedOutBoldItalic( hdc );
                 else if( bold )
                     font->setCrossedOutBold( hdc );
-                /*else if( dim && italic )
-                    font->setCrossedOutDimItalic( hdc );
-                else if( dim )
-                    font->setCrossedOutDim( hdc );*/
                 else if( underline )
                     font->setCrossedOutUnderline( hdc );
                 else if ( italic )
@@ -1760,20 +1814,12 @@ BOOL KClient::renderToDc(HDC hdc, KFont *font, int vnum, int margin, bool blinkO
                 font->setBoldUnderlineItalic( hdc );
             else if( bold && underline )
                 font->setBoldUnderline( hdc );
-            /*else if( dim && underline && italic )
-                font->setDimUnderlineItalic( hdc );
-            else if( dim && underline )
-                font->setDimUnderline( hdc );*/
             else if( underline && italic )
                 font->setUnderlineItalic( hdc );
             else if( bold && italic )
                 font->setBoldItalic( hdc );
             else if( bold )
                 font->setBold( hdc );
-            /*else if( dim && italic )
-                font->setDimItalic( hdc );
-            else if( dim )
-                font->setDim( hdc );*/
             else if( underline )
                 font->setUnderline( hdc );
             else if ( italic )
@@ -1795,7 +1841,7 @@ BOOL KClient::renderToDc(HDC hdc, KFont *font, int vnum, int margin, bool blinkO
         // with the selected attributes.
         SetWorkStoreRect(&rect, kws, font, twid, thi, margin);
 
-        if (blinkOn) {
+        if (!blink || blinkOn) {
             if (kws->fontBuffer == NO_SOFT_FONT) {
                 ExtTextOutW( hdc, rect.left, rect.top,
                              ETO_CLIPPED | ETO_OPAQUE,

--- a/kermit/k95/kui/kclient.cxx
+++ b/kermit/k95/kui/kclient.cxx
@@ -1289,27 +1289,43 @@ void KClient::writeMe()
             int offset = 0;
             int lineHeight = font->getFontSpacedH();
 
-            if (tt_status[vmode]) {
-                BitBlt(hdcScreen(),
-                    0, lineHeight * (thi - 1), w, lineHeight,
-                    hdc(), 0, thi * lineHeight,
-                    SRCCOPY);
-            }
-
+            // Scroll progress determines how much of the old screen top we show
+            // and how much of the new screen bottom.
             offset = (int)(smoothScrollProgress * lineHeight);
 
             if (offset > lineHeight) {
                 offset = lineHeight;
             }
 
+            // The bottom coordinate of the terminal area (excluding the status
+            // line)
+            int terminal_bottom = lineHeight * (thi - (tt_status[vmode]?1:0));
+
+            // The bottom of the screen area (including the status line)
+            int screen_bottom = terminal_bottom +
+                    lineHeight * (tt_status[vmode]?1:0);
+
             // Copy everything except the status line
             BitBlt( hdcScreen(),
-                0, 0, w, lineHeight * (thi - (tt_status[vmode]?1:0)),
+                0, 0, w, terminal_bottom,
                 hdc(),
                 0, offset, SRCCOPY );
 
             // Now grab the status line
+            if (tt_status[vmode]) {
+                BitBlt(hdcScreen(),
+                    0, terminal_bottom,
+                    w, lineHeight,
+                    hdc(),
+                    0, thi * lineHeight,
+                    SRCCOPY);
+            }
 
+            // Lastly, fill anything *below* the status line in case we're
+            // mid-resize and the window is expanding.
+            r.top = screen_bottom+2; // +2 or a visible line appears below the
+                                     // status line.
+            FillRect( hdcScreen(), &r, bgBrush );
         } else {
             BitBlt( hdcScreen(), 0, 0, w, h, hdc(), 0, 0, SRCCOPY );
         }

--- a/kermit/k95/kui/kclient.cxx
+++ b/kermit/k95/kui/kclient.cxx
@@ -47,6 +47,7 @@ extern int tt_update;
 extern int tt_type;
 extern int updmode ;
 extern bool in_smooth_scroll;
+extern bool smooth_scroll_upwards;
 extern vscrn_t vscrn[];
 extern int scrollflag[];
 extern enum markmodes markmodeflag[] ;
@@ -954,7 +955,9 @@ void KClient::writeMe()
     r.right = w;
     r.bottom = h;
 
-    if (smoothScrolling() && !scrollflag[VTERM]) {
+    bool sscroll = smoothScrolling();
+
+    if (sscroll && !scrollflag[VTERM]) {
         r.bottom += font->getFontSpacedH();
     }
 
@@ -1307,11 +1310,14 @@ void KClient::writeMe()
 
             // Scroll progress determines how much of the old screen top we show
             // and how much of the new screen bottom.
-            offset = (int)(smoothScrollProgress * lineHeight);
-
-            if (offset > lineHeight) {
-                offset = lineHeight;
+            if (smooth_scroll_upwards) {
+                offset = (int)(smoothScrollProgress * lineHeight);
+            } else {
+                offset = (int)((1.0 - smoothScrollProgress) * lineHeight);
             }
+
+            if (offset > lineHeight) offset = lineHeight;
+            if (offset < 0) offset = 0;
 
             // The bottom coordinate of the terminal area (excluding the status
             // line)

--- a/kermit/k95/kui/kclient.cxx
+++ b/kermit/k95/kui/kclient.cxx
@@ -48,6 +48,7 @@ extern int tt_type;
 extern int updmode ;
 extern bool in_smooth_scroll;
 extern bool smooth_scroll_upwards;
+extern int smooth_scroll_top, smooth_scroll_bottom;
 extern vscrn_t vscrn[];
 extern int scrollflag[];
 extern enum markmodes markmodeflag[] ;
@@ -170,6 +171,9 @@ KClient::KClient( K_GLOBAL* kg, BYTE cid )
     : KWin( kg )
     , _hdc( 0 )
     , _hdcScreen( 0 )
+    , _hdcScratch( 0 )
+    , _hdcSScrollBlinkOn( 0 )
+    , _hdcSScrollBlinkOff( 0 )
     , maxpHeight( 0 )
     , maxpWidth( 0 )
     , maxHeight( 0 )
@@ -254,6 +258,8 @@ KClient::~KClient()
     ReleaseDC( hWnd, _hdcScreen );
     DeleteDC( _hdc );
     DeleteDC( _hdcScratch );
+    if ( _hdcSScrollBlinkOn != 0 ) DeleteDC( _hdcSScrollBlinkOn );
+    if ( _hdcSScrollBlinkOff != 0 ) DeleteDC( _hdcSScrollBlinkOff );
     DeleteObject( compatBitmap );
     DeleteObject( scratchBitmap );
     DeleteObject( hrgnPaint );
@@ -864,11 +870,39 @@ void KClient::syncSize()
  *   the progress to zero, set in_smooth_scroll to FALSE and post the
  *   Smooth-Scroll-Finished semaphore to allow any pending scroll to proceed and
  *   start the process all over again.
+ *
+ * Smooth Scrolling only *part* of the Screen:
+ *   When the margins are moved away from the page edges, scrolling region still
+ *   smooth-scrolls. For the VT420 and earlier this applies only to the top and
+ *   while the VT520 will smooth-scroll between the left and right margins too.
+ *
+ *   When doing a smooth-scroll of only part of the screen the process is a
+ *   little different. At the start of the scroll event, VscrnScrollPage saves
+ *   the line that is being scrolled away in a temporary location along with the
+ *   top and bottom margins that were used for the scroll event.
+ *
+ *   When render happens, it starts with two rendering passes of the whole
+ *   vscreen (one with blinking elements on, and one with them off). These two
+ *   passes go to a pair of HDCs for later use rather than to the screen. These
+ *   two renders are currently done using renderToDc() which was originally
+ *   created for taking screenshots.
+ *
+ *   Then during the smooth scroll IKTerm only collects data for the scrolling
+ *   region with the line saved by VscrnScrollPage slotted in at the top or
+ *   bottom depending on scroll direction. writeMe() only renders what IKTerm
+ *   hands it, so what gets rendered to _hdc is only scrolling region with the
+ *   saved line added on.
+ *
+ *   Once writeMe() has rendered the scrolling region to _hdc, it then combines
+ *   all the pieces. It BitBlts one of the two initial render passes (which one
+ *   depending on blink state) to the screen, followed by the smooth scroll
+ *   region with an offset for scroll progress.
  */
 
+
 bool KClient::smoothScrolling() {
-    return (updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2) && vmode == VTERM
-        && in_smooth_scroll;
+    return updmode >= TTU_SMOOTH && vmode == VTERM && in_smooth_scroll
+        && !scrollflag[vmode];
 }
 
 void KClient::smoothScroll() {
@@ -906,7 +940,40 @@ void KClient::smoothScroll() {
     // If we're just starting our smooth scroll, refresh our copy of the vscrn
     // so that we have the slightly enlarged buffer we need.
     if (smoothScrollTime == tt_update) {
-        getDrawInfo();
+        EnterCriticalSection(&csDraw);
+
+        if (smooth_scroll_top != -1 && smooth_scroll_bottom != -1) {
+            // We're only scrolling part of the screen. That complicates matters
+            // somewhat. This means we need to render the screen in two stages.
+
+            // For the first stage we need to render the terminal as though
+            // we're not doing smooth scrolling. But don't render it to the
+            // screen - render it to another HDC off to the side. To do this,
+            // we'll use the static rendering functions originally created to
+            // render screenshots.
+            if (_hdcSScrollBlinkOn == 0) {
+                _hdcSScrollBlinkOn = CreateCompatibleDC( _hdcScreen );
+            }
+            if (_hdcSScrollBlinkOff == 0) {
+                _hdcSScrollBlinkOff = CreateCompatibleDC( _hdcScreen );
+            }
+
+            // And we have to render it twice - once with all of the blinking
+            // elements ON, and again with them OFF.
+            renderToDc(_hdcSScrollBlinkOn, font, vmode, margin(), TRUE);
+            renderToDc(_hdcSScrollBlinkOn, font, vmode, margin(), FALSE);
+
+            // The second stage will then only render the scrolling region, and
+            // it will copy all the non-scrolling content out of the pair of HDC
+            // we prepared above.
+        }
+
+        memset( workTemp, '\0', workTempSize );
+        ikterm->getSmoothScrollDrawInfo();
+
+        LeaveCriticalSection(&csDraw);
+
+        writeMe();
     } else {
         checkBlink();
     }
@@ -920,6 +987,10 @@ void KClient::writeMe()
 {
     int twid, thi, hisv;
     //debug(F100,"KClient::writeMe()","",0);
+
+    bool sscroll = smoothScrolling();
+    bool scrollRegionRender = sscroll
+        && smooth_scroll_top != -1 && smooth_scroll_bottom != -1;
 
     ::getDimensions( vmode /* clientID */, &twid, &thi );
     hisv = horz->isVisible();
@@ -945,8 +1016,15 @@ void KClient::writeMe()
     // Make sure soft-fonts are ready
     softFont.refresh(twid, thi - tt_status[vmode]);
 
-    int w, h;
+    int lineHeight = font->getFontSpacedH();
+
+    int w, h, real_height;
     getSize( w, h );
+
+    if (scrollRegionRender) {
+        real_height = h;
+        h = (1 + smooth_scroll_bottom - smooth_scroll_top) * lineHeight;
+    }
 
     // Erase the background with default color
     RECT r;
@@ -955,10 +1033,8 @@ void KClient::writeMe()
     r.right = w;
     r.bottom = h;
 
-    bool sscroll = smoothScrolling();
-
     if (sscroll && !scrollflag[VTERM]) {
-        r.bottom += font->getFontSpacedH();
+        r.bottom += lineHeight;
     }
 
     DWORD rgb = cell_video_attr_background_rgb(geterasecolor(vmode));
@@ -1023,7 +1099,7 @@ void KClient::writeMe()
             kws = &(workStore[wc]);
 
             kws->x = xpos * font->getFontW() - _xoffset;
-            kws->y = (i / twid) * font->getFontSpacedH();
+            kws->y = (i / twid) * lineHeight;
 
             kws->offset = i;
             if( wc )
@@ -1219,12 +1295,12 @@ void KClient::writeMe()
         Bool lower = lattr & VT_LINE_ATTR_LOWER_HALF ? TRUE : FALSE;
     
         int destx = 0;
-        int desty = i * font->getFontSpacedH();
+        int desty = i * lineHeight;
         int destw = twid * font->getFontW();
-        int desth = font->getFontSpacedH();
+        int desth = lineHeight;
 
         int srcx = 0;
-        int srcy = upper ? desty : (desty + font->getFontSpacedH()/2);
+        int srcy = upper ? desty : (desty + lineHeight/2);
         int srcw = dblWide ? (destw/2) : destw;
         int srch = dblHigh ? (desth/2) : desth;
         if( dblWide && !dblHigh )
@@ -1237,7 +1313,7 @@ void KClient::writeMe()
             , _hdcScratch, destx, desty, destw, desth, SRCCOPY );
 
         if( i == thi - 1 ) {
-            desty += font->getFontSpacedH();
+            desty += lineHeight;
             StretchBlt( _hdcScratch, 0, 0, destw, margin()
                 , hdc(), 0, desty, srcw, margin(), SRCCOPY );
 
@@ -1304,9 +1380,8 @@ void KClient::writeMe()
     } else 
 #endif /* COMMENT */
     {
-        if (smoothScrolling() && !scrollflag[vmode]) {
+        if (sscroll && !scrollflag[vmode]) {
             int offset = 0;
-            int lineHeight = font->getFontSpacedH();
 
             // Scroll progress determines how much of the old screen top we show
             // and how much of the new screen bottom.
@@ -1319,35 +1394,52 @@ void KClient::writeMe()
             if (offset > lineHeight) offset = lineHeight;
             if (offset < 0) offset = 0;
 
-            // The bottom coordinate of the terminal area (excluding the status
-            // line)
-            int terminal_bottom = lineHeight * (thi - (tt_status[vmode]?1:0));
+            if (scrollRegionRender) {
+                // We're scrolling only part of the screen. First, copy the
+                // non-scrolling bits prepared at the start of the scroll event.
+                BitBlt( hdcScreen(),
+                    0, 0, w, real_height,
+                    !blink || blinkOn ? _hdcSScrollBlinkOff : _hdcSScrollBlinkOff,
+                    0, 0, SRCCOPY );
 
-            // The bottom of the screen area (including the status line)
-            int screen_bottom = terminal_bottom +
-                    lineHeight * (tt_status[vmode]?1:0);
+                // Then copy only the scrolling region
+                int top = smooth_scroll_top * lineHeight;
 
-            // Copy everything except the status line
-            BitBlt( hdcScreen(),
-                0, 0, w, terminal_bottom,
-                hdc(),
-                0, offset, SRCCOPY );
-
-            // Now grab the status line
-            if (tt_status[vmode]) {
-                BitBlt(hdcScreen(),
-                    0, terminal_bottom,
-                    w, lineHeight,
+                BitBlt( hdcScreen(),
+                    0, top, w, h,
                     hdc(),
-                    0, thi * lineHeight,
-                    SRCCOPY);
-            }
+                    0, offset, SRCCOPY );
+            } else {
+                // The bottom coordinate of the terminal area (excluding the status
+                // line)
+                int terminal_bottom = lineHeight * (thi - (tt_status[vmode]?1:0));
 
-            // Lastly, fill anything *below* the status line in case we're
-            // mid-resize and the window is expanding.
-            r.top = screen_bottom+2; // +2 or a visible line appears below the
-                                     // status line.
-            FillRect( hdcScreen(), &r, bgBrush );
+                // The bottom of the screen area (including the status line)
+                int screen_bottom = terminal_bottom +
+                        lineHeight * (tt_status[vmode]?1:0);
+
+                // Copy everything except the status line
+                BitBlt( hdcScreen(),
+                    0, 0, w, terminal_bottom,
+                    hdc(),
+                    0, offset, SRCCOPY );
+
+                // Now grab the status line
+                if (tt_status[vmode]) {
+                    BitBlt(hdcScreen(),
+                        0, terminal_bottom,
+                        w, lineHeight,
+                        hdc(),
+                        0, thi * lineHeight,
+                        SRCCOPY);
+                }
+
+                // Lastly, fill anything *below* the status line in case we're
+                // mid-resize and the window is expanding.
+                r.top = screen_bottom+2; // +2 or a visible line appears below
+                                         // the status line.
+                FillRect( hdcScreen(), &r, bgBrush );
+            }
         } else {
             BitBlt( hdcScreen(), 0, 0, w, h, hdc(), 0, 0, SRCCOPY );
         }
@@ -1464,7 +1556,7 @@ void KClient::drawRuledLines(HDC hdc, HPEN pen, int cells, KFont* font,
  * TODO: Someday writeMe() and this function should be refactored into a
  *       bunch of methods and/or classes to try and maximise code sharing.
  */
-BOOL KClient::renderToDc(HDC hdc, KFont *font, int vnum, int margin) {
+BOOL KClient::renderToDc(HDC hdc, KFont *font, int vnum, int margin, bool blinkOn) {
     int twid, thi;
     BOOL success = TRUE;
 
@@ -1703,22 +1795,27 @@ BOOL KClient::renderToDc(HDC hdc, KFont *font, int vnum, int margin) {
         // with the selected attributes.
         SetWorkStoreRect(&rect, kws, font, twid, thi, margin);
 
-        // This is where writeMe() decides whether or not to render blinking text.
-        if (kws->fontBuffer == NO_SOFT_FONT) {
-            ExtTextOutW( hdc, rect.left, rect.top,
-                         ETO_CLIPPED | ETO_OPAQUE,
-                         &rect,
-                         (wchar_t*) &(textBuffer[ kws->offset ]),
-                         kws->length,
-                         (int*)&interSpace );
+        if (blinkOn) {
+            if (kws->fontBuffer == NO_SOFT_FONT) {
+                ExtTextOutW( hdc, rect.left, rect.top,
+                             ETO_CLIPPED | ETO_OPAQUE,
+                             &rect,
+                             (wchar_t*) &(textBuffer[ kws->offset ]),
+                             kws->length,
+                             (int*)&interSpace );
+            } else {
+                softFont.textOut(
+                        hdc,
+                        rect.left,
+                        rect.top,
+                        (wchar_t*) &(textBuffer[ kws->offset ]),
+                        kws->length,
+                        kws->fontBuffer);
+            }
         } else {
-            softFont.textOut(
-                    hdc,
-                    rect.left,
-                    rect.top,
-                    (wchar_t*) &(textBuffer[ kws->offset ]),
-                    kws->length,
-                    kws->fontBuffer);
+            ExtTextOut( hdc, rect.left, rect.top,
+            ETO_CLIPPED | ETO_OPAQUE,
+            &rect, 0, 0, 0 );
         }
     }
 

--- a/kermit/k95/kui/kclient.cxx
+++ b/kermit/k95/kui/kclient.cxx
@@ -44,6 +44,7 @@ extern int tt_cursor_blink;
 extern int tt_scrsize[];	/* Scrollback buffer size */
 extern int tt_status[];
 extern int tt_update;
+extern int tt_type;
 extern int updmode ;
 extern bool in_smooth_scroll;
 extern vscrn_t vscrn[];
@@ -134,7 +135,8 @@ VOID CALLBACK KTimerProc( HWND hwnd, UINT msg, UINT_PTR id, DWORD dwtime )
     // debug(F111,"KTimerProc()","dwtime",dwtime);
     KClient* client = (KClient*) kglob->hwndset->find( hwnd );
     if( client ) {
-        if (updmode == TTU_SMOOTH && vmode == VTERM && in_smooth_scroll) {
+        if ((updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2) && vmode == VTERM
+                && in_smooth_scroll) {
             // We're smooth-scrolling.
             client->smoothScroll();
         } else {
@@ -837,7 +839,7 @@ void KClient::syncSize()
 /*------------------------------------------------------------------------
  Handle Smooth Scrolling
 ------------------------------------------------------------------------*/
-/* How Smooth Scroll works (updmode == TTU_SMOOTH):
+/* How Smooth Scroll works (updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2):
  *   When a scroll completes, VscrnScrollPage will set in_smooth_scroll = TRUE
  *   and reset the Smooth-Scroll-Finished semaphore. On the next scroll,
  *   VscrnScrollPage will wait on the Smooth-Scroll-Finished and won't start the
@@ -864,27 +866,41 @@ void KClient::syncSize()
  */
 
 bool KClient::smoothScrolling() {
-    return updmode == TTU_SMOOTH && vmode == VTERM && in_smooth_scroll;
+    return (updmode == TTU_SMOOTH || updmode == TTU_SMOOTH2) && vmode == VTERM
+        && in_smooth_scroll;
 }
 
 void KClient::smoothScroll() {
     smoothScrollTime += tt_update;
 
-    // Update progress. The speeds are:
-    //  VT520, Slow - 9 lines per second, or 111.111ms per line
-    //  VT520, Fast - 18 lines per second, or 55.555ms per line
-    //  VT420, Slow - ?
-    //  VT420, Fast - ?
-    //  VT320         ?
-    //  VT220         6 lines per second
-    //  VT100         6 lines per second (60Hz power)
-    //                5 lines per second (50Hz power
-    // if (FAST) {
-    //    smoothScrollProgres = smoothScrollTime / 55.555;
-    //} else {  // Slow
-        smoothScrollProgress = smoothScrollTime /  111.111;
-    //}
+    // Speed in lines per second
+    int fast, slow;
 
+    switch (tt_type) {
+    case TT_VT420:
+    case TT_VT520:
+    case TT_VT525:
+    case TT_K95:
+        slow = 9;
+        fast = 18;
+        break;
+    case TT_VT320: // Based on a video, looks to be the same as the VT220
+    case TT_VT220:
+    case TT_VT100:
+    default:
+        slow = fast = 6;
+        break;
+    }
+
+    float ms_per_line;
+
+    if (updmode == TTU_SMOOTH2) {
+        ms_per_line = 1000.0f / (float)fast;
+    } else {
+        ms_per_line = 1000.0f / (float)slow;
+    }
+
+    smoothScrollProgress = smoothScrollTime /  ms_per_line;
 
     // If we're just starting our smooth scroll, refresh our copy of the vscrn
     // so that we have the slightly enlarged buffer we need.

--- a/kermit/k95/kui/kclient.cxx
+++ b/kermit/k95/kui/kclient.cxx
@@ -134,11 +134,16 @@ VOID CALLBACK KTimerProc( HWND hwnd, UINT msg, UINT_PTR id, DWORD dwtime )
     // debug(F111,"KTimerProc()","dwtime",dwtime);
     KClient* client = (KClient*) kglob->hwndset->find( hwnd );
     if( client ) {
-        if( ::VscrnClean( vmode /* client->getClientID() */ )
-            && (!tt_sync_output || vmode != VTERM))
-            client->getDrawInfo();
-        else
-            client->checkBlink();
+        if (updmode == TTU_SMOOTH && vmode == VTERM && in_smooth_scroll) {
+            // We're smooth-scrolling.
+            client->smoothScroll();
+        } else {
+            if( ::VscrnClean( vmode /* client->getClientID() */ )
+                && (!tt_sync_output || vmode != VTERM))
+                client->getDrawInfo();
+            else
+                client->checkBlink();
+        }
     }
 #ifndef NOKVERBS
     if ( win32ScrollUp ) {
@@ -698,7 +703,7 @@ void KClient::getEndSize( int& w, int& h )
 Bool KClient::paint()
 {
     clearPaintRgn();
-    if (tt_sync_output && vmode == VTERM) {
+    if ((tt_sync_output && vmode == VTERM) || smoothScrolling()) {
         /* in synchronized output mode - keep re-rendering the existing display
          * until we exit synchronized output mode. */
         writeMe();
@@ -769,7 +774,7 @@ void KClient::checkBlink()
      * besides the cursor.*/
     if (ws_blinking && ((blinkOn && cursorCount == blinkInterval) || (cursorCount == 0)) )
         writeMe();
-    else if (smoothScrolling())
+    else if (smoothScrolling()) /* Skip rendering cursor during smooth-scroll */
         writeMe();
 
     else if (cursorCount%300 == 0) {
@@ -830,9 +835,64 @@ void KClient::syncSize()
 }
 
 /*------------------------------------------------------------------------
+ Handle Smooth Scrolling
 ------------------------------------------------------------------------*/
+/* How Smooth Scroll works (updmode == TTU_SMOOTH):
+ *   When a scroll completes, VscrnScrollPage will set in_smooth_scroll = TRUE
+ *   and reset the Smooth-Scroll-Finished semaphore. On the next scroll,
+ *   VscrnScrollPage will wait on the Smooth-Scroll-Finished and won't start the
+ *   scroll until the last one has completed.
+ *
+ *   If in_smooth_scroll==True and scrollback isn't being viewed
+ *   (!scrollflag[vnum]) then IKterm::getDrawInfo() will grab a slightly
+ *   enlarged snapshot of the vscreen moving the top back by one line so that
+ *   both the old and new top are present.
+ *
+ *   Over here in KClient during a smooth-scroll the timer will call the
+ *   KClient::smoothScroll() rather than KClient::getDrawInfo() or
+ *   KClient::checkBlink() every time it fires.
+ *
+ *   KClient::smoothScroll() increases the scroll progress each time it fires,
+ *   then writeMe() will use that progress to offset the rendered bitmap
+ *   vertically by some percentage of the line height so that the appropriate
+ *   fraction of the old top and new bottom are visible.
+ *
+ *   When the smooth-scroll progress reaches 100%, KClient::writeMe() will reset
+ *   the progress to zero, set in_smooth_scroll to FALSE and post the
+ *   Smooth-Scroll-Finished semaphore to allow any pending scroll to proceed and
+ *   start the process all over again.
+ */
+
 bool KClient::smoothScrolling() {
     return updmode == TTU_SMOOTH && vmode == VTERM && in_smooth_scroll;
+}
+
+void KClient::smoothScroll() {
+    smoothScrollTime += tt_update;
+
+    // Update progress. The speeds are:
+    //  VT520, Slow - 9 lines per second, or 111.111ms per line
+    //  VT520, Fast - 18 lines per second, or 55.555ms per line
+    //  VT420, Slow - ?
+    //  VT420, Fast - ?
+    //  VT320         ?
+    //  VT220         6 lines per second
+    //  VT100         6 lines per second (60Hz power)
+    //                5 lines per second (50Hz power
+    // if (FAST) {
+    //    smoothScrollProgres = smoothScrollTime / 55.555;
+    //} else {  // Slow
+        smoothScrollProgress = smoothScrollTime /  111.111;
+    //}
+
+
+    // If we're just starting our smooth scroll, refresh our copy of the vscrn
+    // so that we have the slightly enlarged buffer we need.
+    if (smoothScrollTime == tt_update) {
+        getDrawInfo();
+    } else {
+        checkBlink();
+    }
 }
 
 /*------------------------------------------------------------------------
@@ -843,25 +903,6 @@ void KClient::writeMe()
 {
     int twid, thi, hisv;
     //debug(F100,"KClient::writeMe()","",0);
-
-    if (smoothScrolling()) {
-        smoothScrollTime += tt_update;
-
-        // Update progress. The speeds are:
-        //  VT520, Slow - 9 lines per second, or 111.111ms per line
-        //  VT520, Fast - 18 lines per second, or 55.555ms per line
-        //  VT420, Slow - ?
-        //  VT420, Fast - ?
-        //  VT320         ?
-        //  VT220         6 lines per second
-        //  VT100         6 lines per second (60Hz power)
-        //                5 lines per second (50Hz power
-        // if (FAST) {
-        //    smoothScrollProgres = smoothScrollTime / 55.555;
-        //} else {  // Slow
-            smoothScrollProgress = smoothScrollTime /  111.111;
-        //}
-    }
 
     ::getDimensions( vmode /* clientID */, &twid, &thi );
     hisv = horz->isVisible();

--- a/kermit/k95/kui/kclient.hxx
+++ b/kermit/k95/kui/kclient.hxx
@@ -133,6 +133,8 @@ private:    // this section is for performance
         long maxcells,
         uchar** workTempOut);
 
+    bool smoothScrolling();
+
     CRITICAL_SECTION csDraw;
 
     IKTerm* ikterm;
@@ -196,6 +198,9 @@ private:    // this section is for performance
     long _msgret;
 
     KSoftFont softFont;
+
+    double smoothScrollProgress;
+    long smoothScrollTime;
 };
 
 #endif

--- a/kermit/k95/kui/kclient.hxx
+++ b/kermit/k95/kui/kclient.hxx
@@ -122,7 +122,7 @@ private:    // this section is for performance
     static void drawRuledLines(
         HDC hdc, HPEN pen, int cells, KFont* font, RECT rect,
         BOOL rlTop, BOOL rlBottom, BOOL rlLeft, BOOL rlRight);
-    static BOOL renderToDc(HDC hdc, KFont *font, int vnum, int margin=0);
+    static BOOL renderToDc(HDC hdc, KFont *font, int vnum, int margin=0, bool blinkOn=TRUE);
     HBITMAP renderToBitmap(int vnum, DWORD **outPixels);
 #ifdef CK_HAVE_GDIPLUS
     BOOL renderToImageFile(int vnum, char* filename, const wchar_t* format);
@@ -148,6 +148,8 @@ private:    // this section is for performance
     HDC _hdc;
     HDC _hdcScreen;
     HDC _hdcScratch;
+    HDC _hdcSScrollBlinkOn;
+    HDC _hdcSScrollBlinkOff;
     HBITMAP compatBitmap;
     HBITMAP scratchBitmap;
     HRGN hrgnPaint;

--- a/kermit/k95/kui/kclient.hxx
+++ b/kermit/k95/kui/kclient.hxx
@@ -70,6 +70,7 @@ public:
 
     void checkBlink();
     void getDrawInfo();
+    void smoothScroll();
     void drawDisabledState( int w, int h );
 
     void getEndSize( int& w, int& h );

--- a/kermit/k95/kui/kclient.hxx
+++ b/kermit/k95/kui/kclient.hxx
@@ -84,6 +84,8 @@ public:
     void stopTimer();
     void startTimer();
 
+    bool smoothScrolling();
+
     BOOL renderToEmfFile(int vnum, char* filename);
 #ifdef CK_SAVE_TO_IMAGE
     BOOL renderToBmpFile(int vnum, char* filename);
@@ -134,9 +136,8 @@ private:    // this section is for performance
         long maxcells,
         uchar** workTempOut);
 
-    bool smoothScrolling();
-
     bool getSmoothScrollDrawInfo();
+    int smoothScrollOffset(int lineHeight) const;
 
     CRITICAL_SECTION csDraw;
 

--- a/kermit/k95/kui/kclient.hxx
+++ b/kermit/k95/kui/kclient.hxx
@@ -136,6 +136,8 @@ private:    // this section is for performance
 
     bool smoothScrolling();
 
+    bool getSmoothScrollDrawInfo();
+
     CRITICAL_SECTION csDraw;
 
     IKTerm* ikterm;
@@ -152,6 +154,8 @@ private:    // this section is for performance
     HDC _hdcSScrollBlinkOff;
     HBITMAP compatBitmap;
     HBITMAP scratchBitmap;
+    HBITMAP scrollBlinkOnBitmap;
+    HBITMAP scrollBlinkOffBitmap;
     HRGN hrgnPaint;
     HBRUSH disabledBrush;
     HBRUSH bgBrush;
@@ -204,6 +208,12 @@ private:    // this section is for performance
 
     double smoothScrollProgress;
     long smoothScrollTime;
+
+    // If a smooth scroll event is currently being rendered smoothly.
+    // During mark mode, a popup, or if a different vscreen is being
+    // displayed then the vscreen is rendered normally but the smooth
+    // smooth scroll progress is still calculated.
+    bool smoothScrollRendering;
 };
 
 #endif

--- a/kermit/samples/demo.sh
+++ b/kermit/samples/demo.sh
@@ -270,11 +270,52 @@ function da_implied_extensions {
         esac
 }
 
+# Request DEC private mode
+function decrqm() {
+        MODE=$1   # Mode to query
+        OUT=$2    # Output full result (true) or just state number (false)
+
+        # -s    Do not echo input
+        # -t    Timmeout - give up after 1s
+        # -d y  Delimiter: Continue reading until a 'y' is read?
+        # -p    Prompt
+        #read -s -t 1 -d y -p $'\e[?3$p'   A; echo "A=$A" | cat -v
+        read -s -t 1 -d y -p $'\e[?'${MODE}'$p' RESP
+
+        # Response is something like: ^[[?3;2$
+        # where 3 is the queried mode, and 2 is the state. State is one of:
+        #       0       Not Recognised
+        #       1       Set
+        #       2       Reset
+        #       3       Permanently Set
+        #       4       Permanently Reset
+
+        # $2 is the mode, $3 is the state
+        RMODE=$(echo $RESP | awk -F'[?;$]' '{print $2}')
+        STATE=$(echo $RESP | awk -F'[?;$]' '{print $3}')
+
+        # This would only happen if the terminal processed requests out of order
+        if [ "$RMODE" != "$MODE" ]; then
+                echo "Error: unexpected mode in respose: $RMODE"
+        fi
+
+
+        if [ "$OUT" = true ]; then
+                SSTATE=$(decrqm_modetext $STATE)
+                echo "MODE ${MODE} STATE=${STATE} (${SSTATE})"
+        else
+                echo $STATE
+        fi
+}
+
 # Request String
 function decrqss() {
         REQ=$1   # String to request
+        TRIM=$2  # Trim?
 
-        read -s -t 5 -d '\\' -r -p $'\eP$q'$REQ$'\e\\' RESP
+        printf -v PROMPT '\x1bP$q%s\x1b\\' "$REQ"
+
+        read -s -t 5 -d '\\' -r -p "${PROMPT}" RESP
         # '
 
         # Response is something like: ^Px$rD....D^\
@@ -285,7 +326,11 @@ function decrqss() {
         if [ "$STAT" = "0" ]; then
                 echo "Invalid Request"
         else
-                echo $RESP
+                if [[ "$TRIM" == "true" ]]; then
+                        echo ${RESP/"$REQ"/""}
+                else
+                        echo ${RESP}
+                fi
         fi
 }
 
@@ -299,6 +344,66 @@ function vtstar_drcs_fix {
     done
     printf '\x1b[m'
   fi
+}
+
+function scroll_away {
+  # Need the terminal height for this!
+  HEIGHT=$(decrqss '*|' "true")
+  if [[ "$HEIGHT" == "" ]]; then
+    return
+  fi
+
+  # OK to scroll away?
+  OK=1
+
+  SSCROLL_RESET=0
+  case $(decrqm 4) in
+    0) OK=0 ;; # Not recognised
+    1) OK=1 ;; # Set
+    2) OK=1; SSCROLL_RESET=1 ;; # Reset
+    3) OK=1 ;; # Permanently Set
+    4) OK=0 ;; # Permanently Reset
+    *) OK=0 ;; # Error
+  esac
+
+  if [[ "$OK" == "0" ]]; then
+    # Smooth scroll not supported
+    return
+  fi
+
+  printf '\x1b[3H'
+  ORIGINAL_SPEED=$(decrqss ' p')
+
+  SPEED=8
+  INCREMENT=$((HEIGHT/8))
+
+  # Temporarily turn smooth-scroll on
+  printf '\x1b[5H\x1b[?4h'
+  printf "\x1b[8 p"  # Go to max speed
+
+  # Scroll the demo screen away downwards
+  for (( i = 1; i <= $HEIGHT; i++ )); do
+    printf '\x1b[H'  # Go to screen top
+    printf '\x1bM'   # Reverse Index to insert a new line
+    printf '\r\n'    # LF to trigger a smooth scroll
+
+    if (( (i+1) % INCREMENT == 0)); then
+      # Accelerate!
+      SPEED=$((SPEED - 1))
+      printf "\x1b[%d p" $SPEED
+    fi
+  done
+
+  # Restore the previous speed setting
+  printf '\x1b[%s' "${ORIGINAL_SPEED}"
+
+  # Then back off as it was off when we started
+  if [[ "$SSCROLL_RESET" == "1" ]]; then
+        printf '\x1b[?4l'
+  fi
+
+  # Back to the bottom
+  printf '\x1b[%dH' $HEIGHT
 }
 
 # Top Banner
@@ -999,13 +1104,18 @@ printf '\x1b[5m\t\t\t'
 # Cursor off
 printf '\x1b[?25l'
 
-read -n 1 -s -r -p "Strike any key to continue..."
+read -n 1 -s -r -p 'Strike any key to continue...'
 
 # Clear the line
 printf '\x1b[2K'
 
-# Blinking off
-printf '\x1b[0m\n'
+# DECOM and DECLRMM off
+printf '\x1b[?6;69l'
+
+# Clear margins and make sure attributes are normal
+printf '\x1b[r\x1b[s\x1b[m'
+
+scroll_away
 
 # Cursor back on
 printf '\x1b[?25h'
@@ -1030,12 +1140,6 @@ fi
 # Erase ruled lines in case a full screen app that doesn't know how to erase
 # them is launched next. DECterm requires all the semicolons, K95 doesn't.
 printf '\x1b[0;;;;,t'
-
-# DECOM and DECLRMM off
-printf '\x1b[?6;69l'
-
-# Clear margins and make sure attributes are normal
-printf '\x1b[r\x1b[s\x1b[m'
 
 # Go to the bottom line, as clearing the margins will have put the cursor at 1,1
 # which is a double-height line.

--- a/kermit/tests/README.md
+++ b/kermit/tests/README.md
@@ -38,3 +38,9 @@ use DECALN.
 
 A patch is provided, [vttest-decaln.patch](vttest-decaln.patch), to enable the
 monochrome Rectangular Area Operations tests to work correctly.
+
+## Smooth-Scroll Test
+
+`scrolltest.sh` can be used to exercise Kermit 95s smooth-scroll support
+combined with various combinations of margins as well as smooth-scrolling in the
+reverse direction.

--- a/kermit/tests/scrolltest.sh
+++ b/kermit/tests/scrolltest.sh
@@ -1,0 +1,352 @@
+#!/bin/bash
+#
+# This is a script for exercising smooth-scroll in Kermit 95. It supports
+# scrolling the whole screen, or an area between some combination of
+# margins in either the forwards (text moving up the screen from the bottom)
+# or reverse (text moving down the screen from the top) direction.
+#
+# It also makes use of the Ruled Lines extension to highlight the scroll
+# region, when set. Corners of scroll regions are also marked with 'X'.
+#
+# It should also work on other terminals, though some features this script can
+# exercise are rarely supported even when smooth-scroll itself is.
+#
+# Ruled Lines
+#    Compatible with WRQ Reflection, K95 and maybe the DEC VT382. DECterm does
+#    implement this extension too, but this script makes no effort to work
+#    around its various bugs.
+# Smooth-Scrolling when the left and right margins are set
+#    No terminal or terminal emulator from DEC appears to support this. When
+#    left/right margins are set the test will run as though smooth scroll was
+#    disabled on those terminals.
+#
+#
+
+# 1 = on, 0 = off
+STBM=1     # Set top and bottom margins
+LRMM=1	   # Set left and right margins
+LINES=1    # Draw lines on the margins?
+REVERSE=1  # Reverse Direction?
+
+# The number of lines output before and after the blinking double height line
+# is set based on the height of the scroll region, but you can limit it for
+# debugging to a smaller number
+LEAD_MAX_HEIGHT=80
+TRAIL_MAX_HEIGHT=80
+
+# Position of the margins, when set
+TOP_MARGIN=5
+BOTTOM_MARGIN=20
+LEFT_MARGIN=20
+RIGHT_MARGIN=59
+
+# Dimensions of the screen. They're not queried so the output of this script
+# can be saved to a file.
+SCREEN_HEIGHT=24
+SCREEN_WIDTH=80
+
+
+# Or a pre-prepared test: TEST_NUM=4 ./scrolltest.sh
+case $TEST_NUM in
+	1)  REVERSE=0; STBM=0; LRMM=0; TOP_MARGIN=5; BOTTOM_MARGIN=20; LEFT_MARGIN=20; RIGHT_MARGIN=59;; # Screen FWD
+	2)  REVERSE=0; STBM=1; LRMM=0; TOP_MARGIN=5; BOTTOM_MARGIN=20; LEFT_MARGIN=20; RIGHT_MARGIN=59;; # T/B FWD
+	3)  REVERSE=0; STBM=0; LRMM=1; TOP_MARGIN=5; BOTTOM_MARGIN=20; LEFT_MARGIN=20; RIGHT_MARGIN=59;; # L/R FWD
+	4)  REVERSE=0; STBM=1; LRMM=1; TOP_MARGIN=5; BOTTOM_MARGIN=20; LEFT_MARGIN=20; RIGHT_MARGIN=59;; # Sware FWD
+	5)  REVERSE=0; STBM=1; LRMM=1; TOP_MARGIN=1; BOTTOM_MARGIN=20; LEFT_MARGIN=1;  RIGHT_MARGIN=59;; # Top Left Corner FWD
+	6)  REVERSE=0; STBM=1; LRMM=1; TOP_MARGIN=1; BOTTOM_MARGIN=20; LEFT_MARGIN=20; RIGHT_MARGIN=80;; # Top Right Corner FWD
+	7)  REVERSE=0; STBM=1; LRMM=1; TOP_MARGIN=5; BOTTOM_MARGIN=24; LEFT_MARGIN=1;  RIGHT_MARGIN=59;; # Bottom Left Corner FWD
+	8)  REVERSE=0; STBM=1; LRMM=1; TOP_MARGIN=5; BOTTOM_MARGIN=24; LEFT_MARGIN=20; RIGHT_MARGIN=80;; # Bottom Right Corner FWD
+	9)  REVERSE=1; STBM=0; LRMM=0; TOP_MARGIN=5; BOTTOM_MARGIN=20; LEFT_MARGIN=20; RIGHT_MARGIN=59;; # Screen REV
+	10) REVERSE=1; STBM=1; LRMM=0; TOP_MARGIN=5; BOTTOM_MARGIN=20; LEFT_MARGIN=20; RIGHT_MARGIN=59;; # T/B REV
+	11) REVERSE=1; STBM=0; LRMM=1; TOP_MARGIN=5; BOTTOM_MARGIN=20; LEFT_MARGIN=20; RIGHT_MARGIN=59;; # L/R REV
+	12) REVERSE=1; STBM=1; LRMM=1; TOP_MARGIN=5; BOTTOM_MARGIN=20; LEFT_MARGIN=20; RIGHT_MARGIN=59;; # Square RV
+	13) REVERSE=1; STBM=1; LRMM=1; TOP_MARGIN=1; BOTTOM_MARGIN=20; LEFT_MARGIN=1;  RIGHT_MARGIN=59;; # Top Left Corner REV
+	14) REVERSE=1; STBM=1; LRMM=1; TOP_MARGIN=1; BOTTOM_MARGIN=20; LEFT_MARGIN=20; RIGHT_MARGIN=80;; # Top Right Corner REV
+	15) REVERSE=1; STBM=1; LRMM=1; TOP_MARGIN=5; BOTTOM_MARGIN=24; LEFT_MARGIN=1;  RIGHT_MARGIN=59;; # Bottom Left Corner REV
+	16) REVERSE=1; STBM=1; LRMM=1; TOP_MARGIN=5; BOTTOM_MARGIN=24; LEFT_MARGIN=20; RIGHT_MARGIN=80;; # Bottom Right Corner REV
+esac
+
+printf '\x1b[2J'	# Clear screen
+printf '\x1b[,t'	# Clear ruled lines
+printf '\x1b[?4h' 	# Smooth Scroll On
+
+# 80 columns by default, narrower if LRMM on.
+WIDTH=$SCREEN_WIDTH
+H_CENTER=$((SCREEN_WIDTH / 2))
+V_CENTER=$((SCREEN_HEIGHT / 2))
+
+if [ "$LRMM" = "1" ]; then
+	WIDTH=$((RIGHT_MARGIN-LEFT_MARGIN +1))
+	H_CENTER=$((LEFT_MARGIN + WIDTH / 2))
+else
+	LEFT_MARGIN=1
+	RIGHT_MARGIN=$SCREEN_WIDTH
+fi
+
+if [ "$STBM" = "1" ]; then
+	HEIGHT=$((BOTTOM_MARGIN-TOP_MARGIN +1))
+	V_CENTER=$((TOP_MARGIN + HEIGHT / 2))
+else
+	HEIGHT=$SCREEN_HEIGHT
+	TOP_MARGIN=1
+	BOTTOM_MARGIN=$SCREEN_HEIGHT
+fi
+
+if [ "$LINES" = "1" ]; then
+	# Put a box in the middle to show it doesn't jiggle during the smooth
+	# scroll in LRMM mode, but scrolls normally when not in LRMM mode.
+	printf '\x1b[15;%d;1;%d;1,r' $H_CENTER $V_CENTER
+fi
+
+if [ "$STBM" = "1" ]; then
+	# Top/Bottom margins
+	printf '\x1b[%d;%dr' $TOP_MARGIN $BOTTOM_MARGIN
+
+	PRE_TOP_MARGIN=$((TOP_MARGIN - 1))
+	POST_BOTTOM_MARGIN=$((BOTTOM_MARGIN + 1))
+
+	# Label them, blinkingly
+	printf '\x1b[5m'
+	if (( TOP_MARGIN > 1 )); then
+		printf '\x1b[%d;%dHTop Margin' $PRE_TOP_MARGIN $((H_CENTER - 5))
+	fi
+	printf '\x1b[%d;%dHBottom Margin' $POST_BOTTOM_MARGIN $((H_CENTER - 6))
+	printf '\x1b[m'
+
+	# Line from the top to the margin
+	if (( TOP_MARGIN > 2 )); then
+		printf '\x1b[1;%dHScreen Top' $((H_CENTER-5))
+		for (( i = 2; i < TOP_MARGIN - 2; i++ )); do
+			printf '\x1b[%d;%dH|' $i $H_CENTER
+		done
+		if (( TOP_MARGIN > 3 )); then
+			printf '\x1b[%d;%dH+' $(( TOP_MARGIN - 2 )) $H_CENTER
+		fi
+	fi
+
+	# Line from the bottom to the margin
+	if (( BOTTOM_MARGIN < SCREEN_HEIGHT - 1)); then
+		printf '\x1b[%d;%dH+' $(( BOTTOM_MARGIN + 2 )) $H_CENTER
+		for (( i = BOTTOM_MARGIN + 3; i < SCREEN_HEIGHT; i++ )); do
+			printf '\x1b[%d;%dH|' $i $H_CENTER
+		done
+		printf '\x1b[%d;%dHScreen Bottom' $SCREEN_HEIGHT $((H_CENTER-6))
+	fi
+else
+	PRE_TOP_MARGIN=$TOP_MARGIN
+	POST_BOTTOM_MARGIN=$BOTTOM_MARGIN
+fi
+
+#printf '\x1b[1;3HHEIGHT=%d,WIDTH=%d' $HEIGHT $WIDTH
+#printf '\x1b[2;3HT=%d,B=%d' $TOP_MARGIN $BOTTOM_MARGIN
+#printf '\x1b[3;3HL=%d,R=%d' $LEFT_MARGIN $RIGHT_MARGIN
+
+if [ "$LRMM" = "1" ]; then
+	# Left/Right margins
+	printf '\x1b[?69h'	# DECLRMM on
+	printf '\x1b[%d;%ds' $LEFT_MARGIN $RIGHT_MARGIN
+
+	PRE_LEFT_MARGIN=$((LEFT_MARGIN-1))
+	POST_RIGHT_MARGIN=$((RIGHT_MARGIN+1))
+
+	# Label the margins, blinkingly
+	printf '\x1b[5m'
+	if (( LEFT_MARGIN >= 14 )); then
+		printf '\x1b[%d;%dHLeft Margin ->' $V_CENTER $((LEFT_MARGIN-14))
+	elif (( LEFT_MARGIN >= 3 )); then
+		printf '\x1b[%d;%dH->' $V_CENTER $((LEFT_MARGIN-2))
+	elif (( LEFT_MARGIN > 1 )); then
+		printf '\x1b[%d;%dH>' $V_CENTER $PRE_LEFT_MARGIN
+	fi
+	if (( RIGHT_MARGIN < SCREEN_WIDTH )); then
+		printf '\x1b[%d;%dH<- Right Margin' $V_CENTER $POST_RIGHT_MARGIN
+	fi
+	printf '\x1b[m'
+
+	# Mark the corners of the screen
+	if (( LEFT_MARGIN > 1 && TOP_MARGIN > 1 )); then
+		printf '\x1b[HX'
+	fi
+	if (( RIGHT_MAGIN < SCREEN_WIDTH && TOP_MARGIN > 1 )); then
+		printf '\x1b[1;%dHX' $SCREEN_WIDTH
+	fi
+	if (( LEFT_MARGIN > 1 && BOTTOM_MARGIN < SCREEN_HEIGHT )); then
+		printf '\x1b[%dHX' $SCREEN_HEIGHT
+	fi
+	if (( RIGHT_MARGIN < SCREEN_WIDTH && BOTTOM_MARGIN < SCREEN_HEIGHT )); then
+		printf '\x1b[%d;%dHX' $SCREEN_HEIGHT $SCREEN_WIDTH
+	fi
+else
+	LEFT_MARGIN=1
+	RIGHT_MARGIN=80
+	PRE_LEFT_MARGIN=$LEFT_MARGIN
+	POST_RIGHT_MARGIN=$RIGHT_MARGIN
+fi
+
+if [ "$STBM$LRMM" = "11" ]; then
+	if [ "$LINES" = "1" ]; then
+		if (( LEFT_MARGIN > 1 || RIGHT_MARGIN < 80 )); then
+			printf '\x1b[15;%d;%d;%d;%d,r' $LEFT_MARGIN $WIDTH $TOP_MARGIN $HEIGHT
+		fi
+
+		# Draw a box around the scroll region. This has to be done
+		# on the outside border of the scroll region as the lines
+		# within the scroll region are sliding upwards
+		if (( TOP_MARGIN > 1 )); then
+			printf '\x1b[1;%d;%d;%d;1,r' $LEFT_MARGIN $WIDTH $PRE_TOP_MARGIN     # Top
+		fi
+		printf '\x1b[4;%d;%d;%d;1,r' $LEFT_MARGIN $WIDTH $POST_BOTTOM_MARGIN # Bottom
+		if (( LEFT_MARGIN > 1 )); then
+			printf '\x1b[2;%d;1;%d;%d,r' $PRE_LEFT_MARGIN $TOP_MARGIN $HEIGHT    # Left
+		fi
+		printf '\x1b[8;%d;1;%d;%d,r' $POST_RIGHT_MARGIN $TOP_MARGIN $HEIGHT  # Right
+	fi
+
+	# Mark the corners too
+	if (( TOP_MARGIN > 1 )); then
+		if (( LEFT_MARGIN > 1 )); then
+			printf '\x1b[%d;%dHXX' $PRE_TOP_MARGIN $PRE_LEFT_MARGIN
+		fi
+		if (( RIGHT_MARGIN < SCREEN_WIDTH )); then
+			printf '\x1b[%d;%dHXX' $PRE_TOP_MARGIN $RIGHT_MARGIN
+		fi
+	fi
+	if (( LEFT_MARGIN > 1 )); then
+		printf '\x1b[%d;%dHX' $TOP_MARGIN $PRE_LEFT_MARGIN
+		printf '\x1b[%d;%dHX' $BOTTOM_MARGIN $PRE_LEFT_MARGIN
+	fi
+	if (( RIGHT_MARGIN < SCREEN_WIDTH - 1 )); then
+		printf '\x1b[%d;%dHX' $TOP_MARGIN $POST_RIGHT_MARGIN
+		printf '\x1b[%d;%dHX' $BOTTOM_MARGIN $POST_RIGHT_MARGIN
+	fi
+	if (( BOTTOM_MARGIN < SCREEN_HEIGHT - 1 )); then
+		if (( LEFT_MARGIN > 1 )); then
+			printf '\x1b[%d;%dHXX' $POST_BOTTOM_MARGIN $PRE_LEFT_MARGIN
+		fi
+		if (( RIGHT_MARGIN < SCREEN_WIDTH )); then
+			printf '\x1b[%d;%dHXX' $POST_BOTTOM_MARGIN $RIGHT_MARGIN
+		fi
+	fi
+
+	HOME="\x1b[${TOP_MARGIN};${LEFT_MARGIN}H"
+elif [ "$STBM" = "1" ]; then
+	if [ "$LINES" = "1" ]; then
+		# Draw a box around the scroll region. This has to be done
+		# on the outside border of the scroll region as the lines
+		# within the scroll region are sliding upwards
+		printf '\x1b[1;1;%d;%d;1,r' $SCREEN_WIDTH $PRE_TOP_MARGIN      # Top
+		printf '\x1b[4;1;%d;%d;1,r' $SCREEN_WIDTH $POST_BOTTOM_MARGIN  # Bottom
+	fi
+
+	# Mark the corners too
+	printf '\x1b[%dHX\x1b[%d;%dHX' $PRE_TOP_MARGIN $PRE_TOP_MARGIN $SCREEN_WIDTH
+	printf '\x1b[%dHX\x1b[%d;%dHX' $POST_BOTTOM_MARGIN $POST_BOTTOM_MARGIN $SCREEN_WIDTH
+
+	HOME="\x1b[${TOP_MARGIN}H"
+elif [ "$LRMM" = "1" ]; then
+	if [ "$LINES" = "1" ]; then
+		# Draw a box around the scroll region. This has to be done
+		# on the outside border of the scroll region as the lines
+		# within the scroll region are sliding upwards
+		printf '\x1b[2;%d;1;1;%d,r' $PRE_LEFT_MARGIN $BOTTOM_MARGIN   # Left
+		printf '\x1b[8;%d;1;1;%d,r' $POST_RIGHT_MARGIN $BOTTOM_MARGIN # Right
+	fi
+
+	# Mark the corners of the margin
+	printf '\x1b[1;%dHX' $PRE_LEFT_MARGIN
+	printf '\x1b[1;%dHX' $POST_RIGHT_MARGIN
+	printf '\x1b[%d;%dHX' $BOTTOM_MARGIN $PRE_LEFT_MARGIN
+	printf '\x1b[%d;%dHX' $BOTTOM_MARGIN $POST_RIGHT_MARGIN
+
+	HOME="\x1b[1;${LEFT_MARGIN}H"
+else
+	HOME='\x1b[H'
+fi
+
+function nextline() {
+	if [ "$REVERSE" = "1" ]; then
+		printf $HOME
+		printf '\x1bM'   # Reverse Index to insert a line
+		printf $HOME
+	else
+		printf '\r\n'
+	fi
+}
+
+
+function dolines() {
+	for (( i = 1; i <= $1; i++ )); do
+		if [ "$REVERSE" = "1" ]; then
+			printf $HOME
+			printf '\x1bM'   # Reverse Index
+		fi
+
+		printf "%03d" $i
+		for (( j = 4; j <= $WIDTH; j++ )); do
+			printf 'A'
+		done
+
+		printf '\r\n'
+	done
+}
+
+# Enlarge it a little so that the double-height line doesn't immediately
+# appear at the bottom.
+HEIGHT=$(( HEIGHT + 10 ))
+
+printf $HOME
+
+if (( $HEIGHT > $LEAD_MAX_HEIGHT )); then
+	dolines $LEAD_MAX_HEIGHT
+else
+	dolines $HEIGHT
+fi
+
+# A blinking line. Double-height if not LRMM
+printf '\x1b[5m'
+if [ "$LRMM" = "0" ]; then
+	if [ "$REVERSE" = "1" ]; then
+		printf $HOME
+		printf '\x1bM\x1b#4'
+		for (( j = 1 ; j <= WIDTH/2; j++ )); do
+			printf 'A'
+		done
+		printf $HOME
+		printf '\x1bM\x1b#3'
+		for (( j = 1 ; j <= WIDTH/2; j++ )); do
+			printf 'A'
+		done
+	else
+		printf '\x1b#3'
+		for (( j = 1 ; j <= WIDTH/2; j++ )); do
+			printf 'A'
+		done
+		printf '\n\x1b#4'
+		for (( j = 1 ; j <= WIDTH/2; j++ )); do
+			printf 'A'
+		done
+		printf '\n'
+	fi
+else
+	if [ "$REVERSE" = "1" ]; then
+		printf $HOME
+		printf '\x1bM'
+	fi
+
+	for (( j = 1 ; j <= $WIDTH; j++ )); do
+		printf 'A'
+	done
+	printf '\r\n'
+fi
+
+printf '\x1b[m'
+
+if (( $HEIGHT > $TRAIL_MAX_HEIGHT )); then
+	dolines $TRAIL_MAX_HEIGHT
+else
+	dolines $HEIGHT
+fi
+
+printf '\x1b[?4;69l'   # Smooth scroll, DECLRMM off
+printf '\x1b[r\x1b[s'  # Margins gone
+printf '\x1b[23H'


### PR DESCRIPTION
What works:
 - Scrolling, smoothly
 - Scrolling in the reverse direction, smoothly
 - Waits happen in the right place appearance/behaviour matches the VT220 and, less obviously, the VT520
 - Viewing scroll-back while scrolling, smoothly
 - Resizing the window and forcing repaints during a smooth scroll doesn't cause bad things to happen
 - Enabling/disabling DECSCLM is deferred until after the next scroll event
 - Different scroll speeds for the different terminals: 6 lines per second for VT100/220/320, and either 9 or 18 lines per second depending on setting for VT420/520/K95.
 - Scrolling between any combination of margins
 - vscreen popups and mark-mode suppress the smooth-scroll animation
 - New command to set scroll mode and speed, setting visible via `show term`

TODO:

- [x] Fix terminal resizing during smooth-scroll
- [x] Repaints shouldn't speed up smooth-scroll
- [x] DECSCLM shouldn't take effect until after the next scroll on VT220 and up (VT100 unknown)
- [x] Different scroll speeds for VT220, 420, 520. 
- [x] Fast and slow scroll for VT420+
- [x] Smooth scrolling *part* of the screen - the amount of work grows further
- [x] vscreen popups - they now just suppress the smooth-scroll animation when they're up. Too much work to try and render them separately, especially given popups are off-by-default.
- [x] Implement #544 
- [x] Testing
- [x] Documentation
- [x] Changelog