### PR TITLE
Fix bug with packet size negotiation

### DIFF
--- a/kermit/k95/ckcfns.c
+++ b/kermit/k95/ckcfns.c
@@ -1701,10 +1701,7 @@ bgetpkt(bufmax) int bufmax;
     }
     dp = data;				/* Point to packet data buffer */
     size = 0;				/* And initialize its size */
-#ifdef COMMENT
-    /* No - bufmax is a parameter */
     bufmax = maxdata();			/* Get maximum data length */
-#endif
 
 #ifdef DEBUG
     if (deblog)
@@ -2626,10 +2623,7 @@ getpkt(bufmax,xlate) int bufmax, xlate;
   We also decide optimally whether it is better to use a short-format or
   long-format packet when we're near the borderline.
 */
-#ifdef COMMENT
-    /* bufmax is a parameter - don't override it! */
     bufmax = maxdata();			/* Get maximum data length */
-#endif /* COMMENT */
 
     if (first == 1) {			/* If first character of this file.. */
 #ifdef UNICODE


### PR DESCRIPTION
This re-implements
https://github.com/OpenKermit/ckermit/commit/0eef9a13efd0eaa990dfd5a7acfc5ce40bdbc3d7 on this tree.

This was detected after OpenKermit's ckermit test suite added eksw compatibility tests.  A stall was observed after sending several packets to E-Kermit (eksw).  C-Kermit 9.0.302 tested working with it.

The bug was tracked down to a change in C-Kermit 9.0 edit 305(alpha05) of 2021-11-16.  In bgetpkt(), it changed:

```
+#ifdef COMMENT
+    /* No - bufmax is a parameter */
     bufmax = maxdata();                        /* Get maximum data length */
+#endif
```

While the comment that bufmax is a parameter is correct, the change to set it to maxdata() was incorrect, since maxdata() accounts for overhead and bufmax does not.  This resulted in packets a few bytes larger than the receiver had signaled acceptance of.

C-Kermit supports such very large packets anyhow that this was never detected when talking to other C-Kermits.

With this change, proper communication with ekermit (eksw) was restored.