### PR TITLE
Fix a few deviations from real terminal behaviour for the LCF

### DIFF
--- a/doc/ctlseqs.xml
+++ b/doc/ctlseqs.xml
@@ -1951,6 +1951,8 @@ DECTSR		462
             <!-- 0x8D -->
             <p>Reverse Index—moves the cursor up one, scrolling the screen
                 if the cursor is already at the top margin.</p>
+            <p>Resets the <a href="#lcf">Last Column Flag</a> for all emulations
+                except VT100/VT102.</p>
         </section>
         <section role="ctlseq" id="ssg2l" ctlseq="ESC N" mnemonic="SS2" title="Single shift G2, left" groups="isvt220 isansi">
             <ref src="e48:84"/>
@@ -2296,8 +2298,11 @@ DECTSR		462
             <p>If autoscroll is on (<tt>set term autoscroll on</tt>), the cursor is at
                 the bottom margin, and the cursor is not in a protected region
                 the terminal scrolls up one line. Otherwise, the cursor remains at the end
-                of the line
+                of the line.
             </p>
+
+            <p>Resets the <a href="#lcf">Last Column Flag</a> for all emulations
+                except VT520/K95.</p>
 
             <p badges="s97801">
                 If in page mode and the cursor is at the bottom margin, the cursor is sent
@@ -2401,6 +2406,10 @@ DECTSR		462
             <ref src="vt52x:336"/>
             <termsupp first="vt100" series="vt" additional="vt330 vt340 putty tt dtterm wt"/>
             <p>Horizontal Tab—sends the cursor to the next tabstop. </p>
+            <p badges="vt220 vt220pc">
+                The VT220 emulation clears the
+                <a href="#lcf">Last Column Flag</a> on Horizontal Tab.
+            </p>
         </section>
         <section id="vt" role="ctlchar" mnemonic="VT" ctlseq="VT" title="Vertical Tab">
             <ref src="e48:88"/>
@@ -6683,6 +6692,8 @@ DCS $ q 3 , } ST</pre>
             <termsupp first="vt220" series="vt" additional="vt330 vt340 vt420 vt510 tt linux putty dtterm wt"/>
             <ctlseq>CSI <param-single/> @</ctlseq>
             <p>Insert <param-single/> characters.</p>
+            <p>Resets the <a href="#lcf">Last Column Flag</a> for all emulations
+                except VT520/K95.</p>
         </section>
 
         <section role="ctlseq" id="sl" mnemonic="SL" title="Scroll Left/Pan right">
@@ -6815,7 +6826,8 @@ DCS $ q 3 , } ST</pre>
             <termsupp first="vt100" series="vt" additional="vt132 vt220 vt330 vt340 vt420 vt510 tt linux sco putty dtterm wt"/>
             <ctlseq>CSI <param-single/> C</ctlseq>
             <p>Cursor Right <param-single/> times (default = 1) staying on the
-            same line. Clears the <a href="#lcf">Last Column Flag</a></p>
+            same line. Clears the <a href="#lcf">Last Column Flag</a> for all
+            emulations except VT100/VT102</p>
         </section>
         <section role="ctlseq" mnemonic="GSS" title="Graphic Size Selection"
                  not-implemented="true" todo="true">
@@ -7006,6 +7018,8 @@ DCS $ q 3 , } ST</pre>
             <p>Send cursor to row;column. Default is 1;1. Implementation is
             shared with <a href="#hvp">HVP</a>.
                 Affected by <a href="#decom">DECOM</a>.</p>
+            <p>Resets the <a href="#lcf">Last Column Flag</a> for all emulations
+                except VT100/VT102.</p>
             <p badges="s97801">
                 If DECSASD is set to the status line, it is reset to terminal.
             </p>
@@ -7076,7 +7090,8 @@ DCS $ q 3 , } ST</pre>
             <ref src="vt52x:334"/>
             <termsupp first="vt100" series="vt" additional="vt132 vt220 vt330 vt340 vt420 vt510 tt linux sco putty dtterm wt"/>
             <p>Erases an area within the display (including attributes)</p>
