### PR TITLE
Change ruled lines to not be affected by DECLRMM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,8 +56,8 @@ env:
   KFW_x86: https://web.mit.edu/kerberos/dist/kfw/4.1/kfw-4.1-i386.msi
   KFW_x86_64: https://web.mit.edu/kerberos/dist/kfw/4.1/kfw-4.1-amd64.msi
   # Infozip
-  #INFOZIP_FTP: https://ftp.zx.net.nz/pub/archive/ftp.info-zip.org/pub/infozip/
-  INFOZIP_FTP: ftp://ftp.info-zip.org/pub/infozip/
+  INFOZIP_FTP: https://ftp.zx.net.nz/pub/archive/ftp.info-zip.org/pub/infozip/
+  #INFOZIP_FTP: ftp://ftp.info-zip.org/pub/infozip/
   # Use JOM instead of nmake for parallel builds
   JOM: https://download.qt.io/official_releases/jom/jom.zip
   # Download it from sourceforge distribution page

--- a/doc/ctlseqs.xml
+++ b/doc/ctlseqs.xml
@@ -3198,6 +3198,11 @@ DECTSR		462
                 double-height or double-wide attributes set will scroll twice as
                 fast as lines without those attributes set.
             </p>
+            <p>
+                If the screen scrolls to the right, any
+                <a href="#decdrlbr">Ruled Lines</a> on the screen are
+                unaffected. They do not move.
+            </p>
         </section>
         <section role="ctlseq" id="scp" mnemonic="SCP" ctlseq="ESC 7"
                  title="Save Cursor (ANSI)" groups="isansi" badges="aaa">
@@ -3265,6 +3270,11 @@ DECTSR		462
                 at the right margin, it scrolls the screen one column to the left.
                 Clears the <a href="#lcf">Last Column Flag</a> if the current
                 position is to the left of the right margin.
+            </p>
+            <p>
+                If the screen scrolls to the left, any
+                <a href="#decdrlbr">Ruled Lines</a> on the screen are
+                unaffected. They do not move.
             </p>
         </section>
         <section role="ctlseq" id="zgua" ctlseq="ESC :" mnemonic="zGUA" title="Guard Unprotected Areas" not-implemented="true" badges="aaa">
@@ -16939,7 +16949,7 @@ DCS $ q 3 , } ST</pre>
                 <a href="#decerlbra">DECERLBRA</a>. They are treated as an
                 attribute on character cells themselves, so control sequences
                 that move or remove character cells will affect ruled lines.
-                Control sequences that  delete charcter cells such as
+                Control sequences that delete charcter cells such as
                 <a href="#dl">DL</a> will also delete any ruled lines in the
                 affected area, while those that move character cells like
                 <a href="#il">IL</a> or scrolling will move ruled lines.
@@ -17013,14 +17023,15 @@ DCS $ q 3 , } ST</pre>
             </p>
             <p>
                 When ruled lines cross left/right margins, the line segements
-                within the margins will scroll with text in the margins. DECterm
-                does not do this as DECterm does not support setting left/right
-                margins. WRQ Reflection 8.0.2 also chooses not to do this even
-                though it <em>does</em> support left/right margins. Should a
-                good reason for Reflections behaviour surface (DEC has not
-                <em>publicly</em> defined what should happen in this case)
-                Kermit 95 may change to match it so this behaviour should not be
-                relied upon.
+                within the margins will <em>not</em> scroll with the text in
+                the margins. Ruled lines only scroll when the entire line
+                scrolls. This is consistent with the only other terminal
+                emulators that implement this feature - DECterm (which does not
+                support left/right marigns) and WRQ Reflection (which behaves
+                the same way as K95 when left/right margins are involved). It is
+                also consistent with other features from the Horizontal Scrolling
+                extension (of which DECLRMM is a part) such as DECFI, DECBI, ICH
+                and DCH not affecting ruled lines.
             </p>
             <p>
                 Ruled Lines are only supported on Windows under K95G. The console
@@ -19592,6 +19603,11 @@ DCS $ q 3 , } ST</pre>
                 right margin shifting right. If the cursor is outside the page
                 margins, DECIC is ignored.
             </p>
+            <p>
+                Any <a href="#decdrlbr">Ruled Lines</a> on the screen between
+                the cursor and the right margin are unaffected - the are not
+                shifted right.
+            </p>
         </section>
         <section role="ctlseq" id="decsasd"
                  mnemonic="DECSASD" title="Select Active Status Display">
@@ -19797,6 +19813,11 @@ DCS $ q 3 , } ST</pre>
                 the right margin towards the cursor. One or more empty columns
                 are inserted at the right margin. If the cursor is outside the
                 page margins, DECDC is ignored.
+            </p>
+            <p>
+                Any <a href="#decdrlbr">Ruled Lines</a> on the screen between
+                the cursor and the right margin are unaffected - the are not
+                shifted towards the cursor.
             </p>
         </section>
         <section role="ctlseq" id="decssdt"

--- a/kermit/k95/ckoco2.c
+++ b/kermit/k95/ckoco2.c
@@ -3602,58 +3602,6 @@ VscrnSetBufferSize( BYTE vmode, ULONG newsize, int new_page_count )
     return rc ;
 }
 
