### PR TITLE
Implement ED-3

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -168,6 +168,8 @@ as part of K95 at this time, the default terminal remains VT220 for now.
  - Soft-fonts (DRCS) for VT220 and higher emulations are now supported
  - The VT520 Play Sound control sequence is now supported.
  - Proper Smooth Scroll is now supported in K95G.
+ - New `CLEAR TERMINAL SCROLLBACK-ONLY` command. Clears the scrollback while
+   preserving current terminal screen contents.
 
 ### Enhancements
  - The Control Sequences documentation ([preliminary version available online](https://davidrg.github.io/ckwin/dev/ctlseqs.html))
@@ -405,7 +407,8 @@ as part of K95 at this time, the default terminal remains VT220 for now.
  - [DECSCLM](https://davidrg.github.io/ckwin/dev/ctlseqs.html#decsclm) - Smooth Scroll (K95G only)
  - [DECSSCLS](https://davidrg.github.io/ckwin/dev/ctlseqs.html#decsscls) - Set Scroll Speed
  - DSR-85 Multiple Session Configuration Status Report (VT420 and up) now 
-   reports not configured.   
+   reports not configured.
+ - [ED-3 (xt)](https://davidrg.github.io/ckwin/dev/ctlseqs.html#ed-3xt) - Clear Scrollback (K95 only), xterm extension
 
 ### Fixed Bugs
  - Fixed an issue introduced in beta 7 which could cause SSH connections made

--- a/doc/changes.md
+++ b/doc/changes.md
@@ -524,6 +524,10 @@ as part of K95 at this time, the default terminal remains VT220 for now.
    history for K95 I've no way of knowing what change broke it, so I've removed 
    the code that was preventing it from being considered a national replacement 
    character set which seems to have fixed it. (K95 bug 842)
+ - Fixed the Clear Scrollback option causing a crash if the terminal is busy
+   receiving a lot of data. Previously K95 would delete and recreate the buffer,
+   now instead it will just reuse the existing one erasing lines as they are
+   reused.
 
 ## Kermit 95 v3.0 beta 7 - 27 January 2025
 

--- a/doc/ctlseqs.xml
+++ b/doc/ctlseqs.xml
@@ -7185,10 +7185,19 @@ DCS $ q 3 , } ST</pre>
                     and clears the <a href="#lcf">Last Column Flag</a>.</p>
             </section>
             <section role="parameter" id="ed-3xt" title="Erase Saved Lines"
-                     not-implemented="true" todo="true">
+                     badges="k95 xterm">
                 <ctlseq><param-single/> = 3</ctlseq>
                 <ref src="xt:h4-Functions-using-CSI-_-ordered-by-the-final-character-lparen-s-rparen:CSI-Ps-J:Ps-=-3.1DDF"/>
                 <termsupp first="xterm" series="xt" additional="linux putty"/>
+                <p>
+                    Erases scrollback while preserving the current contents of
+                    the terminal screen.
+                </p>
+                <p>
+                    Note that data formerly visible in scrollback is <em>not</em>
+                    erased from memory, it is just rendered inaccessible via
+                    scrollback and will eventually be overwritten by new data.
+                </p>
             </section>
             <section role="parameter" badges="s97801" id="ed-3" title="Clear to end of screen with Space">
                 <ctlseq><param-single/> = 3</ctlseq>
@@ -7421,12 +7430,16 @@ DCS $ q 3 , } ST</pre>
                 <ref src="vt510:DECSED.html"/>
                 <termsupp first="vt220" series="vt" additional="vt330 vt340 vt420 vt510 tt dtterm wt"/>
             </section>
-            <section role="parameter" id="decsed-3xt"
-                     title="Selective Erase Saved Lines"
-                     not-implemented="true" todo="true">
+            <section role="parameter" id="decsed-3xt" badges="k95 xterm"
+                     title="Selective Erase Saved Lines">
                 <ctlseq><param-single/> = 3</ctlseq>
                 <ref src="xt:h4-Functions-using-CSI-_-ordered-by-the-final-character-lparen-s-rparen:CSI-?-Ps-J:Ps-=-3.1E4B"/>
                 <termsupp first="xterm" series="xt" additional=""/>
+                <p>
+                    While the Xterm documentation calls this selective erase,
+                    the actual implementation in xterm-409b is the same as for
+                    <a href="#ed-3xt">ED-3</a> and K95 does the same.
+                </p>
             </section>
         </section>
         <section role="ctlseq" id="SGF" mnemonic="SGF"

--- a/doc/manual/kverbs.html
+++ b/doc/manual/kverbs.html
@@ -33,89 +33,90 @@ The first group are for general use and are independent of which terminal
 is being emulated.
 <p>
 <pre>
-   \Kanswerback    Transmit answerback string to host
-   \Kautodownload  Toggle on/off terminal autodownload.
-   \Kbacknext      Continue backward search
-   \Kbacksearch    Begin backward search 
-   \Kbreak         Transmit a BREAK signal
-   \Kbytesize      Toggle terminal bytesize between 7 and 8 bits.
-   \Kclearscreen   Clear the Terminal screen
-   \Kcompose 	   Compose an accented character
-   \Kdebug         Enter/exit Terminal Debug mode
-   \Kdnarr         Transmit Terminal Down Arrow sequence
-   \Kdnone         Roll screen down one line
-   \Kdnhscn        Roll screen down half of one page
-   \Kdnscn         Roll screen down one page
-   \Kdos           "Push" to command shell
-   \Kdump          Dump the current screen text to SET PRINTER device
-   \Kendscn        Roll screen to the bottom of buffer
-   \Kexit          Exit terminal mode
-   \Kflipscn       Reverse foreground and background colors
-   \Kfnkeys        Display function key labels in HP and Wyse emulations
-   \Kfwdnext       Continue forward search
-   \Kfwdsearch     Begin forward search
-   \Kgobook        Goto bookmark in rollback buffer
-   \Kgoto          Goto line number in rollback buffer
-   \Khangup        Hangup line and return to command prompt
-   \Khelp          Display popup help
-   \Kholdscrn      Pause data input
-   \Khomscn        Roll screen to beginning of buffer
-   \Kignore        Ignore keystroke
-   \Kkbemacs       Switch to EMACS keyboard mode
-   \Kkbenglish     Switch to normal keyboard mode
-   \Kkbhebrew      Switch to HEBREW keyboard mode
-   \Kkbrussian     Switch to Russian keyboard mode
-   \Kkbwp          Switch to Word Perfect 5.1 keyboard mode
-   \Kkeyclick      Toggle Keyclick On/Off
-   \Klbreak        Transmit Long Break signal
-   \Klfall         Scroll to left margin
-   \Klfarr         Transmit Terminal Left Arrow sequence
-   \Klfone         Scroll left one column
-   \Klfpage        Scroll left eight columns
-   \Klogoff        Turn Session Log Off
-   \Klogon         Turn Session Log On
-   \Kmarkcancel    Cancel Mark Mode
-   \Kmarkcopyclip  Copy marked text to clipboard
-   \Kmarkcopyhost  Copy marked text to host
-   \Kmarkstart     Start Mark Mode  <!--       \Kmarkselect is marked as invisible
-   \Kmarkselect    Mark Mode: Place marked text into \v(select)           -->
-   \Kmousecurpos   Transmit sequence to move cursor to mouse position
-   \Kmousemark     Mouse drag sequence marks text
-   \Kmouseurl      Start Browser with selected URL
-   \Knull          Transmit Null to host
-   \Kos2           "Push" to command shell
-   \Kpaste         Paste text from clipboard to host
-   \Kprintff       Send Formfeed to SET PRINTER device
-   \Kprtauto       Toggle Auto-print mode
-   \Kprtcopy       Toggle Copy-Print mode
-   \Kprtctrl       Toggle Ctrl-print mode
-   \Kquit          Disconnect from host and terminate Kermit
-   \Kreset         Reset terminal
-   \Krtall         Scroll to right margin
-   \Krtarr         Transmit Terminal Right Arrow sequence
-   \Krtone         Scroll right one column
-   \Krtpage        Scroll right eight columns
-   \Ksession       Toggle on/off session logging to 'session.log' <!--
-   \Kdebuglog      Toggle Debug Logging to File                      This Kverb is marked invisible-->
-   \Ksetbook       Set bookmark 
-   \Kstatus        Toggle statusline (None, Indicator, Host Writeable)
-   \Ktermtype      Toggle Terminal Type
-   \Ktn_ao         Transmit Telnet Cancel-Output request
-   \Ktn_ayt        Transmit Telnet "are you there?" request
-   \Ktn_ec         Transmit Telnet Erase Character request
-   \Ktn_el         Transmit Telnet Erase Line request
-   \Ktn_ga         Transmit Telnet Go Ahead request
-   \Ktn_ip         Transmit Telnet "interrupt process" request
-   \Ktn_logout     Transmit Telnet Do Logout Option
-   \Ktn_naws       Transmit Window Size (if Telnet NAWS is active)
-   \Ktn_sak        Transmit AIX Trusted Shell request
-   \Kucs2          Unicode UCS-2 U+xxxx Compose Key
-   \Kuparr         Transmit Terminal Up Arrow sequence
-   \Kupone         Roll screen up one line
-   \Kuphscn        Roll screen up half of one page
-   \Kupscn	       Roll screen up one page
-   \Kurl           Treat text under cursor position as a URL <!--  \Kemacs_overwrite is marked as invisible
-   \Kemacs_overwrite  Transmit EMACS Overwrite toggle command sequence -->
+   \Kanswerback      Transmit answerback string to host
+   \Kautodownload    Toggle on/off terminal autodownload.
+   \Kbacknext        Continue backward search
+   \Kbacksearch      Begin backward search
+   \Kbreak           Transmit a BREAK signal
+   \Kbytesize        Toggle terminal bytesize between 7 and 8 bits.
+   \Kclearscreen     Clear the Terminal screen
+   \Kclearscrollback Clear the terminal screen and scrollback buffer
+   \Kcompose 	     Compose an accented character
+   \Kdebug           Enter/exit Terminal Debug mode
+   \Kdnarr           Transmit Terminal Down Arrow sequence
+   \Kdnone           Roll screen down one line
+   \Kdnhscn          Roll screen down half of one page
+   \Kdnscn           Roll screen down one page
+   \Kdos             "Push" to command shell
+   \Kdump            Dump the current screen text to SET PRINTER device
+   \Kendscn          Roll screen to the bottom of buffer
+   \Kexit            Exit terminal mode
+   \Kflipscn         Reverse foreground and background colors
+   \Kfnkeys          Display function key labels in HP and Wyse emulations
+   \Kfwdnext         Continue forward search
+   \Kfwdsearch       Begin forward search
+   \Kgobook          Goto bookmark in rollback buffer
+   \Kgoto            Goto line number in rollback buffer
+   \Khangup          Hangup line and return to command prompt
+   \Khelp            Display popup help
+   \Kholdscrn        Pause data input
+   \Khomscn          Roll screen to beginning of buffer
+   \Kignore          Ignore keystroke
+   \Kkbemacs         Switch to EMACS keyboard mode
+   \Kkbenglish       Switch to normal keyboard mode
+   \Kkbhebrew        Switch to HEBREW keyboard mode
+   \Kkbrussian       Switch to Russian keyboard mode
+   \Kkbwp            Switch to Word Perfect 5.1 keyboard mode
+   \Kkeyclick        Toggle Keyclick On/Off
+   \Klbreak          Transmit Long Break signal
+   \Klfall           Scroll to left margin
+   \Klfarr           Transmit Terminal Left Arrow sequence
+   \Klfone           Scroll left one column
+   \Klfpage          Scroll left eight columns
+   \Klogoff          Turn Session Log Off
+   \Klogon           Turn Session Log On
+   \Kmarkcancel      Cancel Mark Mode
+   \Kmarkcopyclip    Copy marked text to clipboard
+   \Kmarkcopyhost    Copy marked text to host
+   \Kmarkstart       Start Mark Mode  <!--   \Kmarkselect is marked as invisible
+   \Kmarkselect      Mark Mode: Place marked text into \v(select)           -->
+   \Kmousecurpos     Transmit sequence to move cursor to mouse position
+   \Kmousemark       Mouse drag sequence marks text
+   \Kmouseurl        Start Browser with selected URL
+   \Knull            Transmit Null to host
+   \Kos2             "Push" to command shell
+   \Kpaste           Paste text from clipboard to host
+   \Kprintff         Send Formfeed to SET PRINTER device
+   \Kprtauto         Toggle Auto-print mode
+   \Kprtcopy         Toggle Copy-Print mode
+   \Kprtctrl         Toggle Ctrl-print mode
+   \Kquit            Disconnect from host and terminate Kermit
+   \Kreset           Reset terminal
+   \Krtall           Scroll to right margin
+   \Krtarr           Transmit Terminal Right Arrow sequence
+   \Krtone           Scroll right one column
+   \Krtpage          Scroll right eight columns
+   \Ksession         Toggle on/off session logging to 'session.log' <!--
+   \Kdebuglog        Toggle Debug Logging to File                      This Kverb is marked invisible-->
+   \Ksetbook         Set bookmark
+   \Kstatus          Toggle statusline (None, Indicator, Host Writeable)
+   \Ktermtype        Toggle Terminal Type
+   \Ktn_ao           Transmit Telnet Cancel-Output request
+   \Ktn_ayt          Transmit Telnet "are you there?" request
+   \Ktn_ec           Transmit Telnet Erase Character request
+   \Ktn_el           Transmit Telnet Erase Line request
+   \Ktn_ga           Transmit Telnet Go Ahead request
+   \Ktn_ip           Transmit Telnet "interrupt process" request
+   \Ktn_logout       Transmit Telnet Do Logout Option
+   \Ktn_naws         Transmit Window Size (if Telnet NAWS is active)
+   \Ktn_sak          Transmit AIX Trusted Shell request
+   \Kucs2            Unicode UCS-2 U+xxxx Compose Key
+   \Kuparr           Transmit Terminal Up Arrow sequence
+   \Kupone           Roll screen up one line
+   \Kuphscn          Roll screen up half of one page
+   \Kupscn	         Roll screen up one page
+   \Kurl             Treat text under cursor position as a URL <!--  \Kemacs_overwrite is marked as invisible
+   \Kemacs_overwrite Transmit EMACS Overwrite toggle command sequence -->
 </pre>
 <p>
 For use with SCOANSI and AT386 emulations:

--- a/kermit/k95/ckoco2.c
+++ b/kermit/k95/ckoco2.c
@@ -2369,6 +2369,28 @@ VscrnGetLineFromTop( BYTE vmode, SHORT y, BOOL view_page )
 }
 
 /*----------------------------------------------------------+----------------*/
+/* VscrnGetPagePage                                         | Page: Specified*/
+/*----------------------------------------------------------+----------------*/
+videoline *
+VscrnGetPageLine( BYTE vmode, SHORT y, int page_number )  /* zero based */
+{
+    vscrn_page_t* page;
+
+    if ( vmode == VTERM && decsasd == SASD_STATUS )
+        vmode = VSTATUS ;
+
+    if ( !vscrn_view_page_valid(vmode) )
+        return(NULL);
+
+    page = &vscrn[vmode].pages[page_number];
+
+    while ( y < 0 )
+        y += page->linecount ;
+
+    return &page->lines[y%page->linecount] ;
+}
+
+/*----------------------------------------------------------+----------------*/
 /* VscrnGetLine                                             | Page: View     */
 /*----------------------------------------------------------+----------------*/
 videoline *
@@ -3627,27 +3649,39 @@ VscrnSetBufferSize( BYTE vmode, ULONG newsize, int new_page_count )
 }
 
 
+/*---------------------------------------------------------------------------*/
+/* VscrnCopyLine                                            | Page: All      */
+/*---------------------------------------------------------------------------*/
+/* Copies the contents of one videoline to another */
+void
+VscrnCopyLine(videoline *source, videoline *dest) {
+    dest->width = source->width;
+    dest->vt_line_attr = source->vt_line_attr;
+    dest->markbeg = source->markbeg;
+    dest->markshowend = source->markshowend;
+    dest->markend = source->markend;
+    memcpy(dest->cells,
+        source->cells,
+        sizeof(viocell) * MAXTERMCOL);
+    memcpy(dest->vt_char_attrs,
+        source->vt_char_attrs,
+        sizeof(vt_char_attr_t) * MAXTERMCOL);
+#ifdef KUI
+    memcpy(dest->cell_attrs,
+        source->cell_attrs,
+        sizeof(vt_cell_attr_t) * CELL_ATTR_LEN);
+#endif /* KUI */
+    memcpy(dest->hyperlinks,
+        source->hyperlinks,
+        sizeof(unsigned short) * MAXTERMCOL);
+}
+
+
 #ifdef KUI
 /* Takes a backup copy of a video line for smooth scroll operations */
 void
 BackupLineForSmoothScroll(videoline *line) {
-    s_scroll_backup_line.width = line->width;
-    s_scroll_backup_line.vt_line_attr = line->vt_line_attr;
-    s_scroll_backup_line.markbeg = line->markbeg;
-    s_scroll_backup_line.markshowend = line->markshowend;
-    s_scroll_backup_line.markend = line->markend;
-    memcpy(s_scroll_backup_line.cells,
-        line->cells,
-        sizeof(viocell) * MAXTERMCOL);
-    memcpy(s_scroll_backup_line.vt_char_attrs,
-        line->vt_char_attrs,
-        sizeof(vt_char_attr_t) * MAXTERMCOL);
-    memcpy(s_scroll_backup_line.cell_attrs,
-        line->cell_attrs,
-        sizeof(vt_cell_attr_t) * MAXTERMCOL);
-    memcpy(s_scroll_backup_line.hyperlinks,
-        line->hyperlinks,
-        sizeof(unsigned short) * MAXTERMCOL);
+    VscrnCopyLine(line, &s_scroll_backup_line);
 }
 #endif /* KUI */
 
@@ -3794,7 +3828,7 @@ VscrnScrollPage(BYTE vmode, int updown, int topmargin, int bottommargin,
                 memset(s_scroll_backup_line.vt_char_attrs, 0,
                     sizeof(vt_char_attr_t) * MAXTERMCOL);
                 memset(s_scroll_backup_line.cell_attrs, 0,
-                    sizeof(vt_cell_attr_t) * MAXTERMCOL);
+                    sizeof(vt_cell_attr_t) * CELL_ATTR_LEN);
                 memset(s_scroll_backup_line.hyperlinks, 0,
                     sizeof(unsigned short) * MAXTERMCOL);
             }