-
+            <p>Resets the <a href="#lcf">Last Column Flag</a> for all emulations
+                except VT100/VT102.</p>
             <!-- TODO: When we do DECSLRM, we can do this too perhaps -->
             <p>For the SNI-97801 terminal type, K95 <em>should</em> only clear
                 within the scroll region, but currently K95 ignores the left and
@@ -7426,6 +7441,8 @@ DCS $ q 3 , } ST</pre>
             <termsupp first="vt100" series="vt" additional="vt132 vt220 vt330 vt340 vt420 vt510 tt linux sco putty dtterm wt"/>
             <ctlseq>CSI <param-single/> K</ctlseq>
             <p>Erase in Line. Erases within a single line.</p>
+            <p>Resets the <a href="#lcf">Last Column Flag</a> for all emulations
+                except VT100/VT102.</p>
             <section role="parameter" id="el-0" title="Clear to end of line with space">
                 <ctlseq><param-single/> = 0</ctlseq>
                 <ref src="xt:h4-Functions-using-CSI-_-ordered-by-the-final-character-lparen-s-rparen:CSI-Ps-K:Ps-=-0.1DDD"/>
@@ -7988,6 +8005,8 @@ DCS $ q 3 , } ST</pre>
             <termsupp first="vt102" series="vt" additional="vt132 vt220 vt330 vt340 vt420 vt510 tt linux sco putty dtterm wt"/>
             <ctlseq>CSI <param-single/> P</ctlseq>
             <p>Delete <param-single/> characters.</p>
+            <p>Resets the <a href="#lcf">Last Column Flag</a> for all emulations
+                except VT100/VT102.</p>
         </section>
 
         <section role="ctlseq" id="ppa" mnemonic="PPA"
@@ -9196,6 +9215,8 @@ DCS $ q 3 , } ST</pre>
                 implemented for compatibility with printing terminals.
                 Applications should use <a href="#cup">CUP</a> instead.
             </p>
+            <p>Resets the <a href="#lcf">Last Column Flag</a> for all emulations
+                except VT100/VT102.</p>
             <p badges="s97801">
                 If DECSASD is set to the status line, it is reset to terminal.
             </p>

--- a/kermit/k95/ckoco3.c
+++ b/kermit/k95/ckoco3.c
@@ -533,6 +533,7 @@ int      savedwrap[SAVED_CURSORS]={FALSE,FALSE,FALSE,FALSE,FALSE} ;
 int      savedrow[SAVED_CURSORS] = {0,0,0,0,0};
 int      savedcol[SAVED_CURSORS] = {0,0,0,0,0};
 int      savedpage[SAVED_CURSORS] = {0,0,0,0,0};
+bool     savedlcf[SAVED_CURSORS] = {FALSE,FALSE,FALSE,FALSE,FALSE};
 extern int      tt_rkeys_saved[], tt_rkeys[];
 
 bool     deccolm = FALSE;               /* 80/132-column mode */
