### PR TITLE
Fix cursor positioning on double-width lines in K95G.

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -539,6 +539,7 @@ as part of K95 at this time, the default terminal remains VT220 for now.
    underscore when it should have been the empty character / null.
  - Fixed SGR font attributes not turning off if the reverse video attribute is 
    set (K95 bug 843)
+ - Fixed cursor positioning on double-height/double-wide lines in K95G (K95 bug 844)
 
 ## Kermit 95 v3.0 beta 7 - 27 January 2025
 

--- a/doc/manual/k95bugs.html
+++ b/doc/manual/k95bugs.html
@@ -1016,6 +1016,7 @@ that users of Windows NT 4.0 download and install this and all later fixes.
 <li><tt>[+] (K)</tt> <a href="#b841">841. K95.EXE may crash on exit</a>
 <li><tt>[+] (K)</tt> <a href="#b842">842. Japanese-roman character set does not work</a>
 <li><tt>[+] (K)</tt> <a href="#b843">843. SGR font attributes do not turn off if the reverse video attribute is set </a>
+<li><tt>[+] (K)</tt> <a href="#b844">844. Cursor positioning on double-width lines in K95G</a>
     <!--
     <li><tt>[ ] (K)</tt> <a href="#bxxx">xxx. </a>
     -->
@@ -8218,6 +8219,15 @@ Fixed in 3.0
 
 <p>This is also logged as
     <a href="https://github.com/davidrg/ckwin/issues/553">Issue #553 on Github</a>
+
+<h3><a name="b844">844. Cursor positioning on double-width lines in K95G</a></h3>
+<p>Cursor positioning is incorrect on double-width and double-height lines in
+    K95G. This is a repeat of bug <a href="#b496">496</a>, but in K95G.</p>
+
+<p>This affects all released versions of K95G prior to 3.0 beta 8.</p>
+
+<p>This is also logged as
+    <a href="https://github.com/davidrg/ckwin/issues/561">Issue #561 on Github</a>
 
 <!--
 <h3><a name="bxxx">xxx. </a></h3>

--- a/kermit/k95/kui/ikterm.cxx
+++ b/kermit/k95/kui/ikterm.cxx
@@ -537,6 +537,8 @@ BOOL IKTerm::getCursorPos()
 	int cursor_page = vbuf->cursor.p;
 	int cursor_x = vbuf->cursor.x;
 	int cursor_y = vbuf->cursor.y;
+    USHORT lineattr = VscrnGetLineVtAttr(vnum,cursor_y);
+    BOOL cursor_dwl = lineattr & VT_LINE_ATTR_DOUBLE_WIDE || lineattr & VT_LINE_ATTR_DOUBLE_HIGH;
 	int page_top = page->top;
 	int page_linecount = page->linecount;
 	int page_scrolltop = page->scrolltop;
@@ -573,6 +575,7 @@ BOOL IKTerm::getCursorPos()
     }
     else {
         kcp->cursorPt.x = cursor_x;
+        kcp->cursorDoubleWideLine = cursor_dwl;
         kcp->cursorPt.y = cursor_y + cursor_offset;
         kcp->cursorVisible = TRUE;
     }

--- a/kermit/k95/kui/ikterm.h
+++ b/kermit/k95/kui/ikterm.h
@@ -12,6 +12,7 @@ typedef struct _K_CLIENT_PAINT {
     int             len;
     BOOL            cursorVisible;
     POINT           cursorPt;
+    BOOL            cursorDoubleWideLine;
 
     unsigned long   beg;            // for vertical scrollbar
     unsigned long   top;

--- a/kermit/k95/kui/kclient.cxx
+++ b/kermit/k95/kui/kclient.cxx
@@ -795,11 +795,16 @@ void KClient::checkBlink()
             else                        // underline
                 adjustedH = kglob->sysMets->borderHeight() + 1;
 
-            cursorRect.left = clientPaint->cursorPt.x * font->getFontW()
+            int fontW = font->getFontW();
+            if (clientPaint->cursorDoubleWideLine) {
+                fontW *= 2;
+            }
+
+            cursorRect.left = clientPaint->cursorPt.x * fontW
                 - _xoffset;
             cursorRect.top = clientPaint->cursorPt.y * font->getFontSpacedH()
                 + ( font->getFontH() - adjustedH );
-            cursorRect.right = cursorRect.left + font->getFontW();
+            cursorRect.right = cursorRect.left + fontW;
             cursorRect.bottom = cursorRect.top + adjustedH;
 
             if ( cursorena[vmode] && cursor_on_visible_page(vmode) || markmodeflag[vmode] != notmarking ) {
@@ -1457,11 +1462,16 @@ void KClient::writeMe()
         else                        // underline
             adjustedH = kglob->sysMets->borderHeight() + 1;
 
-        cursorRect.left = clientPaint->cursorPt.x * font->getFontW() 
+        int fontW = font->getFontW();
+        if (clientPaint->cursorDoubleWideLine) {
+            fontW *= 2;
+        }
+
+        cursorRect.left = clientPaint->cursorPt.x * fontW
                 - _xoffset;
         cursorRect.top = clientPaint->cursorPt.y * font->getFontSpacedH() 
                 + ( font->getFontH() - adjustedH );
-        cursorRect.right = cursorRect.left + font->getFontW();
+        cursorRect.right = cursorRect.left + fontW;
         cursorRect.bottom = cursorRect.top + adjustedH;
         ToggleCursor( hdc(), &cursorRect );
         cursor_displayed = 1;
@@ -1882,7 +1892,6 @@ BOOL KClient::renderToDc(HDC hdc, KFont *font, int vnum, int margin, bool blinkO
     BOOL anyRuledLines = FALSE;
     vt_char_attr_t prevEffect = uchar(-1);
     vt_cell_attr_t prevCellAttr = 0;
-    COLORREF textColor;
     HPEN underlinePen = (HPEN) CreatePen(PS_SOLID, 1, 0); /* Temporary */
     BOOL blink;
     bool overline = FALSE;


### PR DESCRIPTION
The console version of K95 was already behaving properly with this bug fixed in 1.1.16.

fixes #561