--- a/kermit/k95/ckoco3.c
+++ b/kermit/k95/ckoco3.c
@@ -14018,7 +14018,7 @@ dokverb(int mode, int k) {                        /* 'k' is the kverbs[] table i
             VscrnIsDirty(mode);
             return;
         case K_CLRSCROLL:
-            clearscrollback(mode);
+            clearscrollback(mode, FALSE);
             VscrnIsDirty(mode);
             return;
         case K_SESSION:
@@ -25837,6 +25837,14 @@ vtcsi(void)
                                 }
                             }
                             break;
+                        case 3: if (ISK95(tt_type_mode) || ISXTERM(tt_type_mode)) {
+                            /* Selective Erase Scrollback (xterm) */
+                            /* While the xterm docuemntation says this is
+                             * selective erase, in xterm-409b it is an
+                             * unselective erase of everything in scrollback */
+                            clearscrollback(VTERM, TRUE);
+                            break;
+                        }
                         default:
                             break;
                         }
@@ -25901,6 +25909,10 @@ vtcsi(void)
                         /* Clear Attributes */
                         if ( IS97801(tt_type_mode) ) {
                             clreoreg_escape(VTERM,NUL);
+                        }
+                        else if (ISK95(tt_type_mode) || ISXTERM(tt_type_mode)) {
+                            /* Erase Scrollback (xterm) */
+                            clearscrollback(VTERM, TRUE);
                         }
                         break;
                     case 4:

