### PR TITLE
Fix silent data corruptoin from strlen() on binary packet data

### DIFF
--- a/kermit/k95/ckcfn2.c
+++ b/kermit/k95/ckcfn2.c
@@ -555,7 +555,16 @@ input() {
 			debug(F101,"input return pre-stashed packet","",rsn);
 			dumprbuf();
 			rdatap = r_pkt[x].pk_adr;   /* like rpack would do. */
-			rln = (int)strlen((char *) rdatap);
+/*
+  This previously used strlen() on rdatap, but that breaks when the packet's
+  data contains a NULL, as could be the case under, at least, SET CONTROL
+  UNPREFIX ALL.
+
+  Since rpack() already recorded the true length in r_pkt[x].pk_len when this
+  packet was first parsed and stashed, use that instead of recalculating
+  from the data itself.
+*/
+			rln = r_pkt[x].pk_len;
 			type = r_pkt[x].pk_typ;
 			break;
 		    }
@@ -3269,6 +3278,7 @@ rpack() {
     r_pkt[k].pk_seq = rsn;		/* Record in packet info structure */
     r_pkt[k].pk_typ = type;		/* Sequence, type,... */
     r_pkt[k].pk_adr = rdatap;		/* pointer to data buffer */
+    r_pkt[k].pk_len = rln;		/* and its length, for later replay */
     if (local) {			/* Save a function call! */
 	int x = 0;
 	if (fdispla != XYFD_N) x = 1;


### PR DESCRIPTION
This is an import of
https://github.com/OpenKermit/ckermit/commit/b58e0336ba486154f580afb6e1eea2688df20b87

Original description follows:

When a data packet arrives out of order and gets stashed for later, replaying it once the window catches up recalculated its size with strlen().  That breaks when a packet contains a NULL.

Each truncated packet still carries a valid checksum for its own wrong length, so nothing flags an error.  The transfer reports success with an incomplete or corrupted file.

rpack() already computes the correct length when it first parses and validates a packet.  The fix stores that in r_pkt[].pk_len (mirroring s_pkt[].pk_len on the send side) and uses it instead of recomputing from the data on replay.

The underlying bug has been present since this code was introduced in C-Kermit 5A(188) in 1992, 34 years ago!  Commit
https://github.com/OpenKermit/ckermit/commit/a213649d65b4abf75836520d5ae0b5f28c2bb61f