@@ -10902,6 +10903,7 @@ savecurpos(int vmode, int x) {          /* x: 0 = cursor X/Y only, 1 = all */
         savedattrib[slot] = attrib;            /* Current DEC character attributes */
         saverelcursor[slot] = relcursor;       /* Cursor addressing mode */
         savedwrap[slot]     = tt_wrap;         /* Wrap mode */
+        savedlcf[slot] = wrapit;    /* Last column flag */
 
         if ( x==1 ) {
             for (i=0; i<4; i++)
@@ -10953,7 +10955,17 @@ restorecurpos(int vmode, int x) {
             crossedoutattribute=savedcrossedoutattribute[slot];
             attrib = savedattrib[slot];
             relcursor = saverelcursor[slot];   /* Restore cursor addressing mode */
+
+            /* TODO: This is proabably for switching in and out of the status
+             * line. Current behaviour is wrong. Status line needs a separate
+             * saved cursor slot, and tt_wrap among other things should only be
+             * saved/restored when switching in and out of the status line. */
             tt_wrap = savedwrap[slot] ;       /* Restore wrap mode */
+
+            if (tt_type != TT_VT100 && tt_type != TT_VT102) {
+                /* The VT10x does not save the last column flag, the rest do */
+                wrapit = savedlcf[slot];
+            }
 
             if ( x==1 ) {                       /* Restore char sets */
                 for (i=0; i<4; i++)
@@ -19208,7 +19220,17 @@ wrtch(unsigned short ch) {
         default:;                       /* Ignore */
         }
     }
-    lgotoxy(vmode,wherex[vmode],wherey[vmode]);
+
+    if (ch == LF && (tt_type == TT_VT100 || tt_type == TT_VT102)) {
+        /* LF does not reset the LCF on a real VT100. The VT220 and VT520
+         * emulating a VT100 do reset the LCF. */
+        bool lcf = wrapit;
+        lgotoxy(vmode,wherex[vmode],wherey[vmode]);
+        wrapit = lcf;
+    } else {
+        lgotoxy(vmode,wherex[vmode],wherey[vmode]);
+    }
+
     if (cursor_on_visible_page(vmode)) {
         /* always mark the Terminal as requiring the update.. if the cursor is
          * on the visible page. */
@@ -20714,7 +20736,19 @@ vtcsi(void)
                 wrapit = FALSE;
             break;
         case 'C':               /* CUF - Cursor forward, stay on same line */
-            cursorright(0);
+            if (tt_type == TT_VT100 || tt_type == TT_VT102) {
+                /* The VT10x and only the VT10x does not reset the
+                 * LCF on CUF. The VT220 and VT520 when emulating a VT100 do.
+                 * cursorright() always resets the LCF, so take a backup before
+                 * calling.
+                 */
+                bool lcf = wrapit;
+                cursorright(0);
+                wrapit = lcf;
+            }
+            else {
+                cursorright(0);
+            }
             break;
         case 'D':               /* CUB - Cursor back, stay on same line */
             cursorleft(0);
@@ -20762,6 +20796,12 @@ vtcsi(void)
                 }
                 clreoscr_escape(VTERM,SP);
             }
+
+            if (tt_type != TT_VT100 && tt_type != TT_VT102) {
+                /* The VT10x and only the VT10x do not clear the LCF on
+                 * erase display. The VT220 and VT520 emulating a VT100 do. */
+                wrapit = FALSE;
+            }
             break;
         case 'V': /* PP - Preceding Page */
 			if (ISVT330(tt_type_mode) || ISVT420(tt_type_mode)) {
@@ -20779,10 +20819,18 @@ vtcsi(void)
                 ba80_fkey_read = -1;
             }
                 /* Erase from cursor to end of line */
-            else if ( private == TRUE )
-                selclrtoeoln(VTERM,SP);
-            else
-                clrtoeoln(VTERM,SP);
+            else {
+                if ( private == TRUE )
+                    selclrtoeoln(VTERM,SP);
+                else
+                    clrtoeoln(VTERM,SP);
+
+                if (tt_type != TT_VT100 && tt_type != TT_VT102) {
+                    /* The VT10x and only the VT10x do not clear the LCF on
+                     * erase line. The VT220 and VT520 emulating a VT100 do. */
+                    wrapit = FALSE;
+                }
+            }
             break;
         case '?':               /* DEC private */
             private = TRUE;
@@ -22151,11 +22199,21 @@ vtcsi(void)
                         cursorena[VTERM] = TRUE ;
                     }
                 }
-                else  /* CUF - Cursor right pn chars */
+                else {
+                    /* CUF - Cursor right pn chars */
+                    bool lcf = wrapit;
                     do {
                         cursorright(0);
                         pn[1] = pn[1] - 1;
                     } while (pn[1] > 0);
+
+                    if (tt_type == TT_VT100 || tt_type == TT_VT102) {
+                        /* The VT10x and only the VT10x does not reset the LCF
+                         * on CUF. The VT220 and VT520 when emulating a VT100
+                         * do. So restore the LCF from the earlier backup  */
+                        wrapit = lcf;
+                    }
+                }
                 break;
             case 'c':
                 if ( zdsext && ISVT220(tt_type) ) {
@@ -22527,7 +22585,8 @@ vtcsi(void)
                 }
                 /* 'H' is also CUP - Direct cursor address for */
                 /* !ansiext, so don't put a break here   */
