### PR TITLE
Fix bug with packet sizes

### DIFF
--- a/kermit/k95/ckcfn2.c
+++ b/kermit/k95/ckcfn2.c
@@ -1339,6 +1339,16 @@ spack(pkttyp,n,len,d) char pkttyp; int n, len; CHAR *d;
   too long because of extra control fields in a long packet.
   - fdc 13 September 2022
 */
+/*
+
+  Note: Per the comment above, an attempt was made to use a
+  threshold of > 96 to optimize a border case where the sent packet was
+  too long due to long-packet header overhead. However, this was
+  incorrect as it allowed short packets of length 95 and 96 to be built.
+  These produced invalid/non-printable length bytes (0x7f and 0x80)
+  that were rejected by the receiver's packet parser.
+  - jgoerzen 20 June 2026
+*/
     debug(F101,"SPACK LP decision lpcapu","",lpcapu);
     debug(F101,"SPACK LP decision len","",len);
     debug(F101,"SPACK LP decision bctl","",bctl);
@@ -1346,7 +1356,15 @@ spack(pkttyp,n,len,d) char pkttyp; int n, len; CHAR *d;
 
     longpkt = 0;
     if (lpcapu > 0) { /* Only if long packet capability has been negotiated */
-        longpkt = (len + bctl + 2) > 96; 
+        /*
+          A short packet length field can only hold a single printable ASCII character.
+          Since tochar(x) is x + 32, and the maximum printable ASCII character is '~' (126),
+          the maximum value that can be encoded in the length field is 126 - 32 = 94.
+          Any packet where (len + bctl + 2) exceeds 94 must therefore be sent as a
+          long packet (extended length) to avoid invalid length bytes like 0x7f (DEL/rubout)
+          or 0x80 (non-ASCII), which would cause the receiver to reject the packet.
+        */
+        longpkt = (len + bctl + 2) > 94;
         /* Len + Seq + Type + Data + Blockcheck */
         /*  1     1     2      n       1-3      */
     }


### PR DESCRIPTION
This is an import of
https://github.com/OpenKermit/ckermit/commit/d560c580d446a079163b96829bfb56d4e8797258

Original description:

The initial bug can be duplicated with this command, which will hang:

```
touch /tmp/foobar12345
kermit -H -Y -C "set host /network-type:pseudoterminal kermit -x, remote del /tmp/foobar12345, close, exit"
```

Note that the /tmp/foobar12345 filename is the precise length needed to trigger this.

When long packets are negotiated, kermit switches to long packet formatting (extended length) if the total packet size (excluding SOP and the LEN byte itself) exceeds the maximum length that can be represented as a single printable ASCII character in the short packet's LEN field.

Since short packet lengths are encoded via tochar(len) = len + 32, and the maximum printable ASCII character is '~' (126), the maximum value that can be encoded in the short LEN field is 126 - 32 = 94 bytes.

Any packet where (len + bctl + 2) exceeds 94 must be formatted as a long packet. The previous threshold of > 96 was incorrect and caused packets of size 95 and 96 to be formatted as short packets.

This resulted packes of size 95 or 96 generating a len byte of 127 (0x7f) or 128 (0x80), which the receiving end rejected.