### PR TITLE
New option to allow use of the DEC Special Graphics character set and…

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -170,6 +170,11 @@ as part of K95 at this time, the default terminal remains VT220 for now.
  - Proper Smooth Scroll is now supported in K95G.
  - New `CLEAR TERMINAL SCROLLBACK-ONLY` command. Clears the scrollback while
    preserving current terminal screen contents.
+ - New option to allow the DEC Special Graphics character set to be used while
+   in UTF-8 mode without having to use ROCS and DOCS to temporarily switch out
+   of UTF-8 mode. This is similar to xterms vt100Graphics resource, and PuTTYs
+   "Enable VT100 line drawing even in UTF-8 mode" setting. It is off by default
+   for all terminal types except k95 and linux.
 
 ### Enhancements
  - The Control Sequences documentation ([preliminary version available online](https://davidrg.github.io/ckwin/dev/ctlseqs.html))

--- a/doc/changes.md
+++ b/doc/changes.md
@@ -545,6 +545,7 @@ as part of K95 at this time, the default terminal remains VT220 for now.
  - Fixed SGR font attributes not turning off if the reverse video attribute is 
    set (K95 bug 843)
  - Fixed cursor positioning on double-height/double-wide lines in K95G (K95 bug 844)
+ - Fixed ISO-2022 state not being restored when switching back from UTF-8 mode
 
 ## Kermit 95 v3.0 beta 7 - 27 January 2025
 

--- a/doc/ctlseqs.xml
+++ b/doc/ctlseqs.xml
@@ -2698,16 +2698,29 @@ DECTSR		462
             <ref src="dap:170"/>
             <p>Select IBM Proprinter emulation mode</p>
         </section>
-        <section role="ctlseq" id="sdc" mnemonic="ROCS" ctlseq="ESC % @" title="Select default character set">
+        <section role="ctlseq" id="sdc" mnemonic="ROCS" ctlseq="ESC % @"
+                 title="Select default character set">
             <ref src="xt:h4-Controls-beginning-with-ESC:ESC-percent-@.F8C"/>
             <termsupp first="xterm" series="xt" additional="putty wt"/>
             <ref src="dap:160"/>
             <p>Return to ISO-2022 mode</p>
         </section>
-        <section role="ctlseq" id="sutf8" ctlseq="ESC % G" title="Select UTF-8 character set">
+        <section role="ctlseq" id="sutf8" mnemonic="DOCS" ctlseq="ESC % G"
+                 title="Select UTF-8 character set">
             <ref src="xt:h4-Controls-beginning-with-ESC:ESC-percent-G.F93"/>
             <termsupp first="xterm" series="xt" additional="putty wt"/>
-            <p>Select UTF-8 character set with standard return</p>
+            <p>
+                Designate UTF-8 coding system with standard return. Switches
+                the terminal to UTF-8 mode where ISO-2022 rules do not apply. To
+                return to ISO-2022 mode, use <a href="#sdc">ROCS</a>.
+            </p>
+            <p>
+                If the VT-GRAPHICS-IN-UTF8-MODE setting is enabled, Kermit 95
+                will still allow the DEC Special Graphics and any downloaded
+                soft character sets to be used in UTF8 mode for compatibility
+                with legacy software that does not know how to switch the
+                terminal out of UTF-8 mode.
+            </p>
         </section>
         <section role="ctlseq" id="sg0" ctlseq="ESC ( C" mnemonic="SCS" title="Designate G0 Character Set">
             <ref src="xt:h4-Controls-beginning-with-ESC:ESC-lparen-C.F20"/>

--- a/doc/ctlseqs.xml
+++ b/doc/ctlseqs.xml
@@ -537,6 +537,11 @@ DECTSR		462
                 uri="https://ecma-international.org/wp-content/uploads/ECMA-35_6th_edition_december_1994.pdf"
                 uri-type="pdf-page"
                 sort-order="20"/>
+        <refsrc name="iso-ir"
+                key="isoir"
+                uri="https://web.archive.org/web/20230512232742/https://itscj.ipsj.or.jp/english/vbcqpr00000004qn-att/ISO-IR.pdf"
+                uri-type="pdf-page"
+                sort-order="20"/>
         <refsrc name="dec-std-070"
                 key="070"
                 uri="https://bitsavers.org/pdf/dec/standards/EL-SM070-00_DEC_STD_070_Video_Systems_Reference_Manual_Dec91.pdf"
@@ -1765,7 +1770,7 @@ DECTSR		462
             <dd><a href="https://ecma-international.org/wp-content/uploads/ECMA-48_5th_edition_june_1991.pdf">
                 Standard ECMA-48: Control Functions for Coded Character Sets</a>
                 - both the PDF page number and document page number is given (e.g., p35/49—numbered page 35,
-                PDF page 49)</dd>
+                PDF page 49). Equivalent to ISO/IEC 6429</dd>
             <dt>dec-std-070</dt>
             <dd><a href="https://bitsavers.org/pdf/dec/standards/EL-SM070-00_DEC_STD_070_Video_Systems_Reference_Manual_Dec91.pdf">
                 DEC STD 070 Video Systems Reference Manual
@@ -1802,10 +1807,10 @@ DECTSR		462
         <p>Additional reference documentation that may be useful includes:</p>
         <ul>
             <li><a href="https://ecma-international.org/wp-content/uploads/ECMA-35_6th_edition_december_1994.pdf">
-                Standard ECMA-35: Character Code Structure and Extension Techniques
+                Standard ECMA-35: Character Code Structure and Extension Techniques. Equivalent to ISO/IEC 2022
             </a></li>
             <li><a href="https://ecma-international.org/wp-content/uploads/ECMA-43_3rd_edition_december_1991.pdf">
-                Standard ECMA-43: 8-Bit Coded Character Set Structure and Rules
+                Standard ECMA-43: 8-Bit Coded Character Set Structure and Rules. Equivalent to ISO/IEC 4873
             </a></li>
         </ul>
     </section>
@@ -2698,29 +2703,44 @@ DECTSR		462
             <ref src="dap:170"/>
             <p>Select IBM Proprinter emulation mode</p>
         </section>
-        <section role="ctlseq" id="sdc" mnemonic="ROCS" ctlseq="ESC % @"
-                 title="Select default character set">
-            <ref src="xt:h4-Controls-beginning-with-ESC:ESC-percent-@.F8C"/>
-            <termsupp first="xterm" series="xt" additional="putty wt"/>
-            <ref src="dap:160"/>
-            <p>Return to ISO-2022 mode</p>
-        </section>
-        <section role="ctlseq" id="sutf8" mnemonic="DOCS" ctlseq="ESC % G"
-                 title="Select UTF-8 character set">
-            <ref src="xt:h4-Controls-beginning-with-ESC:ESC-percent-G.F93"/>
-            <termsupp first="xterm" series="xt" additional="putty wt"/>
+        <section role="ctlseq" id="docs" mnemonic="DOCS"
+                 title="Designate Other Coding System">
+            <ctlseq>
+                ESC % <param-char symbol="F"/>
+            </ctlseq>
+            <ref src="e35:51"/>
             <p>
-                Designate UTF-8 coding system with standard return. Switches
-                the terminal to UTF-8 mode where ISO-2022 rules do not apply. To
-                return to ISO-2022 mode, use <a href="#sdc">ROCS</a>.
+                Switches the terminal to a different coding system identified
+                the specified final byte.
             </p>
-            <p>
-                If the VT-GRAPHICS-IN-UTF8-MODE setting is enabled, Kermit 95
-                will still allow the DEC Special Graphics and any downloaded
-                soft character sets to be used in UTF8 mode for compatibility
-                with legacy software that does not know how to switch the
-                terminal out of UTF-8 mode.
-            </p>
+            <section role="parameter" id="sdc" mnemonic="ROCS" ctlseq="@"
+                     title="ISO-2022">
+                <ref src="xt:h4-Controls-beginning-with-ESC:ESC-percent-@.F8C"/>
+                <termsupp first="xterm" series="xt" additional="putty wt"/>
+                <ref src="dap:160"/>
+                <ref src="e35:52"/>
+                <p>
+                Switches the terminal to ISO-2022 mode restoring any previous
+                ISO-2022 state.
+                </p>
+            </section>
+            <section role="parameter" id="sutf8" ctlseq="G" title="UTF-8">
+                <ref src="xt:h4-Controls-beginning-with-ESC:ESC-percent-G.F93"/>
+                <ref src="isoir:20"/>
+                <termsupp first="xterm" series="xt" additional="putty wt"/>
+                <p>
+                    Switches the terminal to UTF-8 mode saving any existing
+                    ISO-2022 state and allowing a later return to ISO-2022 mode
+                    via <a href="#sdc">ROCS</a>.
+                </p>
+                <p>
+                    If the VT-GRAPHICS-IN-UTF8-MODE setting is enabled,
+                    Kermit 95 will still allow the DEC Special Graphics and any
+                    downloaded soft character sets to be used in UTF8 mode for
+                    compatibility with legacy software that does not know how to
+                    switch the terminal out of UTF-8 mode.
+                </p>
+            </section>
         </section>
         <section role="ctlseq" id="sg0" ctlseq="ESC ( C" mnemonic="SCS" title="Designate G0 Character Set">
             <ref src="xt:h4-Controls-beginning-with-ESC:ESC-lparen-C.F20"/>

--- a/doc/manual/index.html
+++ b/doc/manual/index.html
@@ -7713,6 +7713,16 @@ Of course host-based forms-filling applications can be written using
 UTF-8 rather than ISO 2022, but you probably won't find any, except maybe
 in new or experimental versions of Linux, or maybe in Plan 9.
 
+<p>
+
+You can optionally allow the use of the DEC Special Graphics character set and
+any downloaded soft character sets using the
+<tt>SET TERM VT-GRAHPICS-IN-UTF8-MODE ON</tt> command. This allows for
+compatibility with software running in a UTF-8 environment that has not been
+updated to use UTF-8 line drawing characters, or that relies on downloaded soft
+character sets. The setting is on by default for the linux terminal type
+(matching the linux console terminal), and also the k95 terminal type as this
+is the behaviour of most other terminals today.
 
 <h3>Switching Fonts</h3>
 

--- a/doc/manual/setterm.html
+++ b/doc/manual/setterm.html
@@ -777,6 +777,16 @@ horizontally</a>. Not supported in K95G.
 
 <p>
 
+<dt><tt>SET TERMINAL VT-GRAPHICS-IN-UTF8-MODE <i>{</i> ON, OFF <i>}</i></tt>
+<dd>Normally in UTF-8 mode ISO-2022 character sets are unavailable unless the
+    host first switches the terminal to ISO-2022 mode. When this setting is ON
+    the DEC Special Graphics character set and any downloaded soft character
+    sets may be designated while in UTF-8 mode allowing compatibility with
+    older software unaware of UTF-8. All other character sets remain
+    unavailable while in UTF-8 mode.
+
+<p>
+
 <dt><tt>SET TERMINAL VT-LANGUAGE <i>language</i></tt>
 <dd>Specifies the National Replacement Character Set (NRC) to be used when
 NRC mode is activated.  The default is "North American".

--- a/kermit/k95/ckoco3.c
+++ b/kermit/k95/ckoco3.c
@@ -514,6 +514,7 @@ char htab[MAXTERMCOL+2] = DEFTABS       /* Default tab settings */
 
 static int achar;                       /* Global - current character */
 int tt_utf8 = 0;                        /* Is UTF8 mode active ? */
+int vt_graphics_in_utf8 = 0;            /* Allow TX_DECSPEC in UTF8 mode? */
 
 struct _vtG G[4] = {
     TX_ASCII,   TX_ASCII,  cs94, cs94, TRUE,  TRUE, TRUE, NULL, NULL, NULL, NULL, TRUE,
@@ -11653,20 +11654,23 @@ int vt_macro_in() {
 /*
   The flow of characters from the communication device to the screen is:
 
-                           +---(debug)----+
-                           |              |
-  rdcomwrtscr --> cwrite --+--> vt100 --> wrtch
-                                       |              |
-                                       +--> vtescape--+
+                                            +---(debug)----+
+                                            |              |
+  rdcomwrtscr --> scriptwrtbuf --> cwrite --+--> vt100 --> wrtch
+                                            |              |
+                                            +--> vtescape--+
 
-  rdcomwrtscr() reads character from communication device via ttinc() and:
+  rdcomwrtscr() reads character from communication device via ttinc() and
+  passes all output characters to scriptwrtbuf()
+
+  scriptwrtbuf()
    - converts 8-bit controls to 7-bit ESC sequences
    - handles TELNET negotiations
    - handles SO/SI (NOTE: this prevents
    - handles charset translation
    - handles newline-mode and cr-display
    - handles connection loss
-   - passes all output chars to cwrite()
+   - Passes characters to cwrite()
 
   cwrite()
    - handles debug output, direct to wrtch().
@@ -12110,6 +12114,17 @@ scriptwrtbuf(unsigned short word)
 #ifdef CK_TRIGGER
     extern char * tt_trigger[], * triggerval;
 #endif /* CK_TRIGGER */
+    int utf8_active = tt_utf8;
+
+    /* If we're in UTF-8 mode, but the host has asked for a soft character set
+     * or the DEC Special Graphics character set, we'll break the rules and
+     * allow it. But only if the vt-graphics-in-utf8 setting is on. */
+    if (tt_utf8 && vt_graphics_in_utf8 && (
+           GNOW->designation == TX_DECSPEC
+        || GNOW->designation == TX_DRCS_1
+        || GNOW->designation == TX_DRCS_2 )) {
+        utf8_active = FALSE;
+    }
 
     /*debug(F111,"scriptwrtbuf","word",word);*/
 
@@ -12226,7 +12241,7 @@ pushed:
         f_popped = 0;
 
         /* Handle the UTF8 conversion if we are in that mode */
-        if ( tt_utf8 ) {
+        if ( utf8_active ) {
             USHORT * ucs2 = NULL;
             int rc = utf8_to_ucs2( (CHAR)(c & 0xFF), &ucs2 );
             if ( rc > 0 )
@@ -12274,9 +12289,9 @@ pushed:
         if ((ISVT220(tt_type_mode) ||
              ISANSI(tt_type_mode)) &&
              !xprint ) {                /* VT220 and above... */
-                cx = tt_utf8 ? c : c & cmask & pmask;   /* C1 check must be masked */
+                cx = utf8_active ? c : c & cmask & pmask;   /* C1 check must be masked */
 
-            if (!tt_utf8 && ( GR->c1 ) &&
+            if (!utf8_active && ( GR->c1 ) &&
                  (cx > 127) && (cx < 160) /* It's a C1 character */
                  ) {
                 f_pushed = 1;
@@ -12288,7 +12303,7 @@ pushed:
 
     if (c >= 0) {                       /* Got character with no error? */
         if ( !xprint ) {
-            if (!tt_utf8)
+            if (!utf8_active)
                c = c & cmask & pmask ;  /* Maybe strip 8th bit */
 #ifndef NOXFER
             if ( (IsConnectMode() && autodl) ||
@@ -12296,7 +12311,7 @@ pushed:
                 autodown( c ) ;                 /* Download? */
 #endif /* NOXFER */
             if (escstate == ES_NORMAL) {
-                if ( !tt_utf8 )
+                if ( !utf8_active )
                     c = rtolxlat(c);
             }
             else {
@@ -20122,6 +20137,10 @@ settermtype( int x, int prompts )
 		/* Assume UTF-8 remote by default. Second parameter is ignored for
 		 * TX_UTF8. */
 		setremcharset(TX_UTF8, -1);
+
+        /* And allow the DEC Special Graphics character set in UTF-8 mode like
+         * xterm does. */
+        vt_graphics_in_utf8 = TRUE;
 #endif /* CKOUNI */
 #endif /* UNICODE */
 
@@ -20217,6 +20236,10 @@ settermtype( int x, int prompts )
 				 * support then override all of the above with UTF-8. Second
 				 * parameter is ignored for TX_UTF8. */
 				setremcharset(TX_UTF8, -1);
+
+                /* And allow the DEC Special Graphics character set in UTF-8
+                 * mode like the modern linux console terminal does */
+                vt_graphics_in_utf8 = TRUE;
 #endif /* CKOUNI */
 #endif /* UNICODE */
 

--- a/kermit/k95/ckoco3.c
+++ b/kermit/k95/ckoco3.c
@@ -535,6 +535,15 @@ struct _vtG QsavedG[4],
             *QsavedGR = NULL,
             *QsavedSSGL = NULL;
 
+/* ISO/IEC 2022:1994 section 15.4.2 says that ISO-2022 state must be saved when
+ * switching to another coding system (UTF-8) and restored when switching back.
+ */
+static int utf8Saved = FALSE;
+static struct _vtG utf8SavedG[4];
+static struct _vtG *utf8SavedGL = NULL;
+static struct _vtG *utf8SavedGR = NULL;
+static struct _vtG *utf8SavedGNOW = NULL;
+
 bool     printregion    = FALSE; /* Print extent = full screen */
 bool     xprintff       = FALSE; /* Print formfeed */
 bool     turnonprinter  = FALSE; /* Time to turn on printer */
@@ -11305,6 +11314,13 @@ doreset(int x) {                        /* x = 0 (soft), nonzero (hard) */
     GNOW = GL = &G[0] ;
     GR = ISLINUX(tt_type_mode) ? &G[1] : ISVT220(tt_type_mode) ? &G[2] : &G[1];
     SSGL = NULL ;
+    if (tt_utf8) {
+        /* Refresh saved ISO-2022 state */
+        docs_utf8();
+    } else {
+        /* Currently in ISO-2022 mode, no saved state */
+        utf8Saved = FALSE;
+    }
     decnrcm = decnrcm_usr;
     setdecsasd(SASD_TERMINAL);
     if ( IS97801(tt_type_mode) )
@@ -12901,6 +12917,34 @@ csetchar(enum charsetsize size, int cset) {
         }
     }
     return "?";
+}
+
+/* Save ISO-2022 state and switch to UTF-8 */
+void
+docs_utf8() {
+    int i;
+    for (i = 0; i < 4; i++) utf8SavedG[i] = G[i];
+    utf8SavedGL = GL;
+    utf8SavedGR = GR;
+    utf8SavedGNOW = GNOW;
+    utf8Saved = TRUE;
+    tt_utf8 = 1;
+}
+
+/* Return to ISO-2022 restoring any previously saved state */
+void
+docs_iso2022() {
+    if (utf8Saved) {
+        int i;
+        /* Restore ISO-2022 state to how it was when we switched
+         * to UTF-8 (ISO/IEC 2022:1994 section 15.4.2) */
+        for (i = 0; i < 4; i++) G[i] = utf8SavedG[i];
+        GL = utf8SavedGL;
+        GR = utf8SavedGR;
+        GNOW = utf8SavedGNOW;
+        utf8Saved = FALSE;
+    }
+    tt_utf8 = 0;
 }
 
 void
@@ -20451,6 +20495,12 @@ settermtype( int x, int prompts )
     GNOW = GL = &G[0] ;
     GR = ISLINUX(tt_type_mode) ? &G[1] : ISVT220(tt_type_mode) ? &G[2] : &G[1];
     SSGL = NULL ;
+
+    if (tt_utf8) {
+        /* If we're in UTF-8 mode, save current ISO-2022 state so there is
+         * something to return to */
+        docs_utf8();
+    }
 
     if ( ISQNX(tt_type) ) {
         user_erasemode = TRUE;
@@ -29585,14 +29635,14 @@ vtescape( void )
                   }
               }
               break;
-        case '%':       /* Non-ISO 2022 character sets */
+        case '%':       /* DOCS - Non-ISO 2022 character sets */
               achar = (escnext<=esclast)?escbuffer[escnext++]:0;
               switch ( achar ) {
               case '@':         /* Return to ISO 2022 mode */
-                  tt_utf8 = 0;
+                  docs_iso2022();
                   break;
               case 'G':         /* UTF-8 with standard return */
-                  tt_utf8 = 1;
+                  docs_utf8();
                   break;
               }
               break;

--- a/kermit/k95/ckocon.h
+++ b/kermit/k95/ckocon.h
@@ -1941,6 +1941,9 @@ _PROTOTYP(unsigned char palette_max_index, (int));
 
 _PROTOTYP(USHORT vtattrib_to_int,(vtattrib));
 
+_PROTOTYP(void docs_iso2022, (void));
+_PROTOTYP(void docs_utf8, (void));
+
 typedef struct _hyperlink {
     int index;
     int type;

--- a/kermit/k95/ckuus2.c
+++ b/kermit/k95/ckuus2.c
@@ -8663,7 +8663,14 @@ static char *hxyterm[] = {
 "  to escape sequences from the other computer.  ENABLED by default.",
 #endif /* NT */
 " ",
-
+"SET TERMINAL VT-GRAPHICS-IN-UTF8-MODE { ON, OFF }",
+"  Normally in UTF-8 mode ISO-2022 character sets are unavailable unless the",
+"  host first switches the terminal to ISO-2022 mode. When this setting is ON",
+"  the DEC Special Graphics character set and any downloaded soft character",
+"  sets may be designated while in UTF-8 mode allowing compatibility with",
+"  older software unaware of UTF-8. All other character sets remain",
+"  unavailable while in UTF-8 mode.",
+" ",
 "SET TERMINAL VT-LANGUAGE <language>",
 "  Specifies the National Replacement Character Set (NRC) to be used when",
 "  NRC mode is activated.  The default is \"North American\".",

--- a/kermit/k95/ckuus5.c
+++ b/kermit/k95/ckuus5.c
@@ -5822,7 +5822,12 @@ shotcs(csl,csr) int csl, csr;
                 csl == TX_UNDEF ? "undefined" : txrinfo[csl]->keywd);
 
     if ( tt_utf8 ) {
-        printf("   Remote: UTF-8\n");
+        extern int vt_graphics_in_utf8;
+        if (vt_graphics_in_utf8) {
+            printf("   Remote: UTF-8 (DEC Special Graphics and soft character sets available)\n");
+        } else {
+            printf("   Remote: UTF-8\n");
+        }
     } else {
         printf("   Remote: %sG0: %s (%s)\n",
            GL == &G[0] ? "GL->" : GR == &G[0] ? "GR->" : "    ",

--- a/kermit/k95/ckuus7.c
+++ b/kermit/k95/ckuus7.c
@@ -1109,6 +1109,7 @@ static struct keytab trmtab[] = {
 #ifdef NT
     { "video-change",      XYTVCH,   0 },
 #endif /* NT */
+    { "vt-graphics-in-utf8-mode", XYTVGUTF8, 0 },
     { "vt-language",       XYTVTLNG, 0 },
     { "vt-nrc-mode",       XYTVTNRC, 0 },
 #endif /* OS2 */
@@ -6374,6 +6375,12 @@ settrm() {
           return(success = 1);
       }
 #ifndef NOCSETS
+      case XYTVGUTF8: {     /* SET TERM VT-GRAPHICS-IN-UTF8-MODE */
+          extern int vt_graphics_in_utf8;
+          if ((x = seton(&vt_graphics_in_utf8)) < 0)
+              return(x);
+          return(success = 1);
+      }
       case XYTVTLNG:        /* SET TERM DEC-LANGUAGE */
         if ((y = cmkey(vtlangtab,nvtlangtab,"VT language",
                        IS97801(tt_type_mode)?"german":"north-american",

--- a/kermit/k95/ckuus7.c
+++ b/kermit/k95/ckuus7.c
@@ -4369,7 +4369,10 @@ setremcharset(x, z) int x, z;
 #ifdef CKOUNI
     else if (x == TX_UTF8) {
         tcs_transp = 0;
-        tt_utf8 = 1;            /* Turn it on if we are UTF8 */
+
+        /* If we're not already in UTF-8 mode, switch to UTF-8 mode saving
+         * ISO-2022 state along the way. */
+        if (!tt_utf8) docs_utf8();
         return;
     }
 #endif /* CKOUNI */

--- a/kermit/k95/ckuusr.h
+++ b/kermit/k95/ckuusr.h
@@ -1354,6 +1354,7 @@ struct stringint {			/* String and (wide) integer */
 #define     TTS_SMOOTH   1
 #define     TTS_SMOOTH_2 2
 #define     TTS_SMOOTH_4 3
+#define   XYTVGUTF8 72  /* SET TERM VT-GRAPHICS-IN-UTF8 */
 #endif /* OS2 */
 
 #define XYATTR 34       /* Attribute packets  */

--- a/kermit/k95/k95custom.ini
+++ b/kermit/k95/k95custom.ini
@@ -37,6 +37,14 @@ if exist \v(exedir)welcome.txt copy /toscreen /interpret \v(exedir)welcome.txt
 ;	set term remote ascii G0
 ;}
 
+; The linux console terminal allows use of the DEC Special Graphics character
+; set in UTF-8 mode, and for better compatibility with other terminals the k95
+; terminal type does too. This improves compatibility with older software not
+; updated to use utf-8 line drawing characters at the risk of the terminal being
+; accidentally put in line drawing mode. If you'd rather K95 operate purely in
+; UTF-8 mode, you can turn this off:
+;set term vt-graphics-in-utf8-mode off
+
 ; In Kermit 95 v3.0 beta 8 the default screen update interval was reduced from
 ; 100ms (10fps) to 20ms (50fps) as there had been no reports of trouble or
 ; observed compatibility problems with this higher frame rate since it became


### PR DESCRIPTION
… any downloaded soft character sets while in UTF-8 mode.

This setting is enabled by default for the linux terminal type (because the linux console terminal does this), and for the k95 terminal type (for compatibility with other terminals).

The option equivalent to PuTTYs "Enable VT100 line drawing even in UTF-8 mode" setting, and a subset of the behaviour of xterms vt100Graphics resource.

Fixes #550