-            case 'f':   /* HVP - Direct cursor address */
+            case 'f': { /* HVP - Direct cursor address */
+                bool lcf = wrapit;
                 if ( IS97801(tt_type_mode) && decsasd == SASD_STATUS )
                     setdecsasd(SASD_TERMINAL);
 
@@ -22545,22 +22604,22 @@ vtcsi(void)
                     pn[1] = VscrnGetHeight(VTERM)-(tt_status[VTERM]?1:0);
                 if (pn[2] == 0)
                     pn[2] = 1;
-				if (relcursor)
-					pn[2] += vscrn_c_page_margin_left(VTERM) - 1;
+                if (relcursor)
+                    pn[2] += vscrn_c_page_margin_left(VTERM) - 1;
 
-				{
-					/* Ensure coordinates are to the left of screen right, or
-					 * if DECOM is set, the right margin */
-					int r = (relcursor ? vscrn_c_page_margin_right(VTERM)
-									   : VscrnGetWidth(VTERM));
+                {
+                    /* Ensure coordinates are to the left of screen right, or
+                     * if DECOM is set, the right margin */
+                    int r = (relcursor ? vscrn_c_page_margin_right(VTERM)
+                                       : VscrnGetWidth(VTERM));
 
-					/* if this line is double width, then its half length */
-                	if (isdoublewidth(pn[1])) {
-						r = r / 2;
-					}
+                    /* if this line is double width, then its half length */
+                    if (isdoublewidth(pn[1])) {
+                        r = r / 2;
+                    }
 
-					if (pn[2] > r) pn[2] = r;
-				}
+                    if (pn[2] > r) pn[2] = r;
+                }
 
                 wrapit = FALSE;
 
@@ -22573,14 +22632,23 @@ vtcsi(void)
                         if ( decssdt == SSDT_INDICATOR )
                             setdecssdt(SSDT_HOST_WRITABLE);
                         setdecsasd(SASD_STATUS);
-                    }
+                         }
                 }
 
                 if ( decsasd == SASD_STATUS )
                     lgotoxy( VSTATUS, pn[2], 1 );
                 else
                     lgotoxy(VTERM, pn[2], pn[1]);
-                break;
+
+                if (tt_type == TT_VT100 || tt_type == TT_VT102) {
+                    /* The VT10x and only the VT10x does not reset the
+                     * LCF on CUP or HVP. The VT220 and VT520 when emulating a
+                     * VT100 do. So restore the LCF from a backup taken earlier.
+                     */
+                    wrapit = lcf;
+                }
+            }
+            break;
             case 'I':
                 if ( ansiext && private ) {
                     if ( ISBA80(tt_type_mode) ) {
@@ -25681,6 +25749,13 @@ vtcsi(void)
                             break;
                         }
                     }
+
+                    if (tt_type != TT_VT100 && tt_type != TT_VT102) {
+                        /* The VT10x and only the VT10x do not clear the LCF on
+                         * erase display. The VT220 and VT520 emulating a VT100
+                         * do. */
+                        wrapit = FALSE;
+                    }
                 } else {
                     /* Erase in Display (ED) */
                     /* ??? For the 97801, the called functions must be */
@@ -25869,6 +25944,13 @@ vtcsi(void)
                         break;
                     default:
                         break;
+                    }
+
+                    if (tt_type != TT_VT100 && tt_type != TT_VT102) {
+                        /* The VT10x and only the VT10x do not clear the LCF on
+                         * erase line. The VT220 and VT520 emulating a VT100
+                         * do. */
+                        wrapit = FALSE;
                     }
                 }
                 break;
@@ -26218,6 +26300,13 @@ vtcsi(void)
                     default:
                         break;
                     }
+
+                    if (tt_type != TT_VT100 && tt_type != TT_VT102) {
+                        /* The VT10x and only the VT10x do not clear the LCF on
+                         * erase line. The VT220 and VT520 emulating a VT100
+                         * do. */
+                        wrapit = FALSE;
+                    }
                 }
                 break;
             case 'L':
@@ -26462,6 +26551,13 @@ vtcsi(void)
                                    pn[1],
                                    blankvcell
                                    );
+
+                    if (tt_type != TT_VT520 && tt_type != TT_VT525 &&
+                            tt_type != TT_K95) {
+                        /* The VT220 and 420 clear the LCF on ICH. The VT520
+                         * does not. */
+                        wrapit = FALSE;
+                    }
                 }
                 break;
             case 'N':