-#ifdef KUI
-#ifdef PACKED_CELL_ATTRS
-/* Copies a range of cell attributes from one packed array of attributes to
- * another */
-void
-copy_cell_attrs(videoline *dest, videoline *source, int start, int end) {
-    if (start%2 == 1) {
-        /* Copy only the lower 4 bits at start */
-        CELL_ATTR_SET(dest, start, CELL_ATTR_GET(source, start));
-        start++;
-    }
-    if (end%2 == 0) {
-        /* Copy the upper 4 bits at end manually */
-        CELL_ATTR_SET(dest, end, CELL_ATTR_GET(source, end));
-        end--;
-    }
-
-    /* Copy everything else. Divide by two because we're
-     * storing two cells worth of attributes in each
-     * byte */
-    start = start / 2;
-    end = end / 2;
-    memcpy(dest->cell_attrs + start,
-           source->cell_attrs + start,
-           sizeof(vt_cell_attr_t) * end-start+1);
-}
-
-/* Clears a range of cell attributes in a packed array of attributes.
- */
-void
-clear_cell_attrs(videoline *dest, int start, int end) {
-
-    if (start%2 == 1) {
-        /* Copy only the lower 4 bits at start */
-        CELL_ATTR_SET(dest, start, CA_ATTR_NONE);
-        start++;
-    }
-    if (end%2 == 0) {
-        /* Copy the upper 4 bits at end manually */
-        CELL_ATTR_SET(dest, end, CA_ATTR_NONE);
-        end--;
-    }
-
-    start = start / 2;
-    end = end / 2;
-    memset(dest->cell_attrs + start,
-           CA_ATTR_NONE | CA_ATTR_NONE << 4,
-           sizeof(vt_cell_attr_t) * end);
-
-}
-#endif /* PACKED_CELL_ATTRS */
-#endif /* KUI */
 
 /*---------------------------------------------------------------------------*/
 /* VscrnScrollPage                                          | Page: Specified*/
@@ -3833,16 +3781,6 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
                         memcpy(this_line.vt_char_attrs+leftmargin,
                                next_line.vt_char_attrs+leftmargin,
                                sizeof(vt_char_attr_t) * (rightmargin-leftmargin+1));
-#ifdef KUI
-#ifndef PACKED_CELL_ATTRS
-                        memcpy(this_line.cell_attrs+leftmargin,
-                               next_line.cell_attrs+leftmargin,
-                               sizeof(vt_cell_attr_t) * (rightmargin-leftmargin+1));
-#else /* PACKED_CELL_ATTRS */
-                        copy_cell_attrs(&this_line, &next_line, leftmargin,
-                            rightmargin);
-#endif /* PACKED_CELL_ATTRS */
-#endif /* KUI */
                     }
                 }
 
@@ -3873,15 +3811,6 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
                         memcpy(line->vt_char_attrs+leftmargin,
                                blank_attrs+leftmargin,
                                sizeof(vt_char_attr_t) * (rightmargin-leftmargin+1));
-#ifdef KUI
-#ifndef PACKED_CELL_ATTRS
-                        memcpy(line->cell_attrs+leftmargin,
-                               blank_cell_attrs+leftmargin,
-                               sizeof(vt_cell_attr_t) * (rightmargin-leftmargin+1));
-#else /* PACKED_CELL_ATTRS */
-                        clear_cell_attrs(line, leftmargin, rightmargin-leftmargin+1);
-#endif /* PACKED_CELL_ATTRS */
-#endif /* KUI */
                     }
                 }
             }
@@ -3927,16 +3856,6 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
                     memcpy(this_line.vt_char_attrs+leftmargin,
                            prev_line.vt_char_attrs+leftmargin,
                            sizeof(vt_char_attr_t) * (rightmargin-leftmargin+1));
-#ifdef KUI
-#ifndef PACKED_CELL_ATTRS
-                    memcpy(this_line.cell_attrs+leftmargin,
-                           prev_line.cell_attrs+leftmargin,
-                           sizeof(vt_cell_attr_t) * (rightmargin-leftmargin+1));
-#else /* PACKED_CELL_ATTRS */
-                    copy_cell_attrs(&this_line, &prev_line, leftmargin,
-                        rightmargin);
-#endif /* PACKED_CELL_ATTRS */
-#endif /* KUI */
                 }
             }
 
@@ -3968,15 +3887,6 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
                     memcpy(line->vt_char_attrs+leftmargin,
                            blank_attrs+leftmargin,
                            sizeof(vt_char_attr_t) * (rightmargin-leftmargin+1));
-#ifdef KUI
-#ifndef PACKED_CELL_ATTRS
-                    memcpy(line->cell_attrs+leftmargin,
-                           blank_cell_attrs+leftmargin,
-                           sizeof(vt_cell_attr_t) * (rightmargin-leftmargin+1));
-#else /* PACKED_CELL_ATTRS */
-                    clear_cell_attrs(line, leftmargin, rightmargin-leftmargin+1);
-#endif /* PACKED_CELL_ATTRS */
-#endif /* KUI */
                 }
             }
             break;


### PR DESCRIPTION
Previously ruled lines between the left and right margins would scroll in the same way as text between those margins. While this was inconsistent with DECterm I considered this OK at the time as DECterm didn't support DECLRMM anyway.

But WRQ Reflection *does* support DECLRMM and it also doesn't scroll ruled lines between the left and right margins. It was also pointed out that none of the other features of the Horizontal Scrolling extension affect ruled lines, so this was perhaps an intentional choice on the part of WRQ.

So this change makes K95s behaviour consistent with all other terminals implementing this feature, reducing the chances of any surprising behaviour now and in the future.