--- a/kermit/k95/ckocon.c
+++ b/kermit/k95/ckocon.c
@@ -800,14 +800,10 @@ clearcmdscreen(void) {
 /* eventually be overwritten by new data.                                    */
 void
 clearscrollback( BYTE vmode, BOOL keep_screen ) {
-    ULONG bufsize;
-    bool recreate_buffer=TRUE;
     int page = 0; /* Only page 0 has scrollback */
     int len;
 
     RequestVscrnMutex( vmode, SEM_INDEFINITE_WAIT ) ;
-
-    bufsize = VscrnGetPageBufferSize(vmode, FALSE, 0) ;
 
     if (keep_screen) {
         int i;
@@ -842,52 +838,29 @@ clearscrollback( BYTE vmode, BOOL keep_screen ) {
         return;
     }
 
-    {
-        /* If we're in connect mode, and we arrived here on some thread other
-         * than the RdComWrtScr thread, then it isn't safe to recreate the
-         * buffer as RdComWrtScr isn't great about acquring the Vscrn Mutex.
-         */
-        extern TID tidRdComWrtScr ;
-#ifdef NT
-        DWORD rdComWrtScrThreadId;
-        DWORD thisThread = GetCurrentThreadId();
-        rdComWrtScrThreadId = GetThreadId(tidRdComWrtScr);
-#else /* OS2 */
-        PTIB ptib;
-        PPIB ppib;
-        APIRET rc;
-        TID thisThread;
-        TID rdComWrtScrThreadId = tidRdComWrtScr;
-        rc = DosGetInfoBlocks(&ptib, &ppib);
-        thisThread = ptib->tib_ptib2->tib2_ultid;
+#ifdef COMMENT
+    /* Prior to 3.0 beta 8 this is how K95 always cleared the scrollback,
+     * though I'm not sure why as it's more work than just moving the top,
+     * begin and end. It's also not safe given K95s multi-threaded nature
+     * as the RdComWrtScr thread isn't great about ensuring it has the vscrn
+     * mutex before doing things. Because of this, the K_CLRSCROLL can
+     * cause a crash if the RdComWrtScr thread is busy doing stuff with
+     * the vscrn.
+     */
+    ULONG bufsize = VscrnGetPageBufferSize(vmode, FALSE, 0) ;
+    VscrnSetBufferSize( vmode, 256, vscrn[vmode].page_count ) ;
+    VscrnSetBufferSize( vmode, bufsize, vscrn[vmode].page_count ) ;
+#else
+    /* Instead, just reuse the existing buffer. VscrnScrollPage erases lines as
+     * it reuses them, so the old stuff in the buffer won't ever be visible.
+     * This is much safer and *seems* to work just as well. */
+    VscrnGetPageTop(vmode, FALSE, page) ;
+    len = VscrnGetHeight(vmode) -(tt_status[vmode]?2:1);
+    VscrnSetPageTop(vmode, 0, FALSE, page, TRUE);
+    VscrnSetPageBegin(vmode, 0, page);
+    VscrnSetPageEnd(vmode, len, page) ;
+#endif /* COMMENT */
 
-        if (rc == 0)
-#endif /* NT */
-        if (IsConnectMode() && thisThread != rdComWrtScrThreadId) {
-            recreate_buffer=FALSE;
-        }
-    }
-
-    if (recreate_buffer) {
-        /* Prior to 3.0 beta 8 this is how K95 always cleared the scrollback,
-         * though I'm not sure why as it's more work than just moving the top,
-         * begin and end. It's also not safe given K95s multi-threaded nature
-         * as most of the terminal emulation code doesn't bother to acquire the
-         * Vscrn Mutex before trying to access it. Because of this, the
-         * K_CLRSCROLL can cause a crash if the RdComWrtScr thread is busy doing
-         * stuff with the vscrn.
-         */
-        VscrnSetBufferSize( vmode, 256, vscrn[vmode].page_count ) ;
-        VscrnSetBufferSize( vmode, bufsize, vscrn[vmode].page_count ) ;
-    } else {
-        /* This is much safer and *seems* to work just as well. Probably it
-         * could replace the old implementation entirely. */
-        VscrnGetPageTop(vmode, FALSE, page) ;
-        len = VscrnGetHeight(vmode) -(tt_status[vmode]?2:1);
-        VscrnSetPageTop(vmode, 0, FALSE, page, TRUE);
-        VscrnSetPageBegin(vmode, 0, page);
-        VscrnSetPageEnd(vmode, len, page) ;
-    }
     scrollstatus[vmode] = FALSE ;
     scrollflag[vmode] = FALSE ;
     cursoron[vmode] = FALSE ;

--- a/kermit/k95/ckocon.c
+++ b/kermit/k95/ckocon.c
@@ -793,10 +793,52 @@ clearcmdscreen(void) {
 /*---------------------------------------------------------------------------*/
 /* clearscrollback                                          | Page: First    */
 /*---------------------------------------------------------------------------*/
-/* Clears the scrollback, which is associated with the first page only       */
+/* Clears the scrollback, which is associated with the first page only.      */
+/* Optionally preserves the current contents of the screen, erasing          */
+/* scrollback only. When preserving the current screen, scrollback data is   */
+/* not erased from memory, it is just rendered inaccessible and will         */
+/* eventually be overwritten by new data.                                    */
 void
-clearscrollback( BYTE vmode ) {
-    ULONG bufsize = VscrnGetPageBufferSize(vmode, FALSE, 0) ;
+clearscrollback( BYTE vmode, BOOL keep_screen ) {
+    ULONG bufsize;
+
+    RequestVscrnMutex( vmode, SEM_INDEFINITE_WAIT ) ;
+
+    bufsize = VscrnGetPageBufferSize(vmode, FALSE, 0) ;
+
+    if (keep_screen) {
+        int top, i, len;
+        int page = 0; /* Only page 0 has scrollback */
+
+        /* We can't get away with just setting the page top as the beginning of
+         * the scrollback - KUI won't show this as "scrollback empty", and
+         * VscrnScrollPage will make the old scrollback available again on the
+         * next scroll. So instead we copy the current screen to the top of the
+         * vscreen buffer, then reset the beginning, top and end of the page.
+         */
+
+        top = VscrnGetPageTop(vmode, FALSE, page) ;
+        len = VscrnGetHeight(vmode) -(tt_status[vmode]?2:1);
+
+        /* Copy the contents of the line to the top of the vscreen buffer */
+        for (i = 0; i <= len; i++) {
+            VscrnCopyLine(VscrnGetPageLineFromTop(vmode, i, page),
+                VscrnGetPageLine(vmode, i, page));
+        }
+
+        VscrnSetPageTop(vmode, 0, FALSE, page, TRUE);
+        VscrnSetPageBegin(vmode, 0, page);
+        VscrnSetPageEnd(vmode, len, page) ;
+
+        scrollstatus[vmode] = FALSE ;
+        scrollflag[vmode] = FALSE ;
+        cursoron[vmode] = FALSE ;
+
+        if ( IsConnectMode() || vmode != VTERM )
+            VscrnIsDirty(vmode);
+
+        return;
+    }
 
     VscrnSetBufferSize( vmode, 256, vscrn[vmode].page_count ) ;
     VscrnSetBufferSize( vmode, bufsize, vscrn[vmode].page_count ) ;
@@ -804,6 +846,8 @@ clearscrollback( BYTE vmode ) {
     scrollflag[vmode] = FALSE ;
     cursoron[vmode] = FALSE ;
     cleartermpage(vmode, 0) ;
+
+    ReleaseVscrnMutex(vmode);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/kermit/k95/ckocon.c
+++ b/kermit/k95/ckocon.c
@@ -801,14 +801,16 @@ clearcmdscreen(void) {
 void
 clearscrollback( BYTE vmode, BOOL keep_screen ) {
     ULONG bufsize;
+    bool recreate_buffer=TRUE;
+    int page = 0; /* Only page 0 has scrollback */
+    int len;
 
     RequestVscrnMutex( vmode, SEM_INDEFINITE_WAIT ) ;
 
     bufsize = VscrnGetPageBufferSize(vmode, FALSE, 0) ;
 
     if (keep_screen) {
-        int top, i, len;
-        int page = 0; /* Only page 0 has scrollback */
+        int i;
 
         /* We can't get away with just setting the page top as the beginning of
          * the scrollback - KUI won't show this as "scrollback empty", and
@@ -817,7 +819,7 @@ clearscrollback( BYTE vmode, BOOL keep_screen ) {
          * vscreen buffer, then reset the beginning, top and end of the page.
          */
 
-        top = VscrnGetPageTop(vmode, FALSE, page) ;
+        VscrnGetPageTop(vmode, FALSE, page) ;
         len = VscrnGetHeight(vmode) -(tt_status[vmode]?2:1);
 
         /* Copy the contents of the line to the top of the vscreen buffer */
@@ -840,8 +842,52 @@ clearscrollback( BYTE vmode, BOOL keep_screen ) {
         return;
     }
 
-    VscrnSetBufferSize( vmode, 256, vscrn[vmode].page_count ) ;
-    VscrnSetBufferSize( vmode, bufsize, vscrn[vmode].page_count ) ;
+    {
+        /* If we're in connect mode, and we arrived here on some thread other
+         * than the RdComWrtScr thread, then it isn't safe to recreate the
+         * buffer as RdComWrtScr isn't great about acquring the Vscrn Mutex.
+         */
+        extern TID tidRdComWrtScr ;
+#ifdef NT
+        DWORD rdComWrtScrThreadId;
+        DWORD thisThread = GetCurrentThreadId();
+        rdComWrtScrThreadId = GetThreadId(tidRdComWrtScr);
+#else /* OS2 */
+        PTIB ptib;
+        PPIB ppib;
+        APIRET rc;
+        TID thisThread;
+        TID rdComWrtScrThreadId = tidRdComWrtScr;
+        rc = DosGetInfoBlocks(&ptib, &ppib);
+        thisThread = ptib->tib_ptib2->tib2_ultid;
+
+        if (rc == 0)
+#endif /* NT */
+        if (IsConnectMode() && thisThread != rdComWrtScrThreadId) {
+            recreate_buffer=FALSE;
+        }
+    }
+
+    if (recreate_buffer) {
+        /* Prior to 3.0 beta 8 this is how K95 always cleared the scrollback,
+         * though I'm not sure why as it's more work than just moving the top,
+         * begin and end. It's also not safe given K95s multi-threaded nature
+         * as most of the terminal emulation code doesn't bother to acquire the
+         * Vscrn Mutex before trying to access it. Because of this, the
+         * K_CLRSCROLL can cause a crash if the RdComWrtScr thread is busy doing
+         * stuff with the vscrn.
+         */
+        VscrnSetBufferSize( vmode, 256, vscrn[vmode].page_count ) ;
+        VscrnSetBufferSize( vmode, bufsize, vscrn[vmode].page_count ) ;
+    } else {
+        /* This is much safer and *seems* to work just as well. Probably it
+         * could replace the old implementation entirely. */
+        VscrnGetPageTop(vmode, FALSE, page) ;
+        len = VscrnGetHeight(vmode) -(tt_status[vmode]?2:1);
+        VscrnSetPageTop(vmode, 0, FALSE, page, TRUE);
+        VscrnSetPageBegin(vmode, 0, page);
+        VscrnSetPageEnd(vmode, len, page) ;
+    }
     scrollstatus[vmode] = FALSE ;
     scrollflag[vmode] = FALSE ;
     cursoron[vmode] = FALSE ;

--- a/kermit/k95/ckocon.h
+++ b/kermit/k95/ckocon.h
@@ -1645,6 +1645,7 @@ _PROTOTYP( void   TermScrnUpd, ( void * ) ) ;
 #endif /* KUI */
 _PROTOTYP( videoline * VscrnGetPageLineFromTop, ( BYTE, SHORT, int ) ) ;
 _PROTOTYP( videoline * VscrnGetLineFromTop, ( BYTE, SHORT, BOOL ) ) ;
+_PROTOTYP( videoline * VscrnGetPageLine, ( BYTE, SHORT, int ) ) ;
 _PROTOTYP( videoline * VscrnGetLine, ( BYTE, SHORT ) ) ;
 _PROTOTYP( USHORT VscrnGetLineVtAttr, ( BYTE, SHORT ) ) ;
 /*_PROTOTYP( USHORT VscrnSetLineVtAttr, ( BYTE, SHORT, USHORT ) ) ;*/
@@ -1689,6 +1690,7 @@ _PROTOTYP( position * VscrnGetCurPosEx, ( BYTE, BOOL ) ) ;
 _PROTOTYP( position * VscrnGetCurPos, ( BYTE ) ) ;
 _PROTOTYP( VOID VscrnSetBookmark, ( BYTE, int, int ) ) ;
 _PROTOTYP( int VscrnGetBookmark, ( BYTE, int ) ) ;
+_PROTOTYP( VOID VscrnCopyLine, (videoline *, videoline *) ) ;
 
 
 _PROTOTYP( bool IsWARPed, ( void ) ) ;
@@ -1767,7 +1769,7 @@ _PROTOTYP(void clearcmdscreen, (void));
 #endif /* KUI */
 _PROTOTYP(void cleartermpage, (BYTE,int));
 _PROTOTYP(void cleartermscreen, (BYTE));
-_PROTOTYP(void clearscrollback, (BYTE) ) ;
+_PROTOTYP(void clearscrollback, (BYTE, BOOL) ) ;
 _PROTOTYP(cell_video_attr_t geterasecolor, (int));
 _PROTOTYP(void clrtoeoln, (BYTE,CHAR));
 _PROTOTYP(void clrbol_escape, (BYTE,CHAR));

--- a/kermit/k95/ckuusr.c
+++ b/kermit/k95/ckuusr.c
@@ -3506,6 +3506,7 @@ int nbeeptab = sizeof(beeptab)/sizeof(struct keytab);
 #define CLR_C_EOS 4
 #define CLR_C_LIN 5
 #define CLR_C_SCR 6
+#define CLR_C_SCRO 7
 
 struct keytab clrcmdtab[] = {
     { "all",        CLR_C_ALL, 0 },
@@ -3514,7 +3515,8 @@ struct keytab clrcmdtab[] = {
     { "eol",        CLR_C_EOL, 0 },
     { "eos",        CLR_C_EOS, 0 },
     { "line",       CLR_C_LIN, 0 },
-    { "scrollback", CLR_C_SCR, 0 }
+    { "scrollback", CLR_C_SCR, 0 },
+    { "scrollback-only", CLR_C_SCRO, 0}
 };
 int nclrcmd = sizeof(clrcmdtab)/sizeof(struct keytab);
 #endif /* OS2 */
@@ -6807,7 +6809,7 @@ doclear() {
 #ifndef NOLOCAL
     switch (x) {
       case CLR_SCL:
-	clearscrollback(VTERM);
+	clearscrollback(VTERM, FALSE);
 	break;
       case CLR_CMD:
 	switch ( z ) {
@@ -6830,7 +6832,10 @@ doclear() {
 	    clrline_escape(VCMD,SP);
 	    break;
 	  case CLR_C_SCR:
-	    clearscrollback(VCMD);
+	    clearscrollback(VCMD, FALSE);
+	    break;
+      case CLR_C_SCRO:
+	    clearscrollback(VCMD, TRUE);
 	    break;
 	default:
 	    printf("Not implemented yet, sorry.\n");
@@ -6867,7 +6872,10 @@ doclear() {
 	    clrline_escape(VTERM,SP);
 	    break;
 	 case CLR_C_SCR:
-	     clearscrollback(VTERM);
+	     clearscrollback(VTERM, FALSE);
+	     break;
+      case CLR_C_SCRO:
+	     clearscrollback(VTERM, TRUE);
 	     break;
 	 default:
 	     printf("Not implemented yet, sorry.\n");


### PR DESCRIPTION
Which erases the scrollback, without erasing the screen! Also added a new CLEAR TERMINAL SCROLLBACK-ONLY command which does the same.

And while we're making changes in the area, also fix the bug where clearing scrollback might cause a crash. Previously this operation would recreate the vscreen buffer, but the terminal emulation thread has never been great about ensuring it has the vscreen buffer mutex so thats a risky approach. Instead just recycle the buffer - VscrnScrollPage erases lines as it reuses them (it must as the buffer is continuously recycling old lines) so it should be fine.