@@ -26569,6 +26665,12 @@ vtcsi(void)
                                    pn[1],
                                    blankvcell
                                    ) ;
+
+                    if (tt_type != TT_VT100 && tt_type != TT_VT102) {
+                        /* The VT10x and only the VT10x do not clear the LCF on
+                         * DCH. The VT220 and VT520 emulating a VT100 do. */
+                        wrapit = FALSE;
+                    }
                 }
                 break;
             case 'Q':   /* SEE - Select Editing Extent */
@@ -28631,8 +28733,19 @@ vtescape( void )
                                  FALSE,
                                  SP,
                                  vscrn_current_page_number(vmode, FALSE) );
-                else
+                else if (tt_type == TT_VT100 || tt_type == TT_VT102) {
+                    /* The VT10x and only the VT10x does not reset the
+                     * LCF on RI. The VT220 and VT520 when emulating a VT100 do.
+                     * cursorup() always resets the LCF, so take a backup before
+                     * calling.
+                     */
+                    bool lcf = wrapit;
                     cursorup(0);
+                    wrapit = lcf;
+                }
+                else {
+                    cursorup(0);
+                }
             }
             else if ( ISH19(tt_type_mode) && achar == 'M' ) {
                 /* H19 - Delete Line */
@@ -29439,6 +29552,13 @@ vt100(unsigned short vtch) {
                  sendchars(answerback,strlen(answerback)) ;
              break;
          case HT:               /* Horizontal tab */
+             if (tt_type_mode == TT_VT220 || tt_type_mode == TT_VT220PC) {
+                 /* The VT220, and only the VT220, clears the last column flag
+                  * on TAB. STD-070 says it should too, but given all later
+                  * terminals don't do this I guess DEC decided it was a bad
+                  * idea. */
+                 wrapit = FALSE;
+             }
              cursortab(1);
              break;
          case SYN:      /* Ctrl-V - AVATAR AVTCODE */


### PR DESCRIPTION
Most of these affected the VT100 emulation which doesn't reset the LCF for a bunch of things.

As tested by wraptest, the VT100/102 and VT220 emulations match the wraptest results for the real terminals, and the K95 terminal type matches the VT520
```
								 K95     K95         K95
					 XTe DEC 100 102 220 220 420 520 K95
wrap works           y   y   y   y	 y   y   y   y   y
wrap is deferred     y   y   y   y	 y   y   y   y   y
CPR beyond last col  n   n   n   n	 n   n   n   n   n
CR works at margin   y   y   y   y	 y   y   y   y   y
BS works at margin   y   y   y   y	 y   y   y   y   y
TAB wraps at margin  n   n   n   n	 n   n   n   n   n
TAB cancels wrap     n   y   n   n	 y   y   n   n   n
NL cancels wrap      y   y   n   n	 y   y   y   y   y
NUL cancels wrap     n   n   n   n	 n   n   n   n   n
BEL cancels wrap     n   n   n   n	 n   n   n   n   n
RI cancels wrap      y   y   n   n	 y   y   y   y   y
SGR cancels wrap     n   n   n   n	 n   n   n   n   n
SM cancels wrap      n   n   n   n	 n   n   n   n   n
CUP cancels wrap     y   y   n   n	 y   y   y   y   y
CUF cancels wrap     y   y   n   n	 y   y   y   y   y
EL cancels wrap      y   y   n   n	 y   y   y   y   y
ED cancels wrap      y   y   n   n	 y   y   y   y   y
DCH cancels wrap     y   y   n   n	 y   y   y   y   y
ICH cancels wrap     y   y   -   y	 y   y   y   n   n
ECH cancels wrap     y   y   -   n	 y   n   y   y   n
CPR cancels wrap     n   n   n   n	 n   n   n   n   n
DECSC cancels wrap   n   n   n   n	 n   n   n   n   n
DECRC restores wrap  y   y   n   n	 y   y   y   y   y
DECRC restores AWM   n   n   n   y	 n   y   n       y
DECRC restores !AWM  n   n   n   y	 n   y   n       y
```

The wraptest results were checked on my VT520, VT220-Z, and an emulated VT100, so K95 should now be matching the real behaviour of these terminals at least as far as wraptest is concerned.

AWM being saved/restored by DECSC/DECRC will be dealt with